### PR TITLE
Recover direct USB after Pluto re-enumeration

### DIFF
--- a/spf/sdrpluto/direct_usb_receiver.py
+++ b/spf/sdrpluto/direct_usb_receiver.py
@@ -161,6 +161,7 @@ class PlutoDirectUsbReceiver:
         self._identity: DirectUsbIdentity | None = None
         self._capabilities: GadgetCapabilitiesV1 | None = None
         self._recovery_hardware_identity: HardwareIdentityV1 | None = None
+        self._terminal_recovery_error: Exception | None = None
         self._detached_kernel_driver = False
 
     @property
@@ -297,6 +298,11 @@ class PlutoDirectUsbReceiver:
         samples_per_channel: int,
         frame_count: int = 1,
     ) -> DirectUsbCapture:
+        if self._terminal_recovery_error is not None:
+            raise DirectUsbRecoveryError(
+                "direct USB receiver is terminal after failed recovery; "
+                "create a new receiver/capture"
+            ) from self._terminal_recovery_error
         try:
             return self._capture_once(
                 samples_per_channel=samples_per_channel,
@@ -311,28 +317,40 @@ class PlutoDirectUsbReceiver:
                 self.requested_port_path,
                 error,
             )
-            self._recover_connection(error)
-            self._attest_recovered_connection(failed_identity)
+            try:
+                self._recover_connection(error)
+            except DirectUsbRecoveryError as recovery_error:
+                self._mark_terminal_recovery_failure(recovery_error)
+                raise
+            try:
+                self._attest_recovered_connection(failed_identity)
+            except DirectUsbRecoveryAttestationError as attestation_error:
+                self._mark_terminal_recovery_failure(attestation_error)
+                raise
             try:
                 capture = self._capture_once(
                     samples_per_channel=samples_per_channel,
                     frame_count=frame_count,
                 )
             except (usb1.USBError, DirectUsbTransportError) as retry_error:
-                raise DirectUsbRecoveryError(
+                recovery_error = DirectUsbRecoveryError(
                     "direct USB transport failed again after rediscovery for "
                     f"serial={self.requested_serial!r} "
                     f"port_path={self.requested_port_path!r}"
-                ) from retry_error
+                )
+                self._mark_terminal_recovery_failure(recovery_error)
+                raise recovery_error from retry_error
 
             metadata = capture.frames[0].metadata
             if metadata.buffer_sequence != 0 or (
                 metadata.flags & MetadataFlags.SAMPLE_SEQUENCE_VALID
                 and metadata.first_sample_sequence != 0
             ):
