### PR TITLE
Recover bounded MAVLink serial disconnects

### DIFF
--- a/spf/mavlink/mavlink_controller.py
+++ b/spf/mavlink/mavlink_controller.py
@@ -11,6 +11,7 @@ import sys
 import termios
 import threading
 import time
+from contextlib import contextmanager
 from datetime import datetime
 
 import numpy as np
@@ -560,20 +561,21 @@ class Drone:
         return self._connection_healthy.is_set()
 
     def _mark_connection_unhealthy(self, error):
-        logging.error("MAVLink connection lost: %s", error)
-        self._connection_healthy.clear()
-        self.connection_failure = None
-        # Never preserve an armed/ready assumption across a broken link.
-        self.armed = False
-        self.drone_ready = False
-        self.planner_in_control = False
-        self.mav_mode = None
-        self.mav_states = []
-        self.gps = np.zeros(2)
-        self.gps_satellites = -1
-        self.gps_fix_type = "NOT_SET_YET"
-        self.ekf_healthy = False
-        self.sensors_health = []
+        with self._connection_lock:
+            logging.error("MAVLink connection lost: %s", error)
+            self._connection_healthy.clear()
+            self.connection_failure = None
+            # Never preserve an armed/ready assumption across a broken link.
+            self.armed = False
+            self.drone_ready = False
+            self.planner_in_control = False
+            self.mav_mode = None
+            self.mav_states = []
+            self.gps = np.zeros(2)
+            self.gps_satellites = -1
+            self.gps_fix_type = "NOT_SET_YET"
+            self.ekf_healthy = False
+            self.sensors_health = []
 
     def _require_healthy_connection(self):
         if self.connection_factory is not None and not self.connection_healthy:
@@ -581,6 +583,30 @@ class Drone:
                 "MAVLink connection is not healthy; refusing vehicle command"
             )
         return self.connection
+
+    @contextmanager
+    def _command_connection(self, *, allow_replacement=False):
+        """Hold one verified connection stable for a runtime operation.
+
+        Vehicle commands fail closed if a reconnect begins while they are
+        waiting for the lock.  Advisory operations such as the buzzer may wait
+        for a bounded reconnect and opt into the replacement connection.
+        """
+        expected_connection = self.connection
+        if (
+            not allow_replacement
+            and self.connection_factory is not None
+            and not self.connection_healthy
+        ):
+            raise MavlinkConnectionError(
+                "MAVLink connection is not healthy; refusing vehicle command"
+            )
+        with self._connection_lock:
+            if not allow_replacement and self.connection is not expected_connection:
+                raise MavlinkConnectionError(
+                    "MAVLink connection changed; refusing stale vehicle command"
+                )
+            yield self._require_healthy_connection()
 
     def raise_if_connection_failed(self):
         if self.connection_failure is not None:
@@ -636,14 +662,26 @@ class Drone:
     def buzzer(self, tone_bytes):
         for _ in range(5):
             try:
-                self.connection.mav.play_tune_send(
-                    self.connection.target_system,
-                    self.connection.target_component,
-                    tone_bytes,
-                )
+                with self._command_connection(allow_replacement=True) as connection:
+                    connection.mav.play_tune_send(
+                        connection.target_system,
+                        connection.target_component,
+                        tone_bytes,
+                    )
                 return True
             except AttributeError:
                 pass
+            except MavlinkConnectionError as error:
+                logging.info(
+                    "Skipping buzzer while MAVLink is unavailable: %s", error
+                )
+                return False
+            except Exception as error:
+                # The buzzer is advisory.  A write failure must not kill the
+                # planner, and receive-loop recovery remains the sole owner of
+                # replacing the transport.
+                logging.warning("MAVLink buzzer command failed: %s", error)
+                return False
             time.sleep(0.1)
         return False
 
@@ -666,8 +704,7 @@ class Drone:
             self.raise_if_connection_failed()
             self.reset_params()
             self.param_count = 0
-            with self._connection_lock:
-                connection = self._require_healthy_connection()
+            with self._command_connection() as connection:
                 try:
                     connection.param_fetch_all()
                 except Exception as error:
@@ -732,9 +769,10 @@ class Drone:
         return self
 
     def send_status(self, text):
-        self.connection.mav.statustext_send(
-            mavutil.mavlink.MAV_SEVERITY_CRITICAL, text.encode()
-        )
+        with self._command_connection() as connection:
+            connection.mav.statustext_send(
+                mavutil.mavlink.MAV_SEVERITY_CRITICAL, text.encode()
+            )
 
     def is_planner_in_control(self):
         return self.planner_in_control
@@ -752,19 +790,20 @@ class Drone:
         return np.linalg.norm(target_point - self.gps)
 
     def erase_logs(self):
-        self.connection.mav.command_long_send(
-            self.connection.target_system,
-            self.connection.target_component,
-            LOG_ERASE,
-            0,  # set position
-            0,  # param1
-            0,  # param2
-            0,  # param3
-            0,  # param4
-            0,  # 37.8047122,  # lat
-            0,  # long,  # -122.4659164,  # lon
-            0,  # 0,
-        )
+        with self._command_connection() as connection:
+            connection.mav.command_long_send(
+                connection.target_system,
+                connection.target_component,
+                LOG_ERASE,
+                0,  # set position
+                0,  # param1
+                0,  # param2
+                0,  # param3
+                0,  # param4
+                0,  # 37.8047122,  # lat
+                0,  # long,  # -122.4659164,  # lon
+                0,  # 0,
+            )
 
     # point long/lat
     def move_to_point(self, point, log_interval=5):
@@ -835,15 +874,16 @@ class Drone:
                 time.sleep(1)
 
         else:
-            while self.mav_mode != "ROVER_MODE_MANUAL":
-                time.sleep(2)
-                logging.info("waiting for rover to move into manual mode...")
-                self.buzzer(tones["wait"])
-
-            while self.mav_mode != "ROVER_MODE_GUIDED":
-                time.sleep(2)
-                logging.info("waiting for rover to move into guided mode...")
-                self.buzzer(tones["ready"])
+            self._wait_for_mode(
+                "ROVER_MODE_MANUAL",
+                tones["wait"],
+                "waiting for rover to move into manual mode...",
+            )
+            self._wait_for_mode(
+                "ROVER_MODE_GUIDED",
+                tones["ready"],
+                "waiting for rover to move into guided mode...",
+            )
 
             if not self.armed:
                 self.arm()
@@ -874,6 +914,14 @@ class Drone:
                 # time.sleep(2)
 
         self.planner_in_control = False
+
+    def _wait_for_mode(self, expected_mode, tone, message, poll_interval=2.0):
+        """Wait for operator mode changes without making the buzzer critical."""
+        while self.mav_mode != expected_mode:
+            self.raise_if_connection_failed()
+            time.sleep(poll_interval)
+            logging.info(message)
+            self.buzzer(tone)
 
     def get_cmd(self, cmd):
         v = getattr(mavutil.mavlink, cmd)
