### PR TITLE
Preserve direct-USB capture failures during cleanup

### DIFF
--- a/spf/data_collector.py
+++ b/spf/data_collector.py
@@ -7,7 +7,6 @@ import struct
 import sys
 import threading
 import time
-import traceback
 from concurrent import futures
 from typing import Any, Dict, Optional
 import concurrent.futures
@@ -342,6 +341,7 @@ class ThreadedRX:
         self.nthetas = nthetas
         self.rx_config = self.pplus.rx_config
         self.seconds_per_sample = seconds_per_sample
+        self.error = None
         assert self.pplus.rx_config.rx_pos is not None
 
     def read_forever(self):
@@ -360,8 +360,14 @@ class ThreadedRX:
             try:
                 data = self.get_data()
             except Exception as e:
-                logging.error(f"Failed to read data , aborting {e}")
-                self.read_q.put(None, timeout=5)
+                self.error = e
+                logging.exception("Failed to read data, aborting")
+                while True:
+                    try:
+                        self.read_q.put(None, timeout=0.5)
+                        break
+                    except queue.Full:
+                        continue
                 self.run = False
                 continue
             put_on_queue = False
@@ -555,7 +561,12 @@ class DataCollector:
         self.position_controller = position_controller
         self.finished_collecting = False
         self.thread_class = thread_class
+        self.collection_error = None
+        self.cleanup_errors = []
+        self.records_written_by_receiver = [0] * len(yaml_config["receivers"])
+        self._records_written_lock = threading.Lock()
         self.setup_record_matrix()
+        self._mark_capture_state("in_progress")
 
     def radios_to_online(self):
         radio_uris = []
@@ -716,6 +727,8 @@ class DataCollector:
 
     def done(self):
         self.collector_thread.join()
+        if self.collection_error is not None:
+            raise self.collection_error
 
     def is_collecting(self):
         return not self.finished_collecting
@@ -726,6 +739,36 @@ class DataCollector:
     def write_to_record_matrix(self, thread_idx, record_idx, read_thread: ThreadedRX):
         raise NotImplementedError
 
+    def _write_record_and_track(self, thread_idx, record_idx, data):
+        self.write_to_record_matrix(thread_idx, record_idx, data)
+        with self._records_written_lock:
+            self.records_written_by_receiver[thread_idx] += 1
+
+    @staticmethod
+    def _error_summary(error):
+        return f"{type(error).__name__}: {error}"
+
+    def _mark_capture_state(self, status):
+        """Persist lifecycle state while the temporary Zarr is still writable."""
+
+        zarr = getattr(self, "zarr", None)
+        if self.data_filename is None or zarr is None:
+            return
+        zarr.attrs["capture_status"] = status
+        zarr.attrs["capture_records_written_by_receiver"] = list(
+            self.records_written_by_receiver
+        )
+        if self.collection_error is not None:
+            zarr.attrs["capture_error_type"] = type(self.collection_error).__name__
+            zarr.attrs["capture_error_message"] = str(self.collection_error)
+            error_number = getattr(self.collection_error, "errno", None)
+            if error_number is not None:
+                zarr.attrs["capture_error_errno"] = int(error_number)
+        if self.cleanup_errors:
+            zarr.attrs["capture_cleanup_errors"] = [
+                self._error_summary(error) for error in self.cleanup_errors
+            ]
+
     def run_inner_collector_thread(self):
         futures = []
         with ThreadPoolExecutorWithQueueSizeLimit(max_workers=2, maxsize=1) as executor:
@@ -733,49 +776,75 @@ class DataCollector:
                 for read_thread_idx, read_thread in enumerate(self.read_threads):
                     data = read_thread.read_q.get()
                     if data is None:
-                        return
+                        if read_thread.error is not None:
+                            raise read_thread.error
+                        raise RuntimeError(
+                            f"receiver {read_thread_idx} stopped without an error"
+                        )
                     futures.append(
                         executor.submit(
-                            self.write_to_record_matrix,
+                            self._write_record_and_track,
                             read_thread_idx,
                             record_idx=record_index,
                             data=data,
                         )
                     )
                     while len(futures) > 4:
-                        future_exception = futures.pop(0).exception()
-                        if future_exception:
-                            logging.error(
-                                "".join(
-                                    traceback.format_exception(
-                                        type(future_exception),
-                                        future_exception,
-                                        future_exception.__traceback__,
-                                    )
-                                )
-                            )
+                        futures.pop(0).result()
+            for future in futures:
+                future.result()
         return
 
     def run_collector_thread(self):
         logging.info("Collector thread is running!")
-        # https://stackoverflow.com/questions/48263704/threadpoolexecutor-how-to-limit-the-queue-maxsize
-        self.run_inner_collector_thread()
-        # read_thread.read_q.shutdown() # py 3.13
-        logging.info("Collector thread is exiting!")
-        self.finished_collecting = True
+        try:
+            # https://stackoverflow.com/questions/48263704/threadpoolexecutor-how-to-limit-the-queue-maxsize
+            self.run_inner_collector_thread()
+        except Exception as error:
+            self.collection_error = error
+            logging.exception("Collector failed")
+        finally:
+            logging.info("Collector tell threads to quit!")
+            for read_thread in self.read_threads:
+                read_thread.run = False
 
-        self.close()
+            logging.info("Collector wait for join!")
+            for read_thread in self.read_threads:
+                try:
+                    read_thread.join()
+                except Exception as error:
+                    self.cleanup_errors.append(error)
+                    logging.exception("Receiver thread cleanup failed")
 
-        # clean up lost threads
-        logging.info("Collector tell threads to quit!")
-        for read_thread_idx, read_thread in enumerate(self.read_threads):
-            read_thread.run = False
-        logging.info("Collector wait for join!")
-        for read_thread_idx, read_thread in enumerate(self.read_threads):
-            read_thread.join()
-        for pplus in self.receiver_pplus.values():
-            pplus.close()
-        logging.info("Collector clean exit!")
+            for uri, pplus in self.receiver_pplus.items():
+                try:
+                    pplus.close()
+                except Exception as error:
+                    self.cleanup_errors.append(error)
+                    logging.exception("%s: radio cleanup/TX mute failed", uri)
+
+            if self.collection_error is None and self.cleanup_errors:
+                self.collection_error = self.cleanup_errors[0]
+
+            self._mark_capture_state(
+                "complete" if self.collection_error is None else "incomplete"
+            )
+            try:
+                self.close()
+            except Exception as error:
+                self.cleanup_errors.append(error)
+                logging.exception("Capture store finalization failed")
+                if self.collection_error is None:
+                    self.collection_error = error
+
+            self.finished_collecting = True
+            if self.collection_error is None:
+                logging.info("Collector clean exit!")
+            else:
+                logging.error(
+                    "Collector exit with primary error: %s",
+                    self._error_summary(self.collection_error),
+                )
 
     def close(self):
         pass
@@ -840,8 +909,11 @@ class DroneDataCollectorRaw(DataCollector):
 
     def close(self):
         if self.data_filename is not None:
-            self.zarr.store.close()
+            zarr = getattr(self, "zarr", None)
+            if zarr is None:
+                return
             self.zarr = None
+            zarr.store.close()
             logging.info(f"Trying to shrink... {self.data_filename}")
             zarr_shrink(self.data_filename)
 

--- a/spf/sdrpluto/sdr_controller.py
+++ b/spf/sdrpluto/sdr_controller.py
@@ -84,6 +84,17 @@ PLUTO_USB_VENDOR_ID = 0x0456
 PLUTO_USB_PRODUCT_ID = 0xB673
 
 
+class SdrCleanupError(RuntimeError):
+    """One or more independent SDR cleanup operations failed."""
+
+    def __init__(self, failures):
+        self.failures = tuple(failures)
+        details = "; ".join(
+            f"{step}: {type(error).__name__}: {error}" for step, error in self.failures
+        )
+        super().__init__(details)
+
+
 def _find_local_pluto_usb_device(serial: str) -> tuple[int, int, tuple[int, ...]]:
     """Resolve one local Pluto serial to its capture-time USB location."""
 
@@ -1021,19 +1032,30 @@ class PPlus:
 
     def close(self):
         logging.info(f"{self.uri}: Start close PlutoPlus")