-                raise ProtocolError(
+                sequence_error = ProtocolError(
                     "recovered direct USB START did not begin a new stream epoch"
                 )
+                self._mark_terminal_recovery_failure(sequence_error)
+                raise sequence_error
             logging.warning(
                 "direct USB transport recovered for serial=%s port_path=%s "
                 "address=%s->%s stream_id=%s; new stream epoch, phase "
@@ -344,6 +362,11 @@ class PlutoDirectUsbReceiver:
                 metadata.stream_id,
             )
             return capture
+
+    def _mark_terminal_recovery_failure(self, error: Exception) -> None:
+        self._terminal_recovery_error = error
+        with contextlib.suppress(usb1.USBError, AttributeError):
+            self.close()
 
     def _capture_once(
         self,

--- a/spf/sdrpluto/direct_usb_receiver.py
+++ b/spf/sdrpluto/direct_usb_receiver.py
@@ -7,7 +7,8 @@ import dataclasses
 import gc
 import logging
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterable, Iterator
+from typing import Any
 
 import numpy as np
 import usb1
@@ -28,6 +29,7 @@ from spf.sdrpluto.direct_usb_protocol import (
     DirectUsbRxFrame,
     GadgetCapabilitiesV1,
     HardwareIdentityV1,
+    HardwareIdentityFlags,
     MetadataFeatures,
     MetadataFlags,
     ProtocolError,
@@ -58,6 +60,30 @@ class DirectUsbTransportError(RuntimeError):
 
 class DirectUsbRecoveryError(RuntimeError):
     """Bounded recovery could not restore one valid finite RX request."""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class RecoveryAttestationDifference:
+    """One fail-closed mismatch observed before a recovered stream START."""
+
+    field: str
+    expected: Any
+    observed: Any
+
+
+class DirectUsbRecoveryAttestationError(DirectUsbRecoveryError):
+    """The re-enumerated device cannot be proven equivalent to the original."""
+
+    def __init__(self, differences: Iterable[RecoveryAttestationDifference]):
+        self.differences = tuple(differences)
+        if not self.differences:
+            raise ValueError("at least one recovery attestation difference is required")
+        details = "; ".join(
+            f"{difference.field}: expected={difference.expected!r}, "
+            f"observed={difference.observed!r}"
+            for difference in self.differences
+        )
+        super().__init__(f"direct USB recovery attestation failed: {details}")
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -111,6 +137,7 @@ class PlutoDirectUsbReceiver:
         protocol_version: int = VERSION_V1,
         reconnect_attempts: int = DEFAULT_RECONNECT_ATTEMPTS,
         reconnect_delay_seconds: float = DEFAULT_RECONNECT_DELAY_SECONDS,
+        reconnect_attestor: Callable[[], None] | None = None,
     ) -> None:
         if not serial and not port_path:
             raise ValueError("serial or physical USB port_path is required")
@@ -128,10 +155,12 @@ class PlutoDirectUsbReceiver:
         self.protocol_version = protocol_version
         self.reconnect_attempts = reconnect_attempts
         self.reconnect_delay_seconds = reconnect_delay_seconds
+        self.reconnect_attestor = reconnect_attestor
         self._context: usb1.USBContext | None = None
         self._handle: usb1.USBDeviceHandle | None = None
         self._identity: DirectUsbIdentity | None = None
         self._capabilities: GadgetCapabilitiesV1 | None = None
+        self._recovery_hardware_identity: HardwareIdentityV1 | None = None
         self._detached_kernel_driver = False
 
     @property
@@ -283,6 +312,7 @@ class PlutoDirectUsbReceiver:
                 error,
             )
             self._recover_connection(error)
+            self._attest_recovered_connection(failed_identity)
             try:
                 capture = self._capture_once(
                     samples_per_channel=samples_per_channel,
@@ -305,7 +335,8 @@ class PlutoDirectUsbReceiver:
                 )
             logging.warning(
                 "direct USB transport recovered for serial=%s port_path=%s "
-                "address=%s->%s stream_id=%s",
+                "address=%s->%s stream_id=%s; new stream epoch, phase "
+                "continuity is not retained",
                 capture.identity.serial,
                 capture.identity.port_path,
                 None if failed_identity is None else failed_identity.address,
@@ -442,6 +473,123 @@ class PlutoDirectUsbReceiver:
             f"serial={self.requested_serial!r} "
             f"port_path={self.requested_port_path!r}"
         ) from last_error
+
+    def pin_recovery_hardware_identity(self) -> HardwareIdentityV1 | None:
+        """Pin valid passive identity fields for subsequent reconnects.
+
+        Older gadgets do not expose this capability. In that case USB serial
+        and physical port remain the durable identity boundary.
+        """
+
+        if not (self.capabilities.capability_flags & CapabilityFlags.HARDWARE_IDENTITY):
+            self._recovery_hardware_identity = None
+            return None
+        identity = self.query_hardware_identity()
+        self._recovery_hardware_identity = identity
+        return identity
+
+    def _attest_recovered_connection(
+        self, failed_identity: DirectUsbIdentity | None
+    ) -> None:
+        differences: list[RecoveryAttestationDifference] = []
+        recovered_identity = self.identity
+        if failed_identity is None:
+            differences.append(
+                RecoveryAttestationDifference(
+                    field="usb_identity",
+                    expected="identity pinned before transport loss",
+                    observed=None,
+                )
+            )
+        else:
+            if recovered_identity.serial != failed_identity.serial:
+                differences.append(
+                    RecoveryAttestationDifference(
+                        field="usb_serial",
+                        expected=failed_identity.serial,
+                        observed=recovered_identity.serial,
+                    )
+                )
+            if recovered_identity.port_path != failed_identity.port_path:
+                differences.append(
+                    RecoveryAttestationDifference(
+                        field="usb_port_path",
+                        expected=failed_identity.port_path,
+                        observed=recovered_identity.port_path,
+                    )
+                )
+
+        expected_hardware = self._recovery_hardware_identity
+        if expected_hardware is not None:
+            try:
+                observed_hardware = self.query_hardware_identity()
+            except Exception as error:
+                differences.append(
+                    RecoveryAttestationDifference(
+                        field="hardware_identity",
+                        expected="readable passive identity",
+                        observed=f"{type(error).__name__}: {error}",
+                    )
+                )
+            else:
+                fields = (
+                    (
+                        HardwareIdentityFlags.FPGA_DEVICE_DNA_VALID,
+                        "fpga_device_dna",
+                    ),
+                    (
+                        HardwareIdentityFlags.GADGET_BUILD_ID_VALID,
+                        "gadget_build_id",
+                    ),
+                )
+                for flag, field in fields:
+                    if not expected_hardware.flags & flag:
+                        continue
+                    expected = getattr(expected_hardware, field)
+                    observed = (
+                        getattr(observed_hardware, field)
+                        if observed_hardware.flags & flag
+                        else None
+                    )
+                    if observed != expected:
+                        differences.append(
+                            RecoveryAttestationDifference(
+                                field=field,
+                                expected=expected,
+                                observed=observed,
+                            )
+                        )
+
+        if differences:
+            raise DirectUsbRecoveryAttestationError(iter(differences))
+        if self.reconnect_attestor is None:
+            raise DirectUsbRecoveryAttestationError(
+                iter(
+                    (
+                        RecoveryAttestationDifference(
+                            field="iio_rx_configuration",
+                            expected="configured reconnect attestor",
+                            observed=None,
+                        ),
+                    )
+                )
+            )
+        try:
+            self.reconnect_attestor()
+        except DirectUsbRecoveryAttestationError:
+            raise
+        except Exception as error:
+            raise DirectUsbRecoveryAttestationError(
+                iter(
+                    (
+                        RecoveryAttestationDifference(
+                            field="iio_rx_configuration",
+                            expected="readable matching configuration",
+                            observed=f"{type(error).__name__}: {error}",
+                        ),
+                    )
+                )
+            ) from error
 
     def query_hardware_identity(self) -> HardwareIdentityV1:
         """Read passive identity data without starting RX or TX."""

--- a/spf/sdrpluto/direct_usb_receiver.py
+++ b/spf/sdrpluto/direct_usb_receiver.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import dataclasses
 import gc
+import logging
 import time
 from collections.abc import Iterator
 
@@ -28,6 +29,7 @@ from spf.sdrpluto.direct_usb_protocol import (
     GadgetCapabilitiesV1,
     HardwareIdentityV1,
     MetadataFeatures,
+    MetadataFlags,
     ProtocolError,
     RxFrameParser,
     pack_start_request_v1,
@@ -42,6 +44,20 @@ USB_TRANSFER_TYPE_MASK = 0x03
 USB_CONTROL_TIMEOUT_MS = 1_000
 USB_BULK_TIMEOUT_MS = 10_000
 DEFAULT_BULK_CHUNK_BYTES = 1024 * 1024
+DEFAULT_RECONNECT_ATTEMPTS = 20
+DEFAULT_RECONNECT_DELAY_SECONDS = 0.25
+
+
+class DirectUsbNotFoundError(RuntimeError):
+    """The selected direct-USB gadget is not currently enumerated."""
+
+
+class DirectUsbTransportError(RuntimeError):
+    """A claimed direct-USB connection failed below the framing layer."""
+
+
+class DirectUsbRecoveryError(RuntimeError):
+    """Bounded recovery could not restore one valid finite RX request."""
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -93,6 +109,8 @@ class PlutoDirectUsbReceiver:
         port_path: tuple[int, ...] | None = None,
         bulk_chunk_bytes: int = DEFAULT_BULK_CHUNK_BYTES,
         protocol_version: int = VERSION_V1,
+        reconnect_attempts: int = DEFAULT_RECONNECT_ATTEMPTS,
+        reconnect_delay_seconds: float = DEFAULT_RECONNECT_DELAY_SECONDS,
     ) -> None:
         if not serial and not port_path:
             raise ValueError("serial or physical USB port_path is required")
@@ -100,10 +118,16 @@ class PlutoDirectUsbReceiver:
             raise ValueError("bulk_chunk_bytes must be positive")
         if protocol_version not in (VERSION_V1, VERSION_V2):
             raise ValueError(f"unsupported direct USB protocol {protocol_version}")
+        if reconnect_attempts <= 0:
+            raise ValueError("reconnect_attempts must be positive")
+        if reconnect_delay_seconds < 0:
+            raise ValueError("reconnect_delay_seconds must be non-negative")
         self.requested_serial = serial
         self.requested_port_path = port_path
         self.bulk_chunk_bytes = bulk_chunk_bytes
         self.protocol_version = protocol_version
+        self.reconnect_attempts = reconnect_attempts
+        self.reconnect_delay_seconds = reconnect_delay_seconds
         self._context: usb1.USBContext | None = None
         self._handle: usb1.USBDeviceHandle | None = None
         self._identity: DirectUsbIdentity | None = None
@@ -201,12 +225,21 @@ class PlutoDirectUsbReceiver:
                         bulk_in_endpoint=bulk_in,
                         bulk_out_endpoint=bulk_out,
                     )
+                    # Bus/address are transient. Pin both durable identities after
+                    # the first successful open so a reconnect cannot claim a
+                    # different Pluto that happens to enumerate first.
+                    self.requested_serial = candidate_serial
+                    self.requested_port_path = candidate_port_path
                     return
         except Exception:
             context.close()
             raise
         context.close()
-        raise RuntimeError("matching SPF direct-USB gadget was not found")
+        raise DirectUsbNotFoundError(
+            "matching SPF direct-USB gadget was not found for "
+            f"serial={self.requested_serial!r} "
+            f"port_path={self.requested_port_path!r}"
+        )
 
     def close(self) -> None:
         handle = self._handle
@@ -234,6 +267,58 @@ class PlutoDirectUsbReceiver:
         *,
         samples_per_channel: int,
         frame_count: int = 1,