@@ -915,58 +963,60 @@ class Drone:
         """
         # According to the custom_mode_mapping, mode 11 is ROVER_MODE_RTL.
         # We can use the underlying MAV_CMD_DO_SET_MODE command to switch modes.
-        connection = self._require_healthy_connection()
-        connection.mav.command_long_send(
-            connection.target_system,
-            connection.target_component,
-            self.get_cmd("MAV_CMD_DO_SET_MODE"),
-            0,  # Confirmation
-            mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,  # Base mode flags
-            ROVER_MODE_RTL,  # Custom mode index for RTL
-            0,
-            0,
-            0,
-            0,
-            0,
-        )
+        with self._command_connection() as connection:
+            connection.mav.command_long_send(
+                connection.target_system,
+                connection.target_component,
+                self.get_cmd("MAV_CMD_DO_SET_MODE"),
+                0,  # Confirmation
+                mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,  # Base mode flags
+                ROVER_MODE_RTL,  # Custom mode index for RTL
+                0,
+                0,
+                0,
+                0,
+                0,
+            )
 
     def run_compass_calibration(self):
-        message = self.connection.mav.command_long_encode(
-            self.connection.target_system,  # Target system ID
-            self.connection.target_component,  # Target component ID
-            self.get_cmd("MAV_CMD_DO_START_MAG_CAL"),  # ID of command to send
-            0,
-            3,  # first two
-            0,
-            1,
-            0,
-            1,
-            0,
-            0,
-        )
-        self.connection.mav.send(message)
+        with self._command_connection() as connection:
+            message = connection.mav.command_long_encode(
+                connection.target_system,  # Target system ID
+                connection.target_component,  # Target component ID
+                self.get_cmd("MAV_CMD_DO_START_MAG_CAL"),  # ID of command to send
+                0,
+                3,  # first two
+                0,
+                1,
+                0,
+                1,
+                0,
+                0,
+            )
+            connection.mav.send(message)
 
     def request_home(self):
-        message = self.connection.mav.command_long_encode(
-            self.connection.target_system,  # Target system ID
-            self.connection.target_component,  # Target component ID
-            self.get_cmd("MAV_CMD_GET_HOME_POSITION"),  # ID of command to send
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-        )
+        with self._command_connection() as connection:
+            message = connection.mav.command_long_encode(
+                connection.target_system,  # Target system ID
+                connection.target_component,  # Target component ID
+                self.get_cmd("MAV_CMD_GET_HOME_POSITION"),  # ID of command to send
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )
 
-        # msg = connection.mav.command_long_encode(
-        #    0, 0, mavutil.mavlink.MAV_CMD_GET_HOME_POSITION, 0, 0, 0, 0, 0, 0, 0, 0
-        # )
+            # msg = connection.mav.command_long_encode(
+            #    0, 0, mavutil.mavlink.MAV_CMD_GET_HOME_POSITION, 0, 0, 0, 0, 0, 0, 0, 0
+            # )
 
-        # Send the COMMAND_LONG
-        self.connection.mav.send(message)
+            # Send the COMMAND_LONG
+            connection.mav.send(message)
 
     def set_home(self, lat, long):
         """Set the vehicle home (and therefore the RTL destination) to lat/long.