-        self.close_rx()
-        self.close_tx()
+        failures = []
+        for step, close_fn in (
+            ("RX cleanup", self.close_rx),
+            ("TX mute", self.close_tx),
+        ):
+            try:
+                close_fn()
+            except Exception as error:
+                failures.append((step, error))
+                logging.exception("%s: %s failed", self.uri, step)
         logging.info(f"{self.uri}: Done close PlutoPlus")
+        if failures:
+            raise SdrCleanupError(failures)
 
     def __del__(self):
-        # logging.debug(f"{self.uri}: Start delete PlutoPlus")
         if hasattr(self, "sdr"):
-            self.close_rx()
-            self.close_tx()
-            # self.sdr.tx_destroy_buffer()
-            # self.sdr.rx_destroy_buffer()
-            self.sdr.tx_enabled_channels = []
-        # logging.debug(f"{self.uri}: Done delete PlutoPlus")
+            try:
+                self.close()
+            except Exception:
+                # Destructors cannot participate in capture error handling. The
+                # explicit collector close path logs and records these failures.
+                logging.debug(
+                    "Best-effort Pluto destructor cleanup failed", exc_info=True
+                )
 
     """
     Setup the Rx part of the pluto
@@ -1183,21 +1205,39 @@ class PPlus:
     """
 
     def close_tx(self):
-        try:
-            self.sdr.tx_hardwaregain_chan0 = -80
-            self.sdr.tx_hardwaregain_chan1 = -80
-            self.sdr.tx_enabled_channels = []
-            self.sdr.tx_destroy_buffer()
-            self.sdr.tx_cyclic_buffer = False
-        except TypeError:
-            pass
+        failures = []
+        operations = (
+            ("mute TX1", lambda: setattr(self.sdr, "tx_hardwaregain_chan0", -80)),
+            ("mute TX2", lambda: setattr(self.sdr, "tx_hardwaregain_chan1", -80)),
+            (
+                "disable TX channels",
+                lambda: setattr(self.sdr, "tx_enabled_channels", []),
+            ),
+            ("destroy TX buffer", lambda: self.sdr.tx_destroy_buffer()),
+            ("disable cyclic TX", lambda: setattr(self.sdr, "tx_cyclic_buffer", False)),
+        )
+        for step, operation in operations:
+            try:
+                operation()
+            except (AttributeError, TypeError):
+                # Preserve compatibility with radio backends that do not expose
+                # every pyadi TX cleanup operation.
+                continue
+            except Exception as error:
+                failures.append((step, error))
         self.tx_config = None
-        # time.sleep(1.0)
+        if failures:
+            raise SdrCleanupError(failures)
 
     def close_rx(self):
-        if getattr(self, "direct_rx", None) is not None:
-            self.direct_rx.close()
-            self.direct_rx = None
+        failures = []
+        direct_rx = getattr(self, "direct_rx", None)
+        self.direct_rx = None
+        if direct_rx is not None:
+            try:
+                direct_rx.close()
+            except Exception as error:
+                failures.append(("close direct USB RX", error))
         self._last_direct_gains = None
         self._last_direct_rssis = None
         self._last_direct_metadata = None
@@ -1205,7 +1245,11 @@ class PPlus:
             self.sdr.rx_destroy_buffer()
         except (AttributeError, TypeError):
             pass
+        except Exception as error:
+            failures.append(("destroy RX buffer", error))
         self.rx_config = None
+        if failures:
+            raise SdrCleanupError(failures)
 
     def _open_direct_rx(self):
         if self.rx_config.direct_usb_protocol_version not in (1, 2):