+    ) -> DirectUsbCapture:
+        try:
+            return self._capture_once(
+                samples_per_channel=samples_per_channel,
+                frame_count=frame_count,
+            )
+        except (usb1.USBError, DirectUsbTransportError) as error:
+            failed_identity = self._identity
+            logging.warning(
+                "direct USB transport lost for serial=%s port_path=%s: %s; "
+                "starting bounded rediscovery",
+                self.requested_serial,
+                self.requested_port_path,
+                error,
+            )
+            self._recover_connection(error)
+            try:
+                capture = self._capture_once(
+                    samples_per_channel=samples_per_channel,
+                    frame_count=frame_count,
+                )
+            except (usb1.USBError, DirectUsbTransportError) as retry_error:
+                raise DirectUsbRecoveryError(
+                    "direct USB transport failed again after rediscovery for "
+                    f"serial={self.requested_serial!r} "
+                    f"port_path={self.requested_port_path!r}"
+                ) from retry_error
+
+            metadata = capture.frames[0].metadata
+            if metadata.buffer_sequence != 0 or (
+                metadata.flags & MetadataFlags.SAMPLE_SEQUENCE_VALID
+                and metadata.first_sample_sequence != 0
+            ):
+                raise ProtocolError(
+                    "recovered direct USB START did not begin a new stream epoch"
+                )
+            logging.warning(
+                "direct USB transport recovered for serial=%s port_path=%s "
+                "address=%s->%s stream_id=%s",
+                capture.identity.serial,
+                capture.identity.port_path,
+                None if failed_identity is None else failed_identity.address,
+                capture.identity.address,
+                metadata.stream_id,
+            )
+            return capture
+
+    def _capture_once(
+        self,
+        *,
+        samples_per_channel: int,
+        frame_count: int,
     ) -> DirectUsbCapture:
         handle = self._require_handle()
         identity = self.identity
@@ -327,6 +412,37 @@ class PlutoDirectUsbReceiver:
             elapsed_seconds=time.monotonic() - start,
         )
 
+    def _recover_connection(self, original_error: Exception) -> None:
+        with contextlib.suppress(usb1.USBError, AttributeError):
+            self.close()
+
+        last_error: Exception = original_error
+        for attempt in range(1, self.reconnect_attempts + 1):
+            if self.reconnect_delay_seconds:
+                time.sleep(self.reconnect_delay_seconds)
+            try:
+                self.open()
+            except (DirectUsbNotFoundError, usb1.USBError) as error:
+                last_error = error
+                logging.warning(
+                    "direct USB rediscovery %s/%s failed for serial=%s "
+                    "port_path=%s: %s",
+                    attempt,
+                    self.reconnect_attempts,
+                    self.requested_serial,
+                    self.requested_port_path,
+                    error,
+                )
+                continue
+            return
+
+        raise DirectUsbRecoveryError(
+            "direct USB gadget did not reappear after "
+            f"{self.reconnect_attempts} bounded attempts for "
+            f"serial={self.requested_serial!r} "
+            f"port_path={self.requested_port_path!r}"
+        ) from last_error
+
     def query_hardware_identity(self) -> HardwareIdentityV1:
         """Read passive identity data without starting RX or TX."""
 
@@ -393,7 +509,8 @@ class PlutoDirectUsbReceiver:
 
         chunks: list[bytes | None] = [None] * frame_count
         pending: set[int] = set()
-        errors: list[str] = []
+        protocol_errors: list[str] = []
+        transport_errors: list[str] = []
         transfers = []
 
         def completed(transfer) -> None:
@@ -402,14 +519,14 @@ class PlutoDirectUsbReceiver:
             if status == usb1.TRANSFER_COMPLETED:
                 actual = transfer.getActualLength()
                 if actual != frame_bytes:
-                    errors.append(
+                    protocol_errors.append(
                         f"bulk transfer {index} completed with {actual} bytes, "
                         f"expected {frame_bytes}"
                     )
                 else:
                     chunks[index] = bytes(transfer.getBuffer()[:actual])
             else:
-                errors.append(
+                transport_errors.append(
                     f"bulk transfer {index} failed with libusb status {status}"
                 )
             pending.discard(index)
@@ -442,10 +559,10 @@ class PlutoDirectUsbReceiver:
                 timeout=USB_CONTROL_TIMEOUT_MS,
             )
             deadline = time.monotonic() + USB_BULK_TIMEOUT_MS / 1000.0 + 1.0
-            while pending and not errors:
+            while pending and not protocol_errors and not transport_errors:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
-                    errors.append(
+                    protocol_errors.append(
                         f"timed out with {len(pending)} queued transfers pending"
                     )
                     break
@@ -474,8 +591,10 @@ class PlutoDirectUsbReceiver:
             # frame buffers are reclaimed deterministically.
             gc.collect(0)
 
-        if errors:
-            raise ProtocolError("; ".join(errors))
+        if transport_errors:
+            raise DirectUsbTransportError("; ".join(transport_errors))
+        if protocol_errors:
+            raise ProtocolError("; ".join(protocol_errors))
         if pending or any(chunk is None for chunk in chunks):
             raise ProtocolError("queued direct USB transfer cleanup was incomplete")
         return [chunk for chunk in chunks if chunk is not None]

--- a/spf/sdrpluto/sdr_controller.py
+++ b/spf/sdrpluto/sdr_controller.py
@@ -246,6 +246,10 @@ class ReceiverConfig(Config):
         self.motor_channel = motor_channel
         self.rx_buffers = rx_buffers
         self.filter_fir_en = filter_fir_en
+        # These two mitigations are part of SPF's observable RX contract even
+        # though field configs do not expose them as user-selectable knobs.
+        self.phase_inversion_debug_attr = 1
+        self.phase_inversion_register_bit = 1
         if rx_transport not in ("iio", "direct_usb"):
             raise ValueError(f"unsupported RX transport: {rx_transport}")
         self.rx_transport = rx_transport
@@ -1074,18 +1078,24 @@ class PPlus:
         self.sdr.rx_destroy_buffer()
 
         # Fix the phase inversion on channel RX1
-        self.sdr._ctrl.debug_attrs["adi,rx1-rx2-phase-inversion-enable"].value = "1"
-        assert (
-            self.sdr._ctrl.debug_attrs["adi,rx1-rx2-phase-inversion-enable"].value
-            == "1"
+        self.sdr._ctrl.debug_attrs["adi,rx1-rx2-phase-inversion-enable"].value = str(
+            self.rx_config.phase_inversion_debug_attr
         )
+        assert self.sdr._ctrl.debug_attrs[
+            "adi,rx1-rx2-phase-inversion-enable"
+        ].value == str(self.rx_config.phase_inversion_debug_attr)
 
         # https://www.analog.com/media/cn/technical-documentation/user-guides/ad9364_register_map_reference_manual_ug-672.pdf
         reg22_value = self.sdr._ctrl.reg_read(0x22)
         # https://github.com/analogdevicesinc/linux/blob/88946d52e61d5b898c061d820caf27fd1c3730d7/drivers/iio/adc/ad9361_regs.h#L780
-        self.sdr._ctrl.reg_write(0x22, reg22_value | (1 << 6))
+        self.sdr._ctrl.reg_write(
+            0x22,
+            reg22_value | (self.rx_config.phase_inversion_register_bit << 6),
+        )
         reg22_value = self.sdr._ctrl.reg_read(0x22)
-        assert (reg22_value & (1 << 6)) != 0
+        assert bool(reg22_value & (1 << 6)) == bool(
+            self.rx_config.phase_inversion_register_bit
+        )
 
         # self.sdr._ctrl.reg_write(0x22, reg22_value & (~(1 << 6)))
         # reg22_value = self.sdr._ctrl.reg_read(0x22)
@@ -1284,6 +1294,7 @@ class PPlus:
             serial=serial,
             port_path=port_path,
             protocol_version=self.rx_config.direct_usb_protocol_version,
+            reconnect_attestor=self._attest_direct_usb_reconnect,
         )
         self.direct_rx.open()
         if iio_serial is not None and self.direct_rx.identity.serial != iio_serial:
@@ -1294,12 +1305,132 @@ class PPlus:
                 "opened direct USB radio does not match the USB-IIO radio: "
                 f"{direct_serial} != {iio_serial}"
             )
+        try:
+            self.direct_rx.pin_recovery_hardware_identity()
+        except Exception:
+            self.direct_rx.close()
+            self.direct_rx = None
+            raise
         logging.info(
             "%s: direct USB RX open as serial=%s port_path=%s",
             self.uri,
             self.direct_rx.identity.serial,
             self.direct_rx.identity.port_path,
         )
+
+    def _attest_direct_usb_reconnect(self):
+        """Verify a re-enumerated radio without writing any radio setting."""
+
+        from spf.sdrpluto.direct_usb_receiver import (
+            DirectUsbRecoveryAttestationError,
+            RecoveryAttestationDifference,
+        )
+
+        if self.rx_config is None or self.direct_rx is None:
+            raise DirectUsbRecoveryAttestationError(
+                iter(
+                    (
+                        RecoveryAttestationDifference(
+                            field="pplus_rx_configuration",
+                            expected="active direct USB ReceiverConfig",
+                            observed=None,
+                        ),
+                    )
+                )
+            )
+
+        expected = {
+            "iio_serial": self.direct_rx.identity.serial,
+            "rx_lo": int(self.rx_config.lo),
+            "sample_rate": int(self.rx_config.sample_rate),
+            "rx_rf_bandwidth": int(self.rx_config.rf_bandwidth),
+            "gain_control_mode_rx1": str(self.rx_config.gain_control_modes[0]),
+            "gain_control_mode_rx2": str(self.rx_config.gain_control_modes[1]),
+            "filter_fir_en_rx1": int(self.rx_config.filter_fir_en),
+            "filter_fir_en_rx2": int(self.rx_config.filter_fir_en),
+            "phase_inversion_debug_attr": int(
+                self.rx_config.phase_inversion_debug_attr
+            ),
+            "phase_inversion_register_bit": int(
+                self.rx_config.phase_inversion_register_bit
+            ),
+        }
+        if self.rx_config.gain_control_modes[0] == "manual":
+            expected["manual_gain_rx1_db"] = float(self.rx_config.gains[0])
+        if self.rx_config.gain_control_modes[1] == "manual":
+            expected["manual_gain_rx2_db"] = float(self.rx_config.gains[1])
+
+        try:
+            fresh_sdr = adi.ad9361(uri=self.uri)
+        except Exception as error:
+            raise DirectUsbRecoveryAttestationError(
+                iter(
+                    (
+                        RecoveryAttestationDifference(
+                            field="iio_context",
+                            expected=f"readable context at {self.uri}",
+                            observed=f"{type(error).__name__}: {error}",
+                        ),
+                    )
+                )
+            ) from error
+
+        def iio_serial():
+            attr = fresh_sdr._ctx.attrs["hw_serial"]
+            return str(getattr(attr, "value", attr))
+
+        rx1 = fresh_sdr._ctrl.find_channel("voltage0", is_output=False)
+        rx2 = fresh_sdr._ctrl.find_channel("voltage1", is_output=False)
+        readers = {
+            "iio_serial": iio_serial,
+            "rx_lo": lambda: int(fresh_sdr.rx_lo),
+            "sample_rate": lambda: int(fresh_sdr.sample_rate),
+            "rx_rf_bandwidth": lambda: int(fresh_sdr.rx_rf_bandwidth),
+            "gain_control_mode_rx1": lambda: str(fresh_sdr.gain_control_mode_chan0),
+            "gain_control_mode_rx2": lambda: str(fresh_sdr.gain_control_mode_chan1),
+            "filter_fir_en_rx1": lambda: int(rx1.attrs["filter_fir_en"].value),
+            "filter_fir_en_rx2": lambda: int(rx2.attrs["filter_fir_en"].value),
+            "phase_inversion_debug_attr": lambda: int(
+                fresh_sdr._ctrl.debug_attrs["adi,rx1-rx2-phase-inversion-enable"].value
+            ),
+            "phase_inversion_register_bit": lambda: int(
+                bool(fresh_sdr._ctrl.reg_read(0x22) & (1 << 6))
+            ),
+        }
+        if "manual_gain_rx1_db" in expected:
+            readers["manual_gain_rx1_db"] = lambda: float(
+                fresh_sdr.rx_hardwaregain_chan0
+            )
+        if "manual_gain_rx2_db" in expected:
+            readers["manual_gain_rx2_db"] = lambda: float(
+                fresh_sdr.rx_hardwaregain_chan1
+            )
+
+        differences = []
+        for field, expected_value in expected.items():
+            try:
+                observed_value = readers[field]()
+            except Exception as error:
+                observed_value = f"{type(error).__name__}: {error}"
+            matches = observed_value == expected_value
+            if field == "rx_lo" and isinstance(observed_value, int):
+                matches = abs(observed_value - expected_value) < 10
+            if not matches:
+                differences.append(
+                    RecoveryAttestationDifference(
+                        field=field,
+                        expected=expected_value,
+                        observed=observed_value,
+                    )
+                )
+
+        if differences:
+            raise DirectUsbRecoveryAttestationError(iter(differences))
+
+        # The original libiio context may refer to a vanished USB device.
+        # Retain the freshly verified control context without reapplying any
+        # settings. Direct USB remains the sole streaming owner.
+        self.sdr = fresh_sdr
 
     def _iio_hardware_serial(self):
         try:

--- a/tests/test_direct_usb_receiver.py
+++ b/tests/test_direct_usb_receiver.py
@@ -74,6 +74,17 @@ class _FakeHandle:
         return wire
 
 
+class _DisconnectedHandle(_FakeHandle):
+    def controlWrite(self, *args, **kwargs):
+        raise usb1.USBErrorNoDevice()
+
+    def releaseInterface(self, interface):
+        pass
+
+    def close(self):
+        pass
+
+
 def _valid_wire_frame(samples=8, sequence=0):
     metadata = GainMetadataV1(
         features=(
@@ -137,6 +148,71 @@ def test_capture_requests_a_complete_framed_transfer_and_stops():
     assert len(capture.frames) == 1
     assert handle.bulk_read_sizes[0][1] == HEADER_BYTES + 8 * 8
     assert len(handle.control_writes) == 2
+
+
+def test_capture_rediscovers_same_radio_after_usb_address_changes(monkeypatch):
+    disconnected = _DisconnectedHandle(b"")
+    receiver = PlutoDirectUsbReceiver(serial="test", port_path=(1,))
+    receiver._handle = disconnected
+    receiver._identity = DirectUsbIdentity(
+        serial="test",
+        bus=1,
+        address=2,
+        port_path=(1,),
+        interface=6,
+        bulk_in_endpoint=0x89,
+        bulk_out_endpoint=0x07,
+    )
+    receiver._capabilities = GadgetCapabilitiesV1(
+        protocol_min=1,
+        protocol_max=1,
+        supported_features=(
+            MetadataFeatures.GAIN_ENDPOINT_SNAPSHOTS
+            | MetadataFeatures.HEADER_CRC32
+            | MetadataFeatures.SAMPLE_SEQUENCE
+        ),
+        max_samples_per_channel=1024,
+        max_finite_frames=16,
+        capability_flags=CapabilityFlags.FINITE_RX,
+    )
+    replacement = _FakeHandle(_valid_wire_frame())
+    open_calls = []
+
+    def reopen():
+        open_calls.append(True)
+        receiver._handle = replacement
+        receiver._identity = DirectUsbIdentity(
+            serial="test",
+            bus=1,
+            address=9,
+            port_path=(1,),
+            interface=6,
+            bulk_in_endpoint=0x89,
+            bulk_out_endpoint=0x07,
+        )
+        receiver._capabilities = GadgetCapabilitiesV1(
+            protocol_min=1,
+            protocol_max=1,
+            supported_features=(
+                MetadataFeatures.GAIN_ENDPOINT_SNAPSHOTS
+                | MetadataFeatures.HEADER_CRC32
+                | MetadataFeatures.SAMPLE_SEQUENCE
+            ),
+            max_samples_per_channel=1024,
+            max_finite_frames=16,
+            capability_flags=CapabilityFlags.FINITE_RX,
+        )
+
+    monkeypatch.setattr(receiver, "open", reopen)
+
+    capture = receiver.capture(samples_per_channel=8)
+
+    assert len(open_calls) == 1
+    assert capture.identity.serial == "test"
+    assert capture.identity.port_path == (1,)
+    assert capture.identity.address == 9
+    assert capture.frames[0].metadata.buffer_sequence == 0
+    assert capture.frames[0].metadata.first_sample_sequence == 0
 
 
 def test_hardware_identity_query_is_read_only_and_does_not_start_streaming():

--- a/tests/test_direct_usb_receiver.py
+++ b/tests/test_direct_usb_receiver.py
@@ -20,6 +20,8 @@ from spf.sdrpluto.direct_usb_protocol import (
     SampleFormat,
 )
 from spf.sdrpluto.direct_usb_receiver import (
+    DirectUsbNotFoundError,
+    DirectUsbRecoveryError,
     DirectUsbIdentity,
     PlutoDirectUsbReceiver,
     iq_payload_to_complex64,
@@ -213,6 +215,84 @@ def test_capture_rediscovers_same_radio_after_usb_address_changes(monkeypatch):
     assert capture.identity.address == 9
     assert capture.frames[0].metadata.buffer_sequence == 0
     assert capture.frames[0].metadata.first_sample_sequence == 0
+
+
+def test_capture_rediscovery_is_bounded(monkeypatch):
+    disconnected = _DisconnectedHandle(b"")
+    receiver = PlutoDirectUsbReceiver(
+        serial="test",
+        port_path=(1,),
+        reconnect_attempts=3,
+        reconnect_delay_seconds=0,
+    )
+    receiver._handle = disconnected
+    receiver._identity = DirectUsbIdentity(
+        serial="test",
+        bus=1,
+        address=2,
+        port_path=(1,),
+        interface=6,
+        bulk_in_endpoint=0x89,
+        bulk_out_endpoint=0x07,
+    )
+    receiver._capabilities = GadgetCapabilitiesV1(
+        protocol_min=1,
+        protocol_max=1,
+        supported_features=(
+            MetadataFeatures.GAIN_ENDPOINT_SNAPSHOTS
+            | MetadataFeatures.HEADER_CRC32
+            | MetadataFeatures.SAMPLE_SEQUENCE
+        ),
+        max_samples_per_channel=1024,
+        max_finite_frames=16,
+        capability_flags=CapabilityFlags.FINITE_RX,
+    )
+    open_calls = []
+
+    def missing():
+        open_calls.append(True)
+        raise DirectUsbNotFoundError("still disconnected")
+
+    monkeypatch.setattr(receiver, "open", missing)
+
+    with pytest.raises(DirectUsbRecoveryError, match="3 bounded attempts"):
+        receiver.capture(samples_per_channel=8)
+
+    assert len(open_calls) == 3
+
+
+def test_protocol_error_fails_closed_without_transport_rediscovery(monkeypatch):
+    handle = _FakeHandle(b"\x00" * (HEADER_BYTES + 8 * 8))
+    receiver = PlutoDirectUsbReceiver(serial="test", port_path=(1,))
+    receiver._handle = handle
+    receiver._identity = DirectUsbIdentity(
+        serial="test",
+        bus=1,
+        address=2,
+        port_path=(1,),
+        interface=6,
+        bulk_in_endpoint=0x89,
+        bulk_out_endpoint=0x07,
+    )
+    receiver._capabilities = GadgetCapabilitiesV1(
+        protocol_min=1,
+        protocol_max=1,
+        supported_features=(
+            MetadataFeatures.GAIN_ENDPOINT_SNAPSHOTS
+            | MetadataFeatures.HEADER_CRC32
+            | MetadataFeatures.SAMPLE_SEQUENCE
+        ),
+        max_samples_per_channel=1024,
+        max_finite_frames=16,
+        capability_flags=CapabilityFlags.FINITE_RX,
+    )
+    open_calls = []
+    monkeypatch.setattr(receiver, "open", lambda: open_calls.append(True))
+
+    with pytest.raises(ProtocolError, match="magic"):
+        receiver.capture(samples_per_channel=8)
+
+    assert open_calls == []
 
 
 def test_hardware_identity_query_is_read_only_and_does_not_start_streaming():

--- a/tests/test_direct_usb_receiver.py
+++ b/tests/test_direct_usb_receiver.py
@@ -154,7 +154,12 @@ def test_capture_requests_a_complete_framed_transfer_and_stops():
 
 def test_capture_rediscovers_same_radio_after_usb_address_changes(monkeypatch):
     disconnected = _DisconnectedHandle(b"")
-    receiver = PlutoDirectUsbReceiver(serial="test", port_path=(1,))
+    attest_calls = []
+    receiver = PlutoDirectUsbReceiver(
+        serial="test",
+        port_path=(1,),
+        reconnect_attestor=lambda: attest_calls.append(True),
+    )
     receiver._handle = disconnected
     receiver._identity = DirectUsbIdentity(
         serial="test",
@@ -210,6 +215,7 @@ def test_capture_rediscovers_same_radio_after_usb_address_changes(monkeypatch):
     capture = receiver.capture(samples_per_channel=8)
 
     assert len(open_calls) == 1
+    assert len(attest_calls) == 1
     assert capture.identity.serial == "test"
     assert capture.identity.port_path == (1,)
     assert capture.identity.address == 9

--- a/tests/test_direct_usb_recovery_attestation.py
+++ b/tests/test_direct_usb_recovery_attestation.py
@@ -1,0 +1,474 @@
+from types import SimpleNamespace
+
+import pytest
+import usb1
+
+from spf.sdrpluto import sdr_controller
+from spf.sdrpluto.direct_usb_protocol import (
+    CapabilityFlags,
+    GadgetCapabilitiesV1,
+    GainMetadataV1,
+    HardwareIdentityFlags,
+    HardwareIdentityV1,
+    MetadataFeatures,
+    MetadataFlags,
+    ProtocolError,
+    SampleFormat,
+)
+from spf.sdrpluto.direct_usb_receiver import (
+    DirectUsbIdentity,
+    DirectUsbRecoveryAttestationError,
+    PlutoDirectUsbReceiver,
+    RecoveryAttestationDifference,
+)
+from spf.sdrpluto.sdr_controller import PPlus
+
+
+SERIAL = "104000bac4950008230026001b440a003a"
+PORT_PATH = (1, 4, 5)
+GADGET_SHA = "a" * 40
+FPGA_DNA = 0x123456789ABCD
+
+
+class _FakeHandle:
+    def __init__(self, wire):
+        self.wire = wire
+        self.control_writes = []
+
+    def controlWrite(self, *args, **kwargs):
+        self.control_writes.append((args, kwargs))
+
+    def controlRead(self, *args, **kwargs):
+        return self.wire
+
+    def bulkRead(self, endpoint, size, timeout):
+        wire, self.wire = self.wire, b""
+        return wire
+
+
+class _DisconnectedHandle(_FakeHandle):
+    def controlWrite(self, *args, **kwargs):
+        raise usb1.USBErrorNoDevice()
+
+    def releaseInterface(self, interface):
+        pass
+
+    def close(self):
+        pass
+
+
+def _valid_wire_frame(samples=8, sequence=0):
+    metadata = GainMetadataV1(
+        features=(
+            MetadataFeatures.GAIN_ENDPOINT_SNAPSHOTS
+            | MetadataFeatures.HEADER_CRC32
+            | MetadataFeatures.SAMPLE_SEQUENCE
+        ),
+        flags=(
+            MetadataFlags.START_VALID
+            | MetadataFlags.END_VALID
+            | MetadataFlags.SAMPLE_SEQUENCE_VALID
+            | MetadataFlags.GAIN_FULL_TABLE_MODE
+        ),
+        stream_id=123,
+        buffer_sequence=sequence,
+        first_sample_sequence=sequence * samples,
+        samples_per_channel=samples,
+        iq_payload_bytes=samples * 8,
+        enabled_scan_mask=0x0F,
+        sample_format=SampleFormat.CS16_LE_TIME_INTERLEAVED,
+        channel_count=2,
+        rx1_gain_start=42,
+        rx2_gain_start=43,
+        rx1_gain_end=42,
+        rx2_gain_end=43,
+        rx1_first_change_sample=0xFFFFFFFF,
+        rx2_first_change_sample=0xFFFFFFFF,
+    )
+    return metadata.pack() + bytes(samples * 8)
+
+
+def _identity(*, bus=1, address=2, serial=SERIAL, port_path=PORT_PATH):
+    return DirectUsbIdentity(
+        serial=serial,
+        bus=bus,
+        address=address,
+        port_path=port_path,
+        interface=6,
+        bulk_in_endpoint=0x89,
+        bulk_out_endpoint=0x07,
+    )
+
+
+def _capabilities(*, hardware_identity=False):
+    flags = CapabilityFlags.FINITE_RX
+    if hardware_identity:
+        flags |= CapabilityFlags.HARDWARE_IDENTITY
+    return GadgetCapabilitiesV1(
+        protocol_min=1,
+        protocol_max=1,
+        supported_features=(
+            MetadataFeatures.GAIN_ENDPOINT_SNAPSHOTS
+            | MetadataFeatures.HEADER_CRC32
+            | MetadataFeatures.SAMPLE_SEQUENCE
+        ),
+        max_samples_per_channel=1024,
+        max_finite_frames=16,
+        capability_flags=flags,
+    )
+
+
+def _hardware_identity(*, dna=FPGA_DNA, build_id=GADGET_SHA):
+    return HardwareIdentityV1(
+        flags=(
+            HardwareIdentityFlags.FPGA_DEVICE_DNA_VALID
+            | HardwareIdentityFlags.GADGET_BUILD_ID_VALID
+        ),
+        fpga_device_dna=dna,
+        gadget_build_id=build_id,
+    )
+
+
+class _RecoveryHandle(_FakeHandle):
+    def __init__(self, wire, event_log):
+        super().__init__(wire)
+        self.event_log = event_log
+
+    def controlWrite(self, *args, **kwargs):
+        self.event_log.append("start_or_stop")
+        return super().controlWrite(*args, **kwargs)
+
+
+def _disconnected_receiver(*, attestor):
+    receiver = PlutoDirectUsbReceiver(
+        serial=SERIAL,
+        port_path=PORT_PATH,
+        reconnect_attempts=1,
+        reconnect_delay_seconds=0,
+        reconnect_attestor=attestor,
+    )
+    receiver._handle = _DisconnectedHandle(b"")
+    receiver._identity = _identity()
+    receiver._capabilities = _capabilities()
+    return receiver
+
+
+def test_recovery_attestation_precedes_start_and_changed_address_is_allowed(
+    monkeypatch,
+):
+    events = []
+    receiver = _disconnected_receiver(attestor=lambda: events.append("iio_config"))
+    receiver._recovery_hardware_identity = _hardware_identity()
+    replacement = _RecoveryHandle(_valid_wire_frame(), events)
+
+    def reopen():
+        events.append("rediscover")
+        receiver._handle = replacement
+        receiver._identity = _identity(address=9)
+        receiver._capabilities = _capabilities(hardware_identity=True)
+
+    monkeypatch.setattr(receiver, "open", reopen)
+    monkeypatch.setattr(
+        receiver,
+        "query_hardware_identity",
+        lambda: (events.append("firmware_identity") or _hardware_identity()),
+    )
+
+    capture = receiver.capture(samples_per_channel=8)
+
+    assert capture.identity.address == 9
+    assert events[:4] == [
+        "rediscover",
+        "firmware_identity",
+        "iio_config",
+        "start_or_stop",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("field", "recovered"),
+    (
+        ("usb_serial", _identity(serial="different")),
+        ("usb_port_path", _identity(port_path=(1, 4, 6))),
+    ),
+)
+def test_durable_usb_identity_mismatch_rejects_before_start(
+    monkeypatch, field, recovered
+):
+    attest_calls = []
+    receiver = _disconnected_receiver(attestor=lambda: attest_calls.append(True))
+    replacement = _FakeHandle(_valid_wire_frame())
+
+    def reopen():
+        receiver._handle = replacement
+        receiver._identity = recovered
+        receiver._capabilities = _capabilities()
+
+    monkeypatch.setattr(receiver, "open", reopen)
+
+    with pytest.raises(DirectUsbRecoveryAttestationError) as raised:
+        receiver.capture(samples_per_channel=8)
+
+    assert [difference.field for difference in raised.value.differences] == [field]
+    assert replacement.control_writes == []
+    assert attest_calls == []
+
+
+@pytest.mark.parametrize(
+    ("field", "observed"),
+    (
+        ("fpga_device_dna", _hardware_identity(dna=FPGA_DNA + 1)),
+        ("gadget_build_id", _hardware_identity(build_id="b" * 40)),
+    ),
+)
+def test_firmware_identity_mismatch_rejects_before_start(monkeypatch, field, observed):
+    attest_calls = []
+    receiver = _disconnected_receiver(attestor=lambda: attest_calls.append(True))
+    receiver._recovery_hardware_identity = _hardware_identity()
+    replacement = _FakeHandle(_valid_wire_frame())
+
+    def reopen():
+        receiver._handle = replacement
+        receiver._identity = _identity(address=9)
+        receiver._capabilities = _capabilities(hardware_identity=True)
+
+    monkeypatch.setattr(receiver, "open", reopen)
+    monkeypatch.setattr(receiver, "query_hardware_identity", lambda: observed)
+
+    with pytest.raises(DirectUsbRecoveryAttestationError) as raised:
+        receiver.capture(samples_per_channel=8)
+
+    assert [difference.field for difference in raised.value.differences] == [field]
+    assert replacement.control_writes == []
+    assert attest_calls == []
+
+
+def test_missing_iio_attestor_fails_closed_before_start(monkeypatch):
+    receiver = _disconnected_receiver(attestor=None)
+    replacement = _FakeHandle(_valid_wire_frame())
+
+    def reopen():
+        receiver._handle = replacement
+        receiver._identity = _identity(address=9)
+        receiver._capabilities = _capabilities()
+
+    monkeypatch.setattr(receiver, "open", reopen)
+
+    with pytest.raises(
+        DirectUsbRecoveryAttestationError, match="configured reconnect attestor"
+    ):
+        receiver.capture(samples_per_channel=8)
+
+    assert replacement.control_writes == []
+
+
+def test_iio_configuration_mismatch_rejects_before_start(monkeypatch):
+    difference = RecoveryAttestationDifference(
+        field="rx_lo",
+        expected=2_467_000_000,
+        observed=2_412_000_000,
+    )
+
+    def mismatch():
+        raise DirectUsbRecoveryAttestationError((difference,))
+
+    receiver = _disconnected_receiver(attestor=mismatch)
+    replacement = _FakeHandle(_valid_wire_frame())
+
+    def reopen():
+        receiver._handle = replacement
+        receiver._identity = _identity(address=9)
+        receiver._capabilities = _capabilities()
+
+    monkeypatch.setattr(receiver, "open", reopen)
+
+    with pytest.raises(DirectUsbRecoveryAttestationError) as raised:
+        receiver.capture(samples_per_channel=8)
+
+    assert raised.value.differences == (difference,)
+    assert replacement.control_writes == []
+
+
+def test_invalid_sequence_zero_is_rejected_after_attested_restart(monkeypatch):
+    receiver = _disconnected_receiver(attestor=lambda: None)
+    replacement = _FakeHandle(_valid_wire_frame(sequence=1))
+
+    def reopen():
+        receiver._handle = replacement
+        receiver._identity = _identity(address=9)
+        receiver._capabilities = _capabilities()
+
+    monkeypatch.setattr(receiver, "open", reopen)
+
+    with pytest.raises(ProtocolError, match="new stream epoch"):
+        receiver.capture(samples_per_channel=8)
+
+
+class _Value:
+    def __init__(self, value):
+        self.value = value
+
+
+class _RxChannel:
+    def __init__(self, fir):
+        self.attrs = {"filter_fir_en": _Value(str(fir))}
+
+
+class _FakeCtrl:
+    def __init__(self, *, fir_rx1=1, fir_rx2=1, debug_attr=1, register_bit=1):
+        self.channels = {
+            "voltage0": _RxChannel(fir_rx1),
+            "voltage1": _RxChannel(fir_rx2),
+        }
+        self.debug_attrs = {
+            "adi,rx1-rx2-phase-inversion-enable": _Value(str(debug_attr))
+        }
+        self.register_bit = register_bit
+
+    def find_channel(self, name, is_output):
+        assert not is_output
+        return self.channels[name]
+
+    def reg_read(self, address):
+        assert address == 0x22
+        return self.register_bit << 6
+
+
+class _FreshSdr:
+    def __init__(
+        self,
+        *,
+        serial=SERIAL,
+        rx_lo=2_467_000_000,
+        sample_rate=3_000_000,
+        rx_rf_bandwidth=3_000_000,
+        gain_mode_rx1="manual",
+        gain_mode_rx2="manual",
+        gain_rx1=26,
+        gain_rx2=41,
+        fir_rx1=1,
+        fir_rx2=1,
+        debug_attr=1,
+        register_bit=1,
+        gains_readable=True,
+    ):
+        self._ctx = SimpleNamespace(attrs={"hw_serial": _Value(serial)})
+        self.rx_lo = rx_lo
+        self.sample_rate = sample_rate
+        self.rx_rf_bandwidth = rx_rf_bandwidth
+        self.gain_control_mode_chan0 = gain_mode_rx1
+        self.gain_control_mode_chan1 = gain_mode_rx2
+        self._gain_rx1 = gain_rx1
+        self._gain_rx2 = gain_rx2
+        self.gains_readable = gains_readable
+        self._ctrl = _FakeCtrl(
+            fir_rx1=fir_rx1,
+            fir_rx2=fir_rx2,
+            debug_attr=debug_attr,
+            register_bit=register_bit,
+        )
+
+    @property
+    def rx_hardwaregain_chan0(self):
+        if not self.gains_readable:
+            raise AssertionError("instantaneous AGC gain must not be read")
+        return self._gain_rx1
+
+    @property
+    def rx_hardwaregain_chan1(self):
+        if not self.gains_readable:
+            raise AssertionError("instantaneous AGC gain must not be read")
+        return self._gain_rx2
+
+
+def _pplus(*, gain_modes=("manual", "manual")):
+    pplus = object.__new__(PPlus)
+    pplus.uri = "usb:1.4.5"
+    pplus.rx_config = SimpleNamespace(
+        lo=2_467_000_000,
+        sample_rate=3_000_000,
+        rf_bandwidth=3_000_000,
+        gain_control_modes=list(gain_modes),
+        gains=[26, 41],
+        filter_fir_en=1,
+        phase_inversion_debug_attr=1,
+        phase_inversion_register_bit=1,
+    )
+    pplus.direct_rx = SimpleNamespace(identity=_identity(address=9))
+    pplus.sdr = object()
+    return pplus
+
+
+@pytest.mark.parametrize(
+    ("field", "overrides"),
+    (
+        ("iio_serial", {"serial": "different"}),
+        ("rx_lo", {"rx_lo": 2_412_000_000}),
+        ("sample_rate", {"sample_rate": 2_000_000}),
+        ("rx_rf_bandwidth", {"rx_rf_bandwidth": 2_000_000}),
+        ("gain_control_mode_rx1", {"gain_mode_rx1": "slow_attack"}),
+        ("gain_control_mode_rx2", {"gain_mode_rx2": "slow_attack"}),
+        ("manual_gain_rx1_db", {"gain_rx1": 25}),
+        ("manual_gain_rx2_db", {"gain_rx2": 40}),
+        ("filter_fir_en_rx1", {"fir_rx1": 0}),
+        ("filter_fir_en_rx2", {"fir_rx2": 0}),
+        ("phase_inversion_debug_attr", {"debug_attr": 0}),
+        ("phase_inversion_register_bit", {"register_bit": 0}),
+    ),
+)
+def test_pplus_rejects_each_observable_configuration_mismatch(
+    monkeypatch, field, overrides
+):
+    pplus = _pplus()
+    fresh = _FreshSdr(**overrides)
+    monkeypatch.setattr(sdr_controller.adi, "ad9361", lambda uri: fresh)
+
+    with pytest.raises(DirectUsbRecoveryAttestationError) as raised:
+        pplus._attest_direct_usb_reconnect()
+
+    assert field in [difference.field for difference in raised.value.differences]
+    assert pplus.sdr is not fresh
+
+
+def test_pplus_matching_configuration_retains_fresh_iio_context(monkeypatch):
+    pplus = _pplus()
+    fresh = _FreshSdr()
+    monkeypatch.setattr(sdr_controller.adi, "ad9361", lambda uri: fresh)
+
+    pplus._attest_direct_usb_reconnect()
+
+    assert pplus.sdr is fresh
+
+
+def test_pplus_does_not_compare_instantaneous_gain_in_agc_modes(monkeypatch):
+    pplus = _pplus(gain_modes=("slow_attack", "fast_attack"))
+    fresh = _FreshSdr(
+        gain_mode_rx1="slow_attack",
+        gain_mode_rx2="fast_attack",
+        gains_readable=False,
+    )
+    monkeypatch.setattr(sdr_controller.adi, "ad9361", lambda uri: fresh)
+
+    pplus._attest_direct_usb_reconnect()
+
+    assert pplus.sdr is fresh
+
+
+def test_pplus_iio_unavailable_is_a_structured_fail_closed_error(monkeypatch):
+    pplus = _pplus()
+
+    def unavailable(uri):
+        raise OSError("No such device")
+
+    monkeypatch.setattr(sdr_controller.adi, "ad9361", unavailable)
+
+    with pytest.raises(DirectUsbRecoveryAttestationError) as raised:
+        pplus._attest_direct_usb_reconnect()
+
+    assert raised.value.differences == (
+        RecoveryAttestationDifference(
+            field="iio_context",
+            expected="readable context at usb:1.4.5",
+            observed="OSError: No such device",
+        ),
+    )

--- a/tests/test_direct_usb_recovery_attestation.py
+++ b/tests/test_direct_usb_recovery_attestation.py
@@ -18,6 +18,7 @@ from spf.sdrpluto.direct_usb_protocol import (
 from spf.sdrpluto.direct_usb_receiver import (
     DirectUsbIdentity,
     DirectUsbRecoveryAttestationError,
+    DirectUsbRecoveryError,
     PlutoDirectUsbReceiver,
     RecoveryAttestationDifference,
 )
@@ -286,6 +287,9 @@ def test_iio_configuration_mismatch_rejects_before_start(monkeypatch):
         receiver.capture(samples_per_channel=8)
 
     assert raised.value.differences == (difference,)
+    assert replacement.control_writes == []
+    with pytest.raises(DirectUsbRecoveryError, match="terminal"):
+        receiver.capture(samples_per_channel=8)
     assert replacement.control_writes == []
 
 

--- a/tests/test_mavlink_radio_collect.py
+++ b/tests/test_mavlink_radio_collect.py
@@ -11,7 +11,6 @@ import yaml
 import spf
 from spf.dataset.v4_data import v4rx_f64_keys
 from spf.dataset.v6_data import v6rx_2x_keys, v6rx_scalar_keys
-from spf.dataset.v7_data import v7rx_2x_keys, v7rx_scalar_keys
 from spf.capture_schema import normalize_capture_config
 from spf.mavlink_radio_collection import validate_transport_schema
 from spf.scripts.zarr_utils import zarr_open_from_lmdb_store
@@ -133,7 +132,7 @@ def test_v7_infers_direct_usb_protocol_v2_and_rejects_conflicts():
         )
 
 
-def test_mavlink_radio_collect_v7_iio_schema():
+def test_mavlink_radio_collect_v7_requires_boot_verified_firmware():
     with tempfile.TemporaryDirectory() as tmpdirname:
         with open(f"{root_dir}/tests/test_config.yaml") as source:
             config = yaml.safe_load(source)
@@ -143,31 +142,19 @@ def test_mavlink_radio_collect_v7_iio_schema():
         with open(config_path, "w") as destination:
             yaml.safe_dump(config, destination)
 
-        subprocess.check_output(
-            f"python3 {root_dir}/spf/mavlink_radio_collection.py --fake-drone --exit -c "
-            + f"{config_path} -m {root_dir}/tests/test_device_mapping "
-            + f"-r center -n 2 --temp {tmpdirname}",
-            timeout=180,
-            shell=True,
-            env=get_env(),
-            stderr=subprocess.STDOUT,
-        ).decode()
+        with pytest.raises(subprocess.CalledProcessError) as raised:
+            subprocess.check_output(
+                f"python3 {root_dir}/spf/mavlink_radio_collection.py "
+                "--fake-drone --exit -c "
+                + f"{config_path} -m {root_dir}/tests/test_device_mapping "
+                + f"-r center -n 2 --temp {tmpdirname}",
+                timeout=180,
+                shell=True,
+                env=get_env(),
+                stderr=subprocess.STDOUT,
+            )
 
-        zarr_fn = glob.glob(f"{tmpdirname}/*.zarr")[0]
-        z = zarr_open_from_lmdb_store(zarr_fn)
-        try:
-            assert z.attrs["radio_metadata_schema_version"] == 2
-            for receiver_idx in range(2):
-                receiver = z[f"receivers/r{receiver_idx}"]
-                assert receiver.signal_matrix.shape == (2, 2, 4096)
-                for key in v7rx_scalar_keys:
-                    assert key in receiver
-                for key in v7rx_2x_keys:
-                    assert key in receiver
-                assert not receiver.gain_metadata_valid[:].any()
-                assert not receiver.rssi_metadata_valid[:].any()
-        finally:
-            z.store.close()
+        assert b"V7 capture requires boot-verified firmware" in raised.value.output
 
 
 # def test_mavlink_radio_collect_direct():

--- a/tests/test_rover_capture_profile.py
+++ b/tests/test_rover_capture_profile.py
@@ -100,7 +100,8 @@ def test_boot_launcher_prints_canonical_v7_plan_without_hardware(tmp_path):
 def test_every_production_boot_waits_for_firmware_loader_by_default():
     production_unit = (ROVER_ROOT / "mavlink_controller.service").read_text()
     assert "Requires=spf-pluto-direct-usb.service" in production_unit
-    assert "After=network-online.target spf-pluto-direct-usb.service" in production_unit
+    assert "After=spf-pluto-direct-usb.service" in production_unit
+    assert "\nAfter=network-online.target" not in production_unit
     assert "EnvironmentFile=-/etc/spf/rover_collection.env" in production_unit
 
     loader_unit = (ROVER_ROOT / "spf-pluto-direct-usb.service").read_text()


### PR DESCRIPTION
## Summary

- recover a direct-USB stream after a Pluto USB reset or re-enumeration;
- rediscover the same physical radio by serial number and USB port path rather
  than retaining a stale bus address;
- bound recovery attempts and delays;
- attest the recovered radio and its observable RX configuration before any new
  direct-USB START request;
- require the restarted stream to begin a fresh sequence-zero epoch;
- distinguish recoverable transport loss from protocol-integrity failures;
- keep device identity and two-Pluto association fail-closed.

## Root cause

The direct-USB receiver retained the transient USB bus/address and live libusb
handle for the lifetime of the capture. A reset invalidated both, even when the
same Pluto returned on the same physical port with the same serial. The old
path surfaced `ENODEV` but had no bounded rediscovery/restart path.

The first recovery implementation reclaimed the direct-USB interface but did
not prove that a restarted Pluto had retained its radio configuration. That
could resume correctly framed IQ at the wrong LO, bandwidth, sample rate, FIR,
or gain mode.

## Recovery attestation

After rediscovery and before START, recovery now requires:

1. the same USB serial and physical port path (a changed bus/address is allowed);
2. matching FPGA Device DNA and gadget build ID when those fields were valid in
   the initially pinned passive hardware identity;
3. a fresh, read-only USB-IIO context for the same serial;
4. matching RX LO, sample rate, RF bandwidth, RX1/RX2 gain-control modes, both
   FIR enable values, the phase-inversion debug attribute, and register `0x22`
   bit 6;
5. matching RX1/RX2 manual gain only for channels configured in manual mode.

Instantaneous gain is deliberately not read or compared in AGC modes.
Differences are returned as structured `field`, `expected`, and `observed`
records. An unavailable IIO context/readback also fails closed. Recovery does
not load firmware, rewrite configuration, retry forever, or claim phase
continuity. A successful reconnect is a new stream epoch.

## Red / green evidence

Original hot-plug regression:

- Red commit: `3a893bd`
- Green commit: `8a3f9a6`

The new isolated mocked cases cover:

- matching identity/configuration resumes;
- changed USB address with the same durable identity resumes;
- serial and physical-port mismatches reject before START;
- FPGA DNA and gadget build mismatches reject before START;
- every observable RX configuration field rejects on mismatch;
- unavailable IIO verification rejects before START;
- AGC instantaneous gain is never read;
- call order is `rediscover -> firmware identity -> IIO config -> START`;
- a recovered stream that does not begin at sequence zero is rejected.

To protect the resource-constrained development Pi, local validation was
limited to:

```text
Black (changed Python files)
python -m py_compile (changed Python files)
git diff --check
```

All substantive tests are delegated to GitHub CI.

## Safety bounds

- retries are finite and cannot switch to another attached Pluto;
- no recovered START occurs until all available identity and configuration
  evidence matches;
- old gadgets without passive FPGA/build identity remain pinned by USB serial
  and physical port, plus the full IIO configuration readback;
- bad magic, CRC, version, header size, payload size, or sequence semantics are
  not treated as hot-plug failures and are not retried;
- failed attestation terminates RX; with capture finalization merged, the
  partial dataset is retained as `.zarr.tmp`;
- a later healthy device still requires a new service/capture start.

## Hardware follow-up

On a disarmed two-Pluto rover, interrupt one Pluto during a sacrificial V7
capture. Verify that only the matching serial/path is reclaimed, the read-only
configuration attestation occurs before START, the new stream epoch starts at
zero, loss is explicit, and the resulting Zarr retains correct per-radio
serial/firmware metadata.