@@ -981,86 +1031,89 @@ class Drone:
         these longitudes — larger than the per-rover rest offsets themselves.
         This mirrors reposition(), which already uses command_int_send.
         """
-        connection = self._require_healthy_connection()
-        connection.mav.command_int_send(
-            connection.target_system,
-            connection.target_component,
-            mavutil.mavlink.MAV_FRAME_GLOBAL,
-            self.get_cmd("MAV_CMD_DO_SET_HOME"),
-            0,  # current
-            0,  # autocontinue
-            0,  # param1: 0 = use SPECIFIED location (1 would discard lat/long)
-            0,  # param2
-            0,  # param3
-            0,  # param4
-            int(lat * 1e7),
-            int(long * 1e7),
-            0,
-        )
+        with self._command_connection() as connection:
+            connection.mav.command_int_send(
+                connection.target_system,
+                connection.target_component,
+                mavutil.mavlink.MAV_FRAME_GLOBAL,
+                self.get_cmd("MAV_CMD_DO_SET_HOME"),
+                0,  # current
+                0,  # autocontinue
+                0,  # param1: 0 = use SPECIFIED location (1 would discard lat/long)
+                0,  # param2
+                0,  # param3
+                0,  # param4
+                int(lat * 1e7),
+                int(long * 1e7),
+                0,
+            )
         # self.ack("COMMAND_ACK")
         self.home = np.array([long, lat])  # Store home for later use
 
     def turn_off_hardware_safety(self):
-        self.connection.mav.set_mode_send(
-            self.connection.target_system,
-            mavutil.mavlink.MAV_MODE_FLAG_DECODE_POSITION_SAFETY,
-            0,
-        )
+        with self._command_connection() as connection:
+            connection.mav.set_mode_send(
+                connection.target_system,
+                mavutil.mavlink.MAV_MODE_FLAG_DECODE_POSITION_SAFETY,
+                0,
+            )
 
     def reboot(self, force=False, hold_in_bootloader=False):
-        if not force:
-            self.connection.reboot_autopilot()
-            return
-        if hold_in_bootloader:
-            param1 = 3
-        else:
-            param1 = 1
-        param6 = 20190226
-        self.connection.mav.command_long_send(
-            self.connection.target_system,
-            self.connection.target_component,
-            mavutil.mavlink.MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN,
-            0,
-            param1,
-            0,
-            0,
-            0,
-            0,
-            param6,
-            0,
-        )
+        with self._command_connection() as connection:
+            if not force:
+                connection.reboot_autopilot()
+                return
+            if hold_in_bootloader:
+                param1 = 3
+            else:
+                param1 = 1
+            param6 = 20190226
+            connection.mav.command_long_send(
+                connection.target_system,
+                connection.target_component,
+                mavutil.mavlink.MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN,
+                0,
+                param1,
+                0,
+                0,
+                0,
+                0,
+                param6,
+                0,
+            )
 
     def disarm(self, force=False):
-        self.connection.mav.command_long_send(
-            self.connection.target_system,
-            self.connection.target_component,
-            self.get_cmd("MAV_CMD_COMPONENT_ARM_DISARM"),
-            0,
-            0,
-            1 if force else 0,
-            0,
-            0,
-            0,
-            0,
-            0,
-        )
+        with self._command_connection() as connection:
+            connection.mav.command_long_send(
+                connection.target_system,
+                connection.target_component,
+                self.get_cmd("MAV_CMD_COMPONENT_ARM_DISARM"),
+                0,
+                0,
+                1 if force else 0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )
         # self.ack("COMMAND_ACK")
 
     def arm(self, force=False):
-        connection = self._require_healthy_connection()
-        connection.mav.command_long_send(
-            connection.target_system,
-            connection.target_component,
-            self.get_cmd("MAV_CMD_COMPONENT_ARM_DISARM"),
-            0,
-            1,
-            1 if force else 0,
-            0,
-            0,
-            0,
-            0,
-            0,
-        )
+        with self._command_connection() as connection:
+            connection.mav.command_long_send(
+                connection.target_system,
+                connection.target_component,
+                self.get_cmd("MAV_CMD_COMPONENT_ARM_DISARM"),
+                0,
+                1,
+                1 if force else 0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )
         # self.ack("COMMAND_ACK")
 
     def reposition(self, lat, long):
@@ -1078,43 +1131,45 @@ class Drone:
         #    0.0,  # altitude
         # )
         # self.mission_item_reached = False
-        connection = self._require_healthy_connection()
-        connection.mav.command_int_send(
-            connection.target_system,
-            connection.target_component,
-            0,  # frame
-            self.get_cmd("MAV_CMD_DO_REPOSITION"),  # cmd
-            0,  # not used
-            0,  # not used
-            -1,  # default ground speed
-            0,  # reposition flags
-            0,  # loiter radius, 0 is ignore
-            math.nan,  # yaw
-            int(lat * 1e7),
-            int(long * 1e7),
-            0.0,  # altitude
-        )
+        with self._command_connection() as connection:
+            connection.mav.command_int_send(
+                connection.target_system,
+                connection.target_component,
+                0,  # frame
+                self.get_cmd("MAV_CMD_DO_REPOSITION"),  # cmd
+                0,  # not used
+                0,  # not used
+                -1,  # default ground speed
+                0,  # reposition flags
+                0,  # loiter radius, 0 is ignore
+                math.nan,  # yaw
+                int(lat * 1e7),
+                int(long * 1e7),
+                0.0,  # altitude
+            )
 
     def do_mission(self, restart_mission=True):
-        self.connection.mav.command_long_send(
-            self.connection.target_system,
-            self.connection.target_component,
-            self.get_cmd("MAV_CMD_DO_SET_MISSION_CURRENT"),
-            0,
-            -1,
-            1 if restart_mission else 0,
-            0,
-            0,
-            0,
-            0,
-            0,
-        )
+        with self._command_connection() as connection:
+            connection.mav.command_long_send(
+                connection.target_system,
+                connection.target_component,
+                self.get_cmd("MAV_CMD_DO_SET_MISSION_CURRENT"),
+                0,
+                -1,
+                1 if restart_mission else 0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )
         # self.ack("COMMAND_ACK")
 
     def ack(self, keyword):
-        return (
-            self.connection.recv_match(type=keyword, blocking=True, timeout=5) is None
-        )
+        with self._command_connection() as connection:
+            return (
+                connection.recv_match(type=keyword, blocking=True, timeout=5) is None
+            )
 
     def single_operation_mode_on(self):
         assert not self.single_operation
@@ -1323,7 +1378,8 @@ class Drone:
             self.message_handlers[msg_type](self, msg)
 
     def set_mode(self, mode):
-        self._require_healthy_connection().set_mode(mode)
+        with self._command_connection() as connection:
+            connection.set_mode(mode)
 
 
 def get_ardupilot_serial():
@@ -1474,7 +1530,9 @@ def mavlink_controller_run(args):
             reconnect_heartbeat_timeout=args.heartbeat_timeout,
         )
         drone.process_message(initial_heartbeat)
-        drone.buzzer(tone_bytes)
+        if not drone.buzzer(tone_bytes):
+            logging.error("Could not send MAVLink buzzer command")
+            sys.exit(1)
         sys.exit(0)
 
     logging.info("Listening...")
@@ -1588,7 +1646,8 @@ def mavlink_controller_run(args):
             drone.single_operation_mode_on()
             drone.disarm()
             time.sleep(0.02)
-            count, changed = drone.params.load(args.load_params, mav=drone.connection)
+            with drone._command_connection() as connection:
+                count, changed = drone.params.load(args.load_params, mav=connection)
             drone.single_operation_mode_off()
         sys.exit(0)
 

--- a/spf/mavlink/mavlink_controller.py
+++ b/spf/mavlink/mavlink_controller.py
@@ -567,6 +567,13 @@ class Drone:
         self.armed = False
         self.drone_ready = False
         self.planner_in_control = False
+        self.mav_mode = None
+        self.mav_states = []
+        self.gps = np.zeros(2)
+        self.gps_satellites = -1
+        self.gps_fix_type = "NOT_SET_YET"
+        self.ekf_healthy = False
+        self.sensors_health = []
 
     def _require_healthy_connection(self):
         if self.connection_factory is not None and not self.connection_healthy:

--- a/spf/mavlink/mavlink_controller.py
+++ b/spf/mavlink/mavlink_controller.py
@@ -1,5 +1,6 @@
 # Import mavutil
 import argparse
+import fcntl
 import glob
 import json
 import logging
@@ -7,6 +8,7 @@ import math
 import os
 import subprocess
 import sys
+import termios
 import threading
 import time
 from datetime import datetime
@@ -180,6 +182,138 @@ LOG_ERASE = 121
 # equatorial radius 6378137 would make a requested 2 m read as 1.9978 m.)
 EARTH_RADIUS_M = 6371008.8
 
+DEFAULT_MAVLINK_RECONNECT_ATTEMPTS = 3
+DEFAULT_MAVLINK_RECONNECT_BACKOFF_SECONDS = 1.0
+DEFAULT_MAVLINK_HEARTBEAT_TIMEOUT_SECONDS = 10.0
+
+
+class MavlinkConnectionError(RuntimeError):
+    """The vehicle link could not be established or recovered safely."""
+
+
+class MavlinkParameterError(MavlinkConnectionError):
+    """The complete vehicle parameter set could not be read."""
+
+
+def resolve_ardupilot_serial(configured="", available_pilots=None):
+    """Return a stable ArduPilot ``/dev/serial/by-id`` endpoint when possible.
+
+    Linux ``ttyACM`` numbers are allocation-order identifiers and can change
+    after a flight-controller reboot.  A caller may still provide a tty name,
+    but it is promoted to the by-id symlink that resolves to the same device.
+    """
+    if available_pilots is None:
+        available_pilots = sorted(glob.glob("/dev/serial/by-id/usb-ArduPilot*"))
+    else:
+        available_pilots = sorted(available_pilots)
+
+    if configured in ("", "serial", None):
+        if len(available_pilots) != 1:
+            raise MavlinkConnectionError(
+                "Expected exactly one ArduPilot serial device; "
+                f"found {len(available_pilots)}: {available_pilots}"
+            )
+        return available_pilots[0]
+
+    if configured in available_pilots or configured.startswith("/dev/serial/by-id/"):
+        return configured
+
+    configured_realpath = os.path.realpath(configured)
+    matches = [
+        candidate
+        for candidate in available_pilots
+        if os.path.realpath(candidate) == configured_realpath
+    ]
+    if len(matches) == 1:
+        logging.info(
+            "Promoted unstable MAVLink endpoint %s to %s",
+            configured,
+            matches[0],
+        )
+        return matches[0]
+    if len(matches) > 1:
+        raise MavlinkConnectionError(
+            f"Serial endpoint {configured} maps to multiple by-id devices: {matches}"
+        )
+
+    logging.warning(
+        "No stable /dev/serial/by-id identity found for %s; reconnects may "
+        "select the wrong tty after re-enumeration",
+        configured,
+    )
+    return configured
+
+
+def _claim_serial_exclusive(connection, endpoint):
+    """Ask the kernel to reject a second opener of this serial port."""
+    if ":" in endpoint or not hasattr(connection, "port"):
+        return
+    try:
+        fd = connection.port.fileno()
+        fcntl.ioctl(fd, termios.TIOCEXCL)
+    except Exception as error:
+        try:
+            connection.close()
+        except Exception:
+            pass
+        raise MavlinkConnectionError(
+            f"Could not claim exclusive MAVLink ownership of {endpoint}: {error}. "
+            "Stop mavproxy/QGroundControl serial access and retry."
+        ) from error
+
+
+def open_mavlink_connection(endpoint, baud=115200):
+    """Open one MAVLink endpoint with exclusive local-serial ownership."""
+    connection = mavutil.mavlink_connection(endpoint, baud=baud)
+    _claim_serial_exclusive(connection, endpoint)
+    return connection
+
+
+def mavlink_connection_factory(endpoint, baud=115200):
+    return lambda: open_mavlink_connection(endpoint, baud=baud)
+
+
+def connect_with_heartbeat(
+    connection_factory,
+    *,
+    attempts=DEFAULT_MAVLINK_RECONNECT_ATTEMPTS,
+    heartbeat_timeout=DEFAULT_MAVLINK_HEARTBEAT_TIMEOUT_SECONDS,
+    retry_backoff=DEFAULT_MAVLINK_RECONNECT_BACKOFF_SECONDS,
+):
+    """Open a link and require a real heartbeat, with a bounded retry count."""
+    last_error = None
+    for attempt in range(1, attempts + 1):
+        connection = None
+        try:
+            connection = connection_factory()
+            heartbeat = connection.wait_heartbeat(
+                blocking=True,
+                timeout=heartbeat_timeout,
+            )
+            if heartbeat is None:
+                raise MavlinkConnectionError(
+                    f"no heartbeat within {heartbeat_timeout:.1f}s"
+                )
+            return connection, heartbeat
+        except Exception as error:
+            last_error = error
+            if connection is not None:
+                try:
+                    connection.close()
+                except Exception:
+                    pass
+            logging.warning(
+                "MAVLink connection attempt %d/%d failed: %s",
+                attempt,
+                attempts,
+                error,
+            )
+            if attempt < attempts:
+                time.sleep(retry_backoff)
+    raise MavlinkConnectionError(
+        f"MAVLink unavailable after {attempts} attempts: {last_error}"
+    ) from last_error
+
 
 def meters_to_degrees(east_m, north_m, latitude_deg):
     """Convert an (East, North) metre offset to (dlong, dlat) degrees.