--- a/tests/test_capture_finalization.py
+++ b/tests/test_capture_finalization.py
@@ -55,9 +55,7 @@ def test_disconnect_preserves_primary_error_and_finalizes_partial_zarr(
     collector = _DisconnectedCollector(partial_path, primary_error)
     collector.receiver_pplus = {"usb:1.4.5": radio}
     collector.read_threads = []
-    collector.collector_thread = threading.Thread(
-        target=collector.run_collector_thread
-    )
+    collector.collector_thread = threading.Thread(target=collector.run_collector_thread)
 
     with caplog.at_level(logging.ERROR):
         collector.start()
@@ -74,9 +72,9 @@ def test_disconnect_preserves_primary_error_and_finalizes_partial_zarr(
     try:
         assert partial.attrs["capture_status"] == "incomplete"
         assert partial.attrs["capture_error_type"] == "OSError"
-        assert "Pluto disappeared during bulk RX" in partial.attrs[
-            "capture_error_message"
-        ]
+        assert (
+            "Pluto disappeared during bulk RX" in partial.attrs["capture_error_message"]
+        )
         assert any(
             "TX mute failed because Pluto is gone" in failure
             for failure in partial.attrs["capture_cleanup_errors"]

--- a/tests/test_capture_finalization.py
+++ b/tests/test_capture_finalization.py
@@ -1,0 +1,111 @@
+import logging
+import threading
+
+import pytest
+
+from spf.data_collector import DataCollector
+from spf.scripts.zarr_utils import zarr_open_from_lmdb_store
+from spf.sdrpluto.sdr_controller import PPlus
+
+
+class _DisconnectedCollector(DataCollector):
+    def __init__(self, data_filename, primary_error):
+        self.primary_error = primary_error
+        super().__init__(
+            yaml_config={"receivers": []},
+            data_filename=str(data_filename),
+            position_controller=None,
+            thread_class=None,
+        )
+
+    def setup_record_matrix(self):
+        self.zarr = zarr_open_from_lmdb_store(self.data_filename, mode="w")
+        self.zarr.create_group("receivers")
+
+    def run_inner_collector_thread(self):
+        raise self.primary_error
+
+    def close(self):
+        zarr = getattr(self, "zarr", None)
+        if zarr is None:
+            return
+        zarr.store.close()
+        self.zarr = None
+
+
+class _CleanupAlsoDisconnects:
+    def __init__(self, cleanup_error):
+        self.cleanup_error = cleanup_error
+        self.close_calls = 0
+
+    def close(self):
+        self.close_calls += 1
+        raise self.cleanup_error
+
+
+def test_disconnect_preserves_primary_error_and_finalizes_partial_zarr(
+    tmp_path, caplog
+):
+    """A cleanup failure must not hide the capture failure or strand LMDB."""
+
+    partial_path = tmp_path / "capture.zarr.tmp"
+    primary_error = OSError(19, "Pluto disappeared during bulk RX")
+    cleanup_error = OSError(19, "TX mute failed because Pluto is gone")
+    radio = _CleanupAlsoDisconnects(cleanup_error)
+    collector = _DisconnectedCollector(partial_path, primary_error)
+    collector.receiver_pplus = {"usb:1.4.5": radio}
+    collector.read_threads = []
+    collector.collector_thread = threading.Thread(
+        target=collector.run_collector_thread
+    )
+
+    with caplog.at_level(logging.ERROR):
+        collector.start()
+        with pytest.raises(OSError) as raised:
+            collector.done()
+
+    assert raised.value is primary_error
+    assert radio.close_calls == 1
+    assert "TX mute failed because Pluto is gone" in caplog.text
+    assert partial_path.is_dir()
+    assert not (tmp_path / "capture.zarr").exists()
+
+    partial = zarr_open_from_lmdb_store(str(partial_path), mode="r")
+    try:
+        assert partial.attrs["capture_status"] == "incomplete"
+        assert partial.attrs["capture_error_type"] == "OSError"
+        assert "Pluto disappeared during bulk RX" in partial.attrs[
+            "capture_error_message"
+        ]
+        assert any(
+            "TX mute failed because Pluto is gone" in failure
+            for failure in partial.attrs["capture_cleanup_errors"]
+        )
+    finally:
+        partial.store.close()
+
+
+def test_pluto_close_attempts_tx_mute_after_rx_cleanup_failure():
+    """RX teardown must not prevent the independent TX safety teardown."""
+
+    radio = object.__new__(PPlus)
+    radio.uri = "usb:1.4.5"
+    calls = []
+
+    def close_rx():
+        calls.append("rx")
+        raise OSError(19, "RX transport is gone")
+
+    def close_tx():
+        calls.append("tx")
+        raise OSError(19, "TX mute failed")
+
+    radio.close_rx = close_rx
+    radio.close_tx = close_tx
+
+    with pytest.raises(RuntimeError) as raised:
+        radio.close()
+
+    assert calls == ["rx", "tx"]
+    assert "RX transport is gone" in str(raised.value)
+    assert "TX mute failed" in str(raised.value)


### PR DESCRIPTION
## Summary

Make rover capture shutdown failure-safe when a Pluto disappears during direct-USB RX:

- preserve the original receiver/capture exception and propagate it from the collector thread to the main process;
- attempt RX teardown and TX mute independently, aggregating cleanup failures instead of allowing one to suppress the other;
- always close the temporary Zarr store and keep failed captures under the existing `.zarr.tmp` incomplete-data convention;
- write explicit lifecycle metadata (`capture_status`, primary error type/message/errno, successful record counts, and cleanup errors) before closing the store;
- surface asynchronous Zarr write failures, including the final queued futures, instead of only logging an early subset;
- make rover Zarr close idempotent and destructor cleanup best-effort.

## Root cause

The receiver worker caught the direct-USB `ENODEV`, logged it, and replaced it with a bare `None` sentinel. The collector interpreted that sentinel as a normal early return. Collector failures lived only in a background thread, because `done()` joined without re-raising them. During teardown, `PPlus.close()` ran RX cleanup before TX mute without isolation, so an RX or device-loss exception prevented TX mute and could become the visible error. Completion was marked before teardown finished, while async writer failures left in the queue were not checked.

Together, those behaviors lost the original radio-disconnect cause and made a failed temporary capture's state ambiguous.

## Red / green evidence

The first commit (`71a04eb`) adds regressions for the observed double failure:

1. bulk RX raises `OSError(19)`;
2. radio cleanup/TX mute also raises `OSError(19)`;
3. the caller must receive the original bulk-RX exception by identity;
4. the `.zarr.tmp` LMDB must reopen successfully and report `capture_status=incomplete`, the primary error, and the cleanup error;
5. TX cleanup must still be attempted after RX cleanup fails.

Before the implementation:

- the collector regression failed with `DID NOT RAISE OSError` and an unhandled background-thread exception;
- the Pluto close regression stopped after RX cleanup and never called TX cleanup.

After `7b7bce9`, both pass.

## Data and recovery semantics

- A successful run records `capture_status=complete` and follows the existing main-process rename from `.zarr.tmp` to `.zarr`.
- Any capture or cleanup failure records `capture_status=incomplete`, closes the LMDB, propagates a non-zero failure, and therefore remains `.zarr.tmp`; it cannot be mistaken for a complete capture.
- `capture_records_written_by_receiver` counts writes that completed successfully.
- `capture_error_*` always describes the first/primary failure.
- `capture_cleanup_errors` records later cleanup/TX-mute failures without replacing the primary failure.
- No automatic truncation or promotion of partial data is performed; existing recovery tooling can inspect the now-closed temporary store.

## Validation

Targeted tests only, per repository safety guidance:

```text
/home/pi/spf-virtualenv/bin/python -m pytest -q \
  tests/test_capture_finalization.py \
  tests/test_direct_usb_collector.py \
  tests/test_mavlink_radio_collect.py::test_mavlink_radio_collect

8 passed, 4 warnings in 56.74s
```

Formatting:

```text
python -m black --check spf/data_collector.py \
  spf/sdrpluto/sdr_controller.py tests/test_capture_finalization.py

3 files would be left unchanged
```

## Hardware validation still required

On a rover with a sacrificial capture, disconnect or reset one Pluto during direct-USB RX and verify:

- the service exits non-zero with the bulk-RX `ENODEV` as the primary error;
- both radio teardown paths are attempted and TX-mute failure is logged;
- the output remains `.zarr.tmp` and can be reopened after process exit;
- its lifecycle attributes and successful record counts match the journal;
- a subsequent clean capture starts without LMDB lock recovery.

Graceful process-level SIGTERM handling is intentionally not included: the current CLI has no top-level lifecycle boundary, and adding one would require a broader refactor than this runtime-disconnect fix.

## Retry and terminal-state behavior

**Graceful failure only; this PR does not retry the transport.** The partial
store is closed and retained as `.zarr.tmp`, and remaining cleanup/TX mute is
attempted. A new capture requires a healthy radio and a manual service or
collection restart. The current production unit has no
`Restart=on-failure`.