@@ -307,15 +441,26 @@ class Drone:
         tolerance_in_m=5,
         distance_finder=None,
         fake=False,
-        ignore_mode=False
+        ignore_mode=False,
+        connection_factory=None,
+        reconnect_attempts=DEFAULT_MAVLINK_RECONNECT_ATTEMPTS,
+        reconnect_backoff=DEFAULT_MAVLINK_RECONNECT_BACKOFF_SECONDS,
+        reconnect_heartbeat_timeout=DEFAULT_MAVLINK_HEARTBEAT_TIMEOUT_SECONDS,
     ):
         self.connection = connection
+        self.connection_factory = connection_factory
+        self.reconnect_attempts = reconnect_attempts
+        self.reconnect_backoff = reconnect_backoff
+        self.reconnect_heartbeat_timeout = reconnect_heartbeat_timeout
+        self.connection_failure = None
+        self._connection_healthy = threading.Event()
+        self._connection_lock = threading.RLock()
         self.param_count = 0
         self.heading = 0
         self.gps_time = 0
         self.time_since_boot = 0
         self.distance_finder = distance_finder
-        self.ignore_mode=ignore_mode
+        self.ignore_mode = ignore_mode
         if self.distance_finder is not None:
             self.distance_finder.run_in_new_thread()
 
@@ -410,6 +555,69 @@ class Drone:
         # self.mission_item_condition = threading.Condition()
         # self.mission_item_reached = False
 
+    @property
+    def connection_healthy(self):
+        return self._connection_healthy.is_set()
+
+    def _mark_connection_unhealthy(self, error):
+        logging.error("MAVLink connection lost: %s", error)
+        self._connection_healthy.clear()
+        self.connection_failure = None
+        # Never preserve an armed/ready assumption across a broken link.
+        self.armed = False
+        self.drone_ready = False
+        self.planner_in_control = False
+
+    def _require_healthy_connection(self):
+        if self.connection_factory is not None and not self.connection_healthy:
+            raise MavlinkConnectionError(
+                "MAVLink connection is not healthy; refusing vehicle command"
+            )
+        return self.connection
+
+    def raise_if_connection_failed(self):
+        if self.connection_failure is not None:
+            raise MavlinkConnectionError(str(self.connection_failure))
+
+    def _recover_connection(self, cause):
+        self._mark_connection_unhealthy(cause)
+        if self.connection_factory is None:
+            self.connection_failure = MavlinkConnectionError(
+                f"MAVLink receive loop stopped: {cause}"
+            )
+            return False
+
+        with self._connection_lock:
+            stale_connection = self.connection
+            try:
+                stale_connection.close()
+            except Exception:
+                pass
+
+            try:
+                connection, heartbeat = connect_with_heartbeat(
+                    self.connection_factory,
+                    attempts=self.reconnect_attempts,
+                    heartbeat_timeout=self.reconnect_heartbeat_timeout,
+                    retry_backoff=self.reconnect_backoff,
+                )
+            except MavlinkConnectionError as error:
+                self.connection_failure = error
+                logging.critical("MAVLink reconnect exhausted: %s", error)
+                return False
+
+            self.connection = connection
+            if not self.fake:
+                self.mav_mode_mapping_name2num = connection.mode_mapping()
+                self.mav_mode_mapping_num2name = mavutil.mode_mapping_bynumber(
+                    connection.sysid_state[connection.sysid].mav_type
+                )
+            self.process_message(heartbeat)
+            logging.info(
+                "MAVLink reconnected after a fresh flight-controller heartbeat"
+            )
+            return True
+
     def set_and_start_planner(self, planner):
         self.planner = planner
         self.planner_in_control = False
@@ -435,26 +643,81 @@ class Drone:
     def reset_params(self):
         self.params = MAVParmDict()
 
-    def update_all_parameters(self, timeout=50):
-        self.connection.param_fetch_all()
-        start_time = time.time()
-        params_read = len(self.params)
-        while self.param_count == 0 or params_read < self.param_count:
-            if time.time() - start_time > timeout:
-                logging.error(
-                    f"Failed to pull parameters! timeout, have {params_read} , need {self.param_count}"
+    def update_all_parameters(
+        self,
+        timeout=50,
+        max_attempts=3,
+        retry_backoff=1.0,
+    ):
+        """Fetch a complete, internally consistent parameter set.
+
+        A stalled partial download is discarded and restarted from zero. This
+        prevents parameters received before a flight-controller reset from
+        being combined with a later boot's parameter stream.
+        """
+        for attempt in range(1, max_attempts + 1):
+            self.raise_if_connection_failed()
+            self.reset_params()
+            self.param_count = 0
+            with self._connection_lock:
+                connection = self._require_healthy_connection()
+                try:
+                    connection.param_fetch_all()
+                except Exception as error:
+                    logging.warning(
+                        "Parameter fetch attempt %d/%d could not start: %s",
+                        attempt,
+                        max_attempts,
+                        error,
+                    )
+                    if attempt < max_attempts:
+                        time.sleep(retry_backoff)
+                        continue
+                    raise MavlinkParameterError(
+                        f"Could not start parameter fetch: {error}"
+                    ) from error
+
+            progress_deadline = time.monotonic() + timeout
+            params_read = 0
+            while self.param_count == 0 or params_read < self.param_count:
+                self.raise_if_connection_failed()
+                current_count = len(self.params)
+                if current_count != params_read:
+                    params_read = current_count
+                    progress_deadline = time.monotonic() + timeout
+                if self.param_count > 0 and params_read == self.param_count:
+                    break
+                if time.monotonic() >= progress_deadline:
+                    break
+                time.sleep(min(0.1, max(timeout / 10.0, 0.001)))
+
+            if self.param_count > 0 and len(self.params) == self.param_count:
+                logging.info(
+                    "Done loading drone parameters: have %d, wanted %d "
+                    "(attempt %d/%d)",
+                    len(self.params),
+                    self.param_count,
+                    attempt,
+                    max_attempts,
                 )
-                sys.exit(1)
-            if len(self.params) != params_read:  # if we got an update reset the clock
-                start_time = time.time()
-            params_read = len(self.params)
-            if params_read > 0 and params_read == self.param_count:
-                break
-            time.sleep(0.1)
-        logging.info(
-            f"Done loading drone parameters: have {len(self.params)} , wanted {self.param_count}"
+                return True
+
+            logging.warning(
+                "Incomplete parameter fetch attempt %d/%d: have %d, expected %d; "
+                "discarding partial set and retrying",
+                attempt,
+                max_attempts,
+                len(self.params),
+                self.param_count,
+            )
+            if attempt < max_attempts:
+                time.sleep(retry_backoff)
+
+        raise MavlinkParameterError(
+            "Failed to read a complete parameter set after "
+            f"{max_attempts} attempts (last attempt had {len(self.params)}/"
+            f"{self.param_count})"
         )
-        return len(self.params) == self.param_count
 
     # motion interface
     def start(self):
@@ -602,7 +865,7 @@ class Drone:
                     self.move_to_point(point)
                 self.planner_in_control = True
                 # time.sleep(2)
-                
+
         self.planner_in_control = False
 
     def get_cmd(self, cmd):
@@ -645,9 +908,10 @@ class Drone:
         """
         # According to the custom_mode_mapping, mode 11 is ROVER_MODE_RTL.
         # We can use the underlying MAV_CMD_DO_SET_MODE command to switch modes.
-        self.connection.mav.command_long_send(
-            self.connection.target_system,
-            self.connection.target_component,
+        connection = self._require_healthy_connection()
+        connection.mav.command_long_send(
+            connection.target_system,
+            connection.target_component,
             self.get_cmd("MAV_CMD_DO_SET_MODE"),
             0,  # Confirmation
             mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,  # Base mode flags
@@ -710,9 +974,10 @@ class Drone:
         these longitudes — larger than the per-rover rest offsets themselves.
         This mirrors reposition(), which already uses command_int_send.
         """
-        self.connection.mav.command_int_send(
-            self.connection.target_system,
-            self.connection.target_component,
+        connection = self._require_healthy_connection()
+        connection.mav.command_int_send(
+            connection.target_system,
+            connection.target_component,
             mavutil.mavlink.MAV_FRAME_GLOBAL,
             self.get_cmd("MAV_CMD_DO_SET_HOME"),
             0,  # current
@@ -775,9 +1040,10 @@ class Drone:
         # self.ack("COMMAND_ACK")
 
     def arm(self, force=False):
-        self.connection.mav.command_long_send(
-            self.connection.target_system,
-            self.connection.target_component,
+        connection = self._require_healthy_connection()
+        connection.mav.command_long_send(
+            connection.target_system,
+            connection.target_component,
             self.get_cmd("MAV_CMD_COMPONENT_ARM_DISARM"),
             0,
             1,
@@ -805,9 +1071,10 @@ class Drone:
         #    0.0,  # altitude
         # )
         # self.mission_item_reached = False
-        self.connection.mav.command_int_send(
-            self.connection.target_system,
-            self.connection.target_component,
+        connection = self._require_healthy_connection()
+        connection.mav.command_int_send(
+            connection.target_system,
+            connection.target_component,
             0,  # frame
             self.get_cmd("MAV_CMD_DO_REPOSITION"),  # cmd
             0,  # not used
@@ -870,7 +1137,23 @@ class Drone:
                         self.single_condition.notify_all()
                     while not self.message_loop:
                         self.message_condition.wait()
-                msg = self.connection.recv_match(blocking=True, timeout=0.5)
+                try:
+                    with self._connection_lock:
+                        connection = self.connection
+                    msg = connection.recv_match(blocking=True, timeout=0.5)
+                    if (
+                        self.connection_healthy
+                        and self.last_heartbeat > 0
+                        and time.time() - self.last_heartbeat
+                        > self.reconnect_heartbeat_timeout
+                    ):
+                        raise MavlinkConnectionError(
+                            "flight-controller heartbeat timed out"
+                        )
+                except Exception as error:
+                    if not self._recover_connection(error):
+                        return
+                    continue
                 self.process_message(msg)
 
     def handle_HOME_POSITION(self, msg):
@@ -917,6 +1200,8 @@ class Drone:
 
     def handle_HEARTBEAT(self, msg, log_interval=5):
         self.last_heartbeat = time.time()
+        self.connection_failure = None
+        self._connection_healthy.set()
         self.mav_states = lookup_exact(msg.system_status, mav_states_list)
         self.mav_mode = custom_mode_mapping[
             msg.custom_mode
@@ -1031,15 +1316,15 @@ class Drone:
             self.message_handlers[msg_type](self, msg)
 
     def set_mode(self, mode):
-        self.connection.set_mode(mode)
+        self._require_healthy_connection().set_mode(mode)
 
 
 def get_ardupilot_serial():
-    available_pilots = glob.glob("/dev/serial/by-id/usb-ArduPilot*")
-    if len(available_pilots) != 1:
-        logging.error(f"Strange number of autopilots found {len(available_pilots)}")
+    try:
+        return resolve_ardupilot_serial()
+    except MavlinkConnectionError as error:
+        logging.error("%s", error)
         return None
-    return available_pilots[0]
 
 
 def get_mavlink_controller_parser():
@@ -1107,6 +1392,24 @@ def get_mavlink_controller_parser():
         default=None,
     )
     parser.add_argument("--skip-heartbeat", action=argparse.BooleanOptionalAction)
+    parser.add_argument(
+        "--connect-attempts",
+        type=int,
+        default=DEFAULT_MAVLINK_RECONNECT_ATTEMPTS,
+        help="bounded initial/reconnect attempt count",
+    )
+    parser.add_argument(
+        "--heartbeat-timeout",
+        type=float,
+        default=DEFAULT_MAVLINK_HEARTBEAT_TIMEOUT_SECONDS,
+        help="seconds to wait for a fresh flight-controller heartbeat",
+    )
+    parser.add_argument(
+        "--reconnect-backoff",
+        type=float,
+        default=DEFAULT_MAVLINK_RECONNECT_BACKOFF_SECONDS,
+        help="seconds between bounded reconnect attempts",
+    )
     parser.add_argument("--reboot", action=argparse.BooleanOptionalAction)
     parser.add_argument(
         "--time-since-boot",
@@ -1127,26 +1430,28 @@ def get_mavlink_controller_parser():
 
 def mavlink_controller_run(args):
     if args.serial == "" and args.ip == "":
-        args.serial = get_ardupilot_serial()
-        if args.serial is None:
-            sys.exit(1)
+        args.serial = resolve_ardupilot_serial()
 
     logging.info("Connecting to mavlink (drone)...")
     if args.serial != "":
-        connection = mavutil.mavlink_connection(args.serial, baud=115200)
+        endpoint = resolve_ardupilot_serial(args.serial)
     elif args.ip != "":
-        connection = mavutil.mavlink_connection(
-            f"{args.proto}:{args.ip}:{args.port}"
-        )  # tcp is 5670
-        # connection = mavutil.mavlink_connection(f"udpout:{args.ip}:14550")
+        endpoint = f"{args.proto}:{args.ip}:{args.port}"
     else:
-        logging.error("need ip or serial")
-        exit(1)
+        raise MavlinkConnectionError("need ip or serial")
 
-    logging.info("Waiting for heartbeat...")
-    while not args.skip_heartbeat:
-        if connection.wait_heartbeat(blocking=True, timeout=1):
-            break
+    connection_factory = mavlink_connection_factory(endpoint)
+    initial_heartbeat = None
+    if args.skip_heartbeat:
+        connection = connection_factory()
+    else:
+        logging.info("Waiting for heartbeat...")
+        connection, initial_heartbeat = connect_with_heartbeat(
+            connection_factory,
+            attempts=args.connect_attempts,
+            heartbeat_timeout=args.heartbeat_timeout,
+            retry_backoff=args.reconnect_backoff,
+        )
 
     if args.buzzer is not None:
         assert not args.skip_heartbeat
@@ -1156,16 +1461,16 @@ def mavlink_controller_run(args):
             tone_bytes = args.buzzer.replace(" ", "").encode()
         drone = Drone(
             connection=connection,
+            connection_factory=connection_factory,
+            reconnect_attempts=args.connect_attempts,
+            reconnect_backoff=args.reconnect_backoff,
+            reconnect_heartbeat_timeout=args.heartbeat_timeout,
         )
+        drone.process_message(initial_heartbeat)
         drone.buzzer(tone_bytes)
         sys.exit(0)
 
     logging.info("Listening...")
-
-    # get rid of the top?
-    msg = connection.recv_match(blocking=True, timeout=0.5)
-    while msg is None or msg.get_type() == "BAD_DATA":
-        msg = connection.recv_match(blocking=True, timeout=0.5)
 
     boundary = franklin_safe
 
@@ -1175,7 +1480,13 @@ def mavlink_controller_run(args):
 
     drone = Drone(
         connection,
+        connection_factory=connection_factory,
+        reconnect_attempts=args.connect_attempts,
+        reconnect_backoff=args.reconnect_backoff,
+        reconnect_heartbeat_timeout=args.heartbeat_timeout,
     )
+    if initial_heartbeat is not None:
+        drone.process_message(initial_heartbeat)
 
     logging.info("Drone start()")
     drone.start()
@@ -1272,13 +1583,15 @@ def mavlink_controller_run(args):
         sys.exit(0)
 
     if args.mode is not None:
-        return_code=set_drone_mode(drone,args.mode)
+        return_code = set_drone_mode(drone, args.mode)
         sys.exit(return_code)
 
     while True:
-        time.sleep(200)
+        drone.raise_if_connection_failed()
+        time.sleep(1)
 
-def set_drone_mode(drone,mode):
+
+def set_drone_mode(drone, mode):
     target_mode = mode.upper()
     if target_mode not in switchable_modes:
         logging.error("Not a valid switchable mode")

--- a/spf/mavlink_radio_collection.py
+++ b/spf/mavlink_radio_collection.py
@@ -7,7 +7,6 @@ import time
 from datetime import datetime
 
 import yaml
-from pymavlink import mavutil
 
 from spf.data_collector import (
     DroneDataCollectorRaw,
@@ -24,9 +23,14 @@ from spf.distance_finder.distance_finder_controller import DistanceFinderControl
 from spf.gps.boundaries import boundaries  # crissy_boundary_convex
 from spf.gps.boundaries import find_closest_boundary
 from spf.mavlink.mavlink_controller import (
+    DEFAULT_MAVLINK_HEARTBEAT_TIMEOUT_SECONDS,
+    DEFAULT_MAVLINK_RECONNECT_ATTEMPTS,
+    DEFAULT_MAVLINK_RECONNECT_BACKOFF_SECONDS,
     Drone,
+    connect_with_heartbeat,
     drone_get_planner,
-    get_ardupilot_serial,
+    mavlink_connection_factory,
+    resolve_ardupilot_serial,
 )
 from spf.scripts.train_utils import load_config_from_fn
 from spf.utils import (
@@ -231,17 +235,27 @@ if __name__ == "__main__":
     logging.info("MavRadioCollection: Starting data collector...")
     if not args.fake_drone:
         if yaml_config["drone-uri"] == "serial":
-            serial = get_ardupilot_serial()
-            if serial is None:
-                print("Failed to get serial")
-                sys.exit(1)
-            yaml_config["drone-uri"] = serial
-            connection = mavutil.mavlink_connection(serial, baud=115200)
+            endpoint = resolve_ardupilot_serial()
+            yaml_config["drone-uri"] = endpoint
         else:
-            connection = mavutil.mavlink_connection(yaml_config["drone-uri"])
-        drone = Drone(
-            connection, distance_finder=distance_finder, ignore_mode=args.ignore_mode
+            endpoint = yaml_config["drone-uri"]
+        connection_factory = mavlink_connection_factory(endpoint)
+        connection, initial_heartbeat = connect_with_heartbeat(
+            connection_factory,
+            attempts=DEFAULT_MAVLINK_RECONNECT_ATTEMPTS,
+            heartbeat_timeout=DEFAULT_MAVLINK_HEARTBEAT_TIMEOUT_SECONDS,
+            retry_backoff=DEFAULT_MAVLINK_RECONNECT_BACKOFF_SECONDS,
         )
+        drone = Drone(
+            connection,
+            distance_finder=distance_finder,
+            ignore_mode=args.ignore_mode,
+            connection_factory=connection_factory,
+            reconnect_attempts=DEFAULT_MAVLINK_RECONNECT_ATTEMPTS,
+            reconnect_backoff=DEFAULT_MAVLINK_RECONNECT_BACKOFF_SECONDS,
+            reconnect_heartbeat_timeout=DEFAULT_MAVLINK_HEARTBEAT_TIMEOUT_SECONDS,
+        )
+        drone.process_message(initial_heartbeat)
         drone.start()
     else:
         drone = Drone(
@@ -252,6 +266,7 @@ if __name__ == "__main__":
         )
 
     while not args.fake_drone and not drone.drone_ready:
+        drone.raise_if_connection_failed()
         logging.info(
             f"Drone startup wait for drone ready: gps:{str(drone.gps)} , ekf:{str(drone.ekf_healthy)}"
         )
@@ -338,6 +353,8 @@ if __name__ == "__main__":
     data_collector.radios_to_online()  # blocking
 
     def check_exit():
+        if not args.fake_drone:
+            drone.raise_if_connection_failed()
         if args.run_for_seconds > 0 and time.time() - start_time > args.run_for_seconds:
             sys.exit(0)
 

--- a/tests/test_mavlink_recovery.py
+++ b/tests/test_mavlink_recovery.py
@@ -1,0 +1,166 @@
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from spf.mavlink.mavlink_controller import (
+    Drone,
+    MavlinkConnectionError,
+    resolve_ardupilot_serial,
+)
+
+
+class FakeMessage(SimpleNamespace):
+    def get_type(self):
+        return self.message_type
+
+
+def heartbeat():
+    return FakeMessage(
+        message_type="HEARTBEAT",
+        system_status=3,
+        custom_mode=0,
+        base_mode=0,
+    )
+
+
+class FakeMav:
+    def __init__(self):
+        self.arm_commands = []
+
+    def command_long_send(self, *args):
+        self.arm_commands.append(args)
+
+
+class ReconnectConnection:
+    target_system = 1
+    target_component = 1
+
+    def __init__(self, *, receive_error=None, reconnect_heartbeat=None):
+        self.mav = FakeMav()
+        self.receive_error = receive_error
+        self.reconnect_heartbeat = reconnect_heartbeat
+        self.closed = False
+
+    def recv_match(self, *, blocking, timeout):
+        if self.receive_error is not None:
+            error, self.receive_error = self.receive_error, None
+            raise error
+        return None
+
+    def wait_heartbeat(self, *, blocking=True, timeout):
+        return self.reconnect_heartbeat
+
+    def close(self):
+        self.closed = True
+
+
+class ParameterConnection:
+    def __init__(self):
+        self.fetches = 0
+        self.drone = None
+
+    def param_fetch_all(self):
+        self.fetches += 1
+        count = 3
+        values = [("A", 1.0), ("B", 2.0)]
+        if self.fetches == 2:
+            values.append(("C", 3.0))
+        for index, (name, value) in enumerate(values):
+            self.drone.handle_PARAM_VALUE(
+                FakeMessage(
+                    param_id=name,
+                    param_value=value,
+                    param_index=index,
+                    param_count=count,
+                )
+            )
+
+
+def wait_until(predicate, timeout=1.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return False
+
+
+def test_transient_serial_read_failure_reopens_and_requires_new_heartbeat():
+    disconnected = ReconnectConnection(receive_error=OSError("USB disappeared"))
+    reconnected = ReconnectConnection(reconnect_heartbeat=heartbeat())
+    factory_calls = []
+
+    def factory():
+        factory_calls.append(True)
+        return reconnected
+
+    drone = Drone(
+        disconnected,
+        fake=True,
+        connection_factory=factory,
+        reconnect_attempts=1,
+        reconnect_backoff=0,
+        reconnect_heartbeat_timeout=0.01,
+    ).start()
+
+    assert wait_until(lambda: drone.connection is reconnected)
+    assert factory_calls == [True]
+    assert disconnected.closed
+    assert drone.connection_healthy
+    assert drone.last_heartbeat > 0
+
+
+def test_failed_reconnect_fails_closed_for_arming():
+    disconnected = ReconnectConnection(receive_error=OSError("USB disappeared"))
+
+    def factory():
+        raise OSError("still absent")
+
+    drone = Drone(
+        disconnected,
+        fake=True,
+        connection_factory=factory,
+        reconnect_attempts=1,
+        reconnect_backoff=0,
+        reconnect_heartbeat_timeout=0.01,
+    ).start()
+
+    assert wait_until(lambda: drone.connection_failure is not None)
+    with pytest.raises(MavlinkConnectionError, match="not healthy"):
+        drone.arm()
+    assert disconnected.mav.arm_commands == []
+
+
+def test_incomplete_parameter_fetch_is_restarted_from_scratch():
+    connection = ParameterConnection()
+    drone = Drone(connection, fake=True)
+    connection.drone = drone
+
+    assert drone.update_all_parameters(
+        timeout=0.01,
+        max_attempts=2,
+        retry_backoff=0,
+    )
+    assert connection.fetches == 2
+    assert set(drone.params) == {"A", "B", "C"}
+
+
+def test_tty_name_is_promoted_to_matching_stable_by_id(monkeypatch):
+    stable = "/dev/serial/by-id/usb-ArduPilot_Pixhawk1"
+    realpaths = {
+        "/dev/ttyACM1": "/dev/ttyACM1",
+        stable: "/dev/ttyACM1",
+    }
+    monkeypatch.setattr(
+        "spf.mavlink.mavlink_controller.os.path.realpath",
+        lambda path: realpaths[path],
+    )
+
+    assert (
+        resolve_ardupilot_serial(
+            "/dev/ttyACM1",
+            available_pilots=[stable],
+        )
+        == stable
+    )

--- a/tests/test_mavlink_recovery.py
+++ b/tests/test_mavlink_recovery.py
@@ -6,6 +6,7 @@ import pytest
 from spf.mavlink.mavlink_controller import (
     Drone,
     MavlinkConnectionError,
+    connect_with_heartbeat,
     resolve_ardupilot_serial,
 )
 
@@ -58,9 +59,11 @@ class ReconnectConnection:
 class ParameterConnection:
     def __init__(self):
         self.fetches = 0
+        self.starting_sizes = []
         self.drone = None
 
     def param_fetch_all(self):
+        self.starting_sizes.append(len(self.drone.params))
         self.fetches += 1
         count = 3
         values = [("A", 1.0), ("B", 2.0)]
@@ -143,7 +146,34 @@ def test_incomplete_parameter_fetch_is_restarted_from_scratch():
         retry_backoff=0,
     )
     assert connection.fetches == 2
+    assert connection.starting_sizes == [0, 0]
     assert set(drone.params) == {"A", "B", "C"}
+
+
+def test_initial_connection_retries_are_bounded_and_require_heartbeat():
+    connections = [
+        ReconnectConnection(reconnect_heartbeat=None),
+        ReconnectConnection(reconnect_heartbeat=None),
+        ReconnectConnection(reconnect_heartbeat=heartbeat()),
+    ]
+    calls = []
+
+    def factory():
+        calls.append(True)
+        return connections[len(calls) - 1]
+
+    with pytest.raises(MavlinkConnectionError, match="after 2 attempts"):
+        connect_with_heartbeat(
+            factory,
+            attempts=2,
+            heartbeat_timeout=0.01,
+            retry_backoff=0,
+        )
+
+    assert len(calls) == 2
+    assert connections[0].closed
+    assert connections[1].closed
+    assert not connections[2].closed
 
 
 def test_tty_name_is_promoted_to_matching_stable_by_id(monkeypatch):

--- a/tests/test_mavlink_recovery.py
+++ b/tests/test_mavlink_recovery.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from types import SimpleNamespace
 
@@ -16,29 +17,42 @@ class FakeMessage(SimpleNamespace):
         return self.message_type
 
 
-def heartbeat():
+def heartbeat(custom_mode=0):
     return FakeMessage(
         message_type="HEARTBEAT",
         system_status=3,
-        custom_mode=0,
+        custom_mode=custom_mode,
         base_mode=0,
     )
 
 
 class FakeMav:
-    def __init__(self):
+    def __init__(self, *, tune_error=None):
         self.arm_commands = []
+        self.tune_commands = []
+        self.tune_error = tune_error
 
     def command_long_send(self, *args):
         self.arm_commands.append(args)
+
+    def play_tune_send(self, *args):
+        if self.tune_error is not None:
+            raise self.tune_error
+        self.tune_commands.append(args)
 
 
 class ReconnectConnection:
     target_system = 1
     target_component = 1
 
-    def __init__(self, *, receive_error=None, reconnect_heartbeat=None):
-        self.mav = FakeMav()
+    def __init__(
+        self,
+        *,
+        receive_error=None,
+        reconnect_heartbeat=None,
+        tune_error=None,
+    ):
+        self.mav = FakeMav(tune_error=tune_error)
         self.receive_error = receive_error
         self.reconnect_heartbeat = reconnect_heartbeat
         self.closed = False
@@ -141,6 +155,104 @@ def test_failed_reconnect_fails_closed_for_arming():
     with pytest.raises(MavlinkConnectionError, match="not healthy"):
         drone.arm()
     assert disconnected.mav.arm_commands == []
+
+
+def test_unhealthy_buzzer_refuses_to_use_stale_connection():
+    disconnected = ReconnectConnection()
+    drone = Drone(
+        disconnected,
+        fake=True,
+        connection_factory=lambda: ReconnectConnection(),
+    )
+
+    assert not drone.buzzer(b"tone")
+    assert disconnected.mav.tune_commands == []
+
+
+def test_buzzer_send_error_does_not_kill_caller_or_trigger_reconnect():
+    disconnected = ReconnectConnection(tune_error=OSError("USB disappeared"))
+    factory_calls = []
+
+    def factory():
+        factory_calls.append(True)
+        return ReconnectConnection(reconnect_heartbeat=heartbeat())
+
+    drone = Drone(
+        disconnected,
+        fake=True,
+        connection_factory=factory,
+    )
+    drone.process_message(heartbeat())
+
+    assert not drone.buzzer(b"tone")
+    assert drone.connection is disconnected
+    assert drone.connection_failure is None
+    assert factory_calls == []
+
+
+def test_mode_wait_survives_reconnect_and_buzzes_replacement_connection():
+    disconnected = ReconnectConnection()
+    replacement = ReconnectConnection(reconnect_heartbeat=heartbeat(custom_mode=0))
+    factory_entered = threading.Event()
+    release_factory = threading.Event()
+
+    def factory():
+        factory_entered.set()
+        assert release_factory.wait(timeout=1)
+        return replacement
+
+    drone = Drone(
+        disconnected,
+        fake=True,
+        connection_factory=factory,
+        reconnect_attempts=1,
+        reconnect_backoff=0,
+        reconnect_heartbeat_timeout=0.1,
+    )
+    drone.process_message(heartbeat(custom_mode=15))
+
+    recovery_result = []
+    recovery_thread = threading.Thread(
+        target=lambda: recovery_result.append(
+            drone._recover_connection(OSError("USB disappeared"))
+        )
+    )
+    recovery_thread.start()
+    assert factory_entered.wait(timeout=1)
+
+    planner_errors = []
+
+    def wait_for_manual_mode():
+        try:
+            drone._wait_for_mode(
+                "ROVER_MODE_MANUAL",
+                b"tone",
+                "waiting for manual mode",
+                poll_interval=0.001,
+            )
+        except Exception as error:
+            planner_errors.append(error)
+
+    planner_thread = threading.Thread(target=wait_for_manual_mode)
+    planner_thread.start()
+    time.sleep(0.02)
+
+    # The mode-wait buzzer must not touch the closed connection while the
+    # reconnect owns the connection swap.
+    assert disconnected.closed
+    assert disconnected.mav.tune_commands == []
+
+    release_factory.set()
+    recovery_thread.join(timeout=1)
+    planner_thread.join(timeout=1)
+
+    assert not recovery_thread.is_alive()
+    assert not planner_thread.is_alive()
+    assert recovery_result == [True]
+    assert planner_errors == []
+    assert replacement.mav.tune_commands
+    assert drone.connection is replacement
+    assert drone.connection_healthy
 
 
 def test_incomplete_parameter_fetch_is_restarted_from_scratch():

--- a/tests/test_mavlink_recovery.py
+++ b/tests/test_mavlink_recovery.py
@@ -220,7 +220,20 @@ def test_mode_wait_survives_reconnect_and_buzzes_replacement_connection():
     recovery_thread.start()
     assert factory_entered.wait(timeout=1)
 
+    with pytest.raises(MavlinkConnectionError, match="not healthy"):
+        drone.arm()
+    assert disconnected.mav.arm_commands == []
+    assert replacement.mav.arm_commands == []
+
     planner_errors = []
+    buzzer_started = threading.Event()
+    buzzer = drone.buzzer
+
+    def observed_buzzer(tone):
+        buzzer_started.set()
+        return buzzer(tone)
+
+    drone.buzzer = observed_buzzer
 
     def wait_for_manual_mode():
         try:
@@ -235,7 +248,7 @@ def test_mode_wait_survives_reconnect_and_buzzes_replacement_connection():
 
     planner_thread = threading.Thread(target=wait_for_manual_mode)
     planner_thread.start()
-    time.sleep(0.02)
+    assert buzzer_started.wait(timeout=1)
 
     # The mode-wait buzzer must not touch the closed connection while the
     # reconnect owns the connection swap.

--- a/tests/test_mavlink_recovery.py
+++ b/tests/test_mavlink_recovery.py
@@ -105,13 +105,21 @@ def test_transient_serial_read_failure_reopens_and_requires_new_heartbeat():
         reconnect_attempts=1,
         reconnect_backoff=0,
         reconnect_heartbeat_timeout=0.01,
-    ).start()
+    )
+    drone.gps[:] = [1.0, 2.0]
+    drone.ekf_healthy = True
+    drone.sensors_health = ["MAV_SYS_STATUS_SENSOR_GPS"]
+    drone.drone_ready = True
+    drone.start()
 
     assert wait_until(lambda: drone.connection is reconnected)
     assert factory_calls == [True]
     assert disconnected.closed
     assert drone.connection_healthy
     assert drone.last_heartbeat > 0
+    assert not drone.drone_ready
+    assert not drone.ekf_healthy
+    assert drone.sensors_health == []
 
 
 def test_failed_reconnect_fails_closed_for_arming():


### PR DESCRIPTION
## Summary

- reopen the flight-controller link after transient USB/serial receive failures
- resolve an explicit `ttyACM` endpoint back to its stable `/dev/serial/by-id/usb-ArduPilot*` identity when possible
- claim local serial links with `TIOCEXCL` and emit an actionable multiple-owner diagnostic
- require a fresh heartbeat before a newly opened link becomes command-capable
- discard incomplete parameter downloads and retry the complete set from zero
- surface exhausted reconnects to the collector instead of leaving a dead message thread behind
- fail closed for arm, reposition, set-home, RTL, and mode commands while the link is unhealthy
- serialize runtime command access against reconnect swaps so commands never use a stale handle
- keep planner mode-wait buzzer failures advisory while bounded receive-loop recovery proceeds

## Root cause

The rover already auto-discovered an ArduPilot by-id symlink, but `Drone` retained a single opened pymavlink connection forever. A `SerialException` from `recv_match()` escaped the daemon message thread, so state remained stale while no reader existed. Parameter verification separately called `sys.exit(1)` after one stalled partial stream (the observed 728/885 case). Explicit tty arguments also bypassed stable identity, and SPF did not request kernel-exclusive serial ownership, so re-enumeration and competing clients were poorly diagnosed. A follow-up audit found that runtime methods still dereferenced the mutable connection directly; most importantly, a mode-wait buzzer write could race the swap, use the closed handle, and terminate the planner thread even when receive-loop recovery succeeded.

## Retry and safety bounds

- initial open/reconnect: 3 attempts by default
- each attempt: fresh heartbeat required within 10 seconds
- delay between attempts: 1 second
- parameter sync: 3 complete fetch attempts
- parameter attempt timeout: 50 seconds without progress (existing timeout semantics)
- each partial parameter set is discarded before retry
- once retries are exhausted, the daemon/collector receives `MavlinkConnectionError` and exits fail-closed; it does not arm or continue issuing movement commands

The connection limits are exposed on `mavlink_controller.py` as `--connect-attempts`, `--heartbeat-timeout`, and `--reconnect-backoff`.

## Red / green evidence

Red commit: `403b038`

```text
pytest -q tests/test_mavlink_recovery.py
ERROR: ImportError: cannot import name 'MavlinkConnectionError'
```

The tests specify transient serial recovery, fresh-heartbeat gating, exhausted-retry arm refusal, full parameter restart after a partial download, bounded initial connection attempts, and tty-to-by-id promotion.

Green commits: `1ab9e27`, `f919329`

Reconnect command-serialization red commit: `3520b99`

The follow-up tests cover an unhealthy buzzer refusing the stale handle, a buzzer send exception remaining advisory without launching a competing recovery, fail-closed arm during an in-progress reconnect, and planner mode waiting resuming on the replacement only after its fresh heartbeat.

Reconnect command-serialization green commit: `df5c708`

```text
pytest -q tests/test_mavlink_recovery.py tests/test_mavlink_prearm_check.py
8 passed, 1 warning
```

Additional checks:

```text
black --check spf/mavlink/mavlink_controller.py spf/mavlink_radio_collection.py tests/test_mavlink_recovery.py
3 files would be left unchanged

python -m py_compile spf/mavlink/mavlink_controller.py spf/mavlink_radio_collection.py
git diff --check
```

For the `df5c708` follow-up, lightweight local validation was limited to `py_compile` and `git diff --check`; the new focused mocked tests and broader suite are delegated to GitHub CI.

## Remaining hardware validation

1. On a disarmed rover, start the production service through the stable by-id path and confirm the exclusive-open diagnostic by attempting a second SPF/MAVProxy serial owner.
2. Momentarily unplug/replug the flight-controller USB cable; confirm the same by-id identity returns, a fresh heartbeat is logged, and no arm/movement command is emitted during the gap.
3. Reboot the flight controller during parameter download; confirm the first partial set is discarded and a later complete `N/N` set passes.
4. Keep the controller absent beyond all three attempts; confirm the collector exits nonzero and systemd reports the bounded failure rather than a live service with a dead message thread.

## Retry and terminal-state behavior

**Bounded automatic recovery, then fail closed.** A successful reconnect
requires a fresh heartbeat and resumes normal processing. After all attempts
are exhausted, stale vehicle state remains cleared and the collector exits
nonzero. There is no background retry afterward; because the production unit
has no `Restart=on-failure`, an operator, launcher, or reboot must start it
again after the controller returns.