### PR TITLE
Gate rover boot on compass policy

### DIFF
--- a/data_collection/rover/rover_v3.1/PRE_FIELD_CHECKLIST.md
+++ b/data_collection/rover/rover_v3.1/PRE_FIELD_CHECKLIST.md
@@ -408,12 +408,17 @@ slot. Recalibrate outdoors with the assembled vehicle away from steel,
 magnets, high-current wiring, SDRs, and the Pi. Then rerun this gate and the
 normal ArduPilot pre-arm check.
 
-The production boot launcher repeats this read-only gate from a freshly
-downloaded full parameter set after managed parameter synchronization and
-before GPS-time synchronization, capture, arming, or motion. It invalidates
+The production boot launcher combines managed parameter synchronization,
+acknowledgement verification, and this policy gate in one MAVLink session with
+one full parameter download. Unchanged values come from that complete
+snapshot; changed values are accepted only after matching `PARAM_VALUE`
+acknowledgements; the resulting in-memory set is diffed and evaluated before
+GPS-time synchronization, capture, arming, or motion. This replaces the two
+full downloads previously used for load-plus-diff, so the policy gate adds no
+normal production boot delay. It invalidates
 `/home/pi/compass_ready.json` before every check and refuses to continue on
-failure. `SPF_BOOT_VALIDATE_ONLY=1` also runs the gate, but still performs no
-parameter writes, capture, arming, or motion.
+failure. `SPF_BOOT_VALIDATE_ONLY=1` and `SPF_SKIP_PARAMETER_SYNC=1` use one
+read-only download and perform no managed parameter writes.
 
 For offline diagnosis, evaluate a saved MAVProxy/Mission Planner parameter
 export without opening the vehicle:

--- a/data_collection/rover/rover_v3.1/PRE_FIELD_CHECKLIST.md
+++ b/data_collection/rover/rover_v3.1/PRE_FIELD_CHECKLIST.md
@@ -408,6 +408,13 @@ slot. Recalibrate outdoors with the assembled vehicle away from steel,
 magnets, high-current wiring, SDRs, and the Pi. Then rerun this gate and the
 normal ArduPilot pre-arm check.
 
+The production boot launcher repeats this read-only gate from a freshly
+downloaded full parameter set after managed parameter synchronization and
+before GPS-time synchronization, capture, arming, or motion. It invalidates
+`/home/pi/compass_ready.json` before every check and refuses to continue on
+failure. `SPF_BOOT_VALIDATE_ONLY=1` also runs the gate, but still performs no
+parameter writes, capture, arming, or motion.
+
 For offline diagnosis, evaluate a saved MAVProxy/Mission Planner parameter
 export without opening the vehicle:
 

--- a/data_collection/rover/rover_v3.1/drone_run.sh
+++ b/data_collection/rover/rover_v3.1/drone_run.sh
@@ -208,21 +208,25 @@ verify_direct_ready() {
 }
 
 sync_vehicle_configuration() {
-    is_true "$SKIP_PARAMETER_SYNC" && return 0
+    if is_true "$SKIP_PARAMETER_SYNC"; then
+        verify_compass_policy_read_only
+        return 0
+    fi
     sed "s/__ROVER_ID__/${rover_id}/g" \
         < <(cat \
             "${SCRIPT_DIR}/rover3_base_parameters.params" \
             "${SCRIPT_DIR}/rover3_rc_servo_parameters.params") \
         >"$PARAMS_FILE"
-    "$PYTHON" "$MAVLINK_CONTROLLER" --load-params "$PARAMS_FILE"
-    if ! "$PYTHON" "$MAVLINK_CONTROLLER" --diff-params "$PARAMS_FILE"; then
-        die "Vehicle parameter verification failed after loading parameters."
+    rm -f -- "$COMPASS_READY_FILE"
+    if ! "$PYTHON" "$MAVLINK_CONTROLLER" \
+        --prepare-vehicle-params "$PARAMS_FILE" \
+        --compass-policy-json "$COMPASS_READY_FILE"; then
+        die "Vehicle parameter or compass policy verification failed."
     fi
 }
 
-verify_compass_policy() {
-    # A prior boot's report must never authorize this boot. Download the full
-    # live parameter set after any managed parameter writes, then fail closed.
+verify_compass_policy_read_only() {
+    # Boot validation performs no managed parameter writes.
     rm -f -- "$COMPASS_READY_FILE"
     "$PYTHON" "$MAVLINK_CONTROLLER" --save-params "$COMPASS_PARAMS_FILE"
     if ! "$PYTHON" "$COMPASS_POLICY_CHECKER" "$COMPASS_PARAMS_FILE" \
@@ -276,13 +280,12 @@ main() {
 
     if is_true "$BOOT_VALIDATE_ONLY"; then
         read_only_vehicle_gate
-        verify_compass_policy
+        verify_compass_policy_read_only
         printf 'PASS: boot validation stopped before parameter writes or collection.\n'
         return 0
     fi
 
     sync_vehicle_configuration
-    verify_compass_policy
     sync_gps_time
     printf 'performance\n' | sudo tee \
         /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor >/dev/null

--- a/data_collection/rover/rover_v3.1/drone_run.sh
+++ b/data_collection/rover/rover_v3.1/drone_run.sh
@@ -13,8 +13,11 @@ readonly PROFILE_ENV="/etc/spf/rover_collection.env"
 readonly READY_FILE="/run/spf/direct_usb_ready.json"
 readonly DEVICE_MAPPING="/home/pi/device_mapping"
 readonly MAVLINK_CONTROLLER="${REPO_ROOT}/spf/mavlink/mavlink_controller.py"
+readonly COMPASS_POLICY_CHECKER="${REPO_ROOT}/spf/mavlink/compass_policy.py"
 readonly BOOT_UNIT_RECONCILER="${SCRIPT_DIR}/reconcile_rover_boot_units.sh"
 readonly PARAMS_FILE="/home/pi/this_rover.params"
+readonly COMPASS_PARAMS_FILE="/home/pi/this_rover_full.params"
+readonly COMPASS_READY_FILE="/home/pi/compass_ready.json"
 readonly TIME_FILE="/home/pi/time"
 
 die() {
@@ -217,6 +220,17 @@ sync_vehicle_configuration() {
     fi
 }
 
+verify_compass_policy() {
+    # A prior boot's report must never authorize this boot. Download the full
+    # live parameter set after any managed parameter writes, then fail closed.
+    rm -f -- "$COMPASS_READY_FILE"
+    "$PYTHON" "$MAVLINK_CONTROLLER" --save-params "$COMPASS_PARAMS_FILE"
+    if ! "$PYTHON" "$COMPASS_POLICY_CHECKER" "$COMPASS_PARAMS_FILE" \
+        --json-output "$COMPASS_READY_FILE"; then
+        die "Compass policy verification failed; refusing collection and motion."
+    fi
+}
+
 sync_gps_time() {
     "$PYTHON" "$MAVLINK_CONTROLLER" --get-time "$TIME_FILE"
     sudo date -s "$(cat "$TIME_FILE")"
@@ -262,11 +276,13 @@ main() {
 
     if is_true "$BOOT_VALIDATE_ONLY"; then
         read_only_vehicle_gate
+        verify_compass_policy
         printf 'PASS: boot validation stopped before parameter writes or collection.\n'
         return 0
     fi
 
     sync_vehicle_configuration
+    verify_compass_policy
     sync_gps_time
     printf 'performance\n' | sudo tee \
         /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor >/dev/null

--- a/spf/mavlink/mavlink_controller.py
+++ b/spf/mavlink/mavlink_controller.py
@@ -18,6 +18,7 @@ from pymavlink import mavutil
 from spf.gps.boundaries import boundary_to_diamond  # crissy_boundary_convex
 from spf.gps.boundaries import franklin_safe
 from spf.gps.gps_utils import swap_lat_long
+from spf.mavlink.compass_policy import evaluate_compass_policy
 from spf.mavlink.mavparm import MAVParmDict
 from spf.motion_planners.dynamics import Dynamics
 from spf.motion_planners.planner import (
@@ -33,6 +34,11 @@ logging.basicConfig(
     format="%(asctime)s:%(levelname)s: %(message)s",
 )
 logging.getLogger().addHandler(logging.StreamHandler())
+
+
+class VehicleParameterVerificationError(RuntimeError):
+    """Managed vehicle parameters were not acknowledged and verified."""
+
 
 EKF_STATUS_DEC_TO_STRING = {
     1: "EKF_ATTITUDE",
@@ -602,7 +608,7 @@ class Drone:
                     self.move_to_point(point)
                 self.planner_in_control = True
                 # time.sleep(2)
-                
+
         self.planner_in_control = False
 
     def get_cmd(self, cmd):
@@ -1042,6 +1048,44 @@ def get_ardupilot_serial():
     return available_pilots[0]
 
 
+def prepare_vehicle_parameters(drone, parameter_file):
+    """Load, verify, and evaluate one complete in-memory parameter snapshot.
+
+    The initial full download verifies every unchanged value. ``MAVParmDict``
+    updates changed values only after the flight controller echoes a matching
+    ``PARAM_VALUE`` acknowledgement. The final diff and compass policy
+    therefore reuse one authoritative session without another full download.
+    """
+    parameter_file = os.fspath(parameter_file)
+    if not os.path.isfile(parameter_file):
+        raise FileNotFoundError(f"Parameter file does not exist: {parameter_file}")
+    if not drone.update_all_parameters():
+        raise VehicleParameterVerificationError(
+            "Could not download the complete vehicle parameter set"
+        )
+
+    drone.single_operation_mode_on()
+    try:
+        drone.disarm()
+        time.sleep(0.02)
+        drone.params.load(parameter_file, mav=drone.connection)
+    finally:
+        drone.single_operation_mode_off()
+
+    differences = drone.params.diff(parameter_file)
+    if differences:
+        raise VehicleParameterVerificationError(
+            f"Managed parameter verification found {differences} differences"
+        )
+    return evaluate_compass_policy(drone.params)
+
+
+def write_compass_policy_report(report, output_path):
+    with open(output_path, "w") as output_file:
+        json.dump(report.to_dict(), output_file, indent=2, sort_keys=True)
+        output_file.write("\n")
+
+
 def get_mavlink_controller_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -1067,6 +1111,23 @@ def get_mavlink_controller_parser():
         "--diff-params",
         type=str,
         help="save params to this file",
+        required=False,
+        default=None,
+    )
+    parser.add_argument(
+        "--prepare-vehicle-params",
+        type=str,
+        help=(
+            "download parameters once, apply this managed parameter file, "
+            "verify acknowledgements, and evaluate compass policy"
+        ),
+        required=False,
+        default=None,
+    )
+    parser.add_argument(
+        "--compass-policy-json",
+        type=str,
+        help="write the combined preparation's compass policy report",
         required=False,
         default=None,
     )
@@ -1245,10 +1306,38 @@ def mavlink_controller_run(args):
         args.save_params is not None
         or args.load_params is not None
         or args.diff_params is not None
+        or args.prepare_vehicle_params is not None
     ):
         while drone.last_heartbeat == 0:
             time.sleep(3)
         drone.buzzer(tones["check-diff"])
+
+        if args.prepare_vehicle_params is not None:
+            if args.compass_policy_json is None:
+                logging.error("--prepare-vehicle-params requires --compass-policy-json")
+                sys.exit(2)
+            try:
+                report = prepare_vehicle_parameters(
+                    drone,
+                    args.prepare_vehicle_params,
+                )
+            except (OSError, VehicleParameterVerificationError) as error:
+                logging.error("Vehicle parameter preparation failed: %s", error)
+                sys.exit(1)
+            write_compass_policy_report(report, args.compass_policy_json)
+            if report.external_compass is not None:
+                logging.info(
+                    "External compass slot %d, device ID %d, offset norm %.1f mG",
+                    report.external_compass.slot,
+                    report.external_compass.device_id,
+                    report.external_compass.offset_norm_mg,
+                )
+            for warning in report.warnings:
+                logging.warning("Compass policy: %s", warning)
+            for error in report.errors:
+                logging.error("Compass policy: %s", error)
+            sys.exit(0 if report.ok else 1)
+
         drone.update_all_parameters()
 
         if args.diff_params is not None:
@@ -1277,6 +1366,7 @@ def mavlink_controller_run(args):
 
     while True:
         time.sleep(200)
+
 
 def set_drone_mode(drone,mode):
     target_mode = mode.upper()

--- a/tests/test_mavlink_compass_preflight.py
+++ b/tests/test_mavlink_compass_preflight.py
@@ -108,9 +108,7 @@ def test_prepare_vehicle_uses_one_download_and_acknowledged_values(tmp_path):
 def test_prepare_vehicle_fails_closed_on_unverified_parameter(tmp_path):
     managed_path = tmp_path / "managed.params"
     managed_path.write_text("MANAGED_VALUE 2\n")
-    drone = FakeDrone(
-        FakeParameters(_healthy_parameters(), differences=1)
-    )
+    drone = FakeDrone(FakeParameters(_healthy_parameters(), differences=1))
 
     with pytest.raises(VehicleParameterVerificationError, match="1 differences"):
         prepare_vehicle_parameters(drone, managed_path)

--- a/tests/test_mavlink_compass_preflight.py
+++ b/tests/test_mavlink_compass_preflight.py
@@ -1,0 +1,129 @@
+from pathlib import Path
+
+import pytest
+
+from spf.mavlink.mavlink_controller import (
+    VehicleParameterVerificationError,
+    prepare_vehicle_parameters,
+)
+
+
+EXTERNAL_COMPASS_DEVICE_ID = 658953
+
+
+def _healthy_parameters():
+    params = {
+        "COMPASS_ENABLE": 1,
+        "COMPASS_CAL_FIT": 16,
+        "COMPASS_DISBLMSK": 0,
+        "COMPASS_PRIO1_ID": EXTERNAL_COMPASS_DEVICE_ID,
+        "COMPASS_PRIO2_ID": 131594,
+        "COMPASS_PRIO3_ID": 0,
+    }
+    for slot in (1, 2, 3):
+        suffix = "" if slot == 1 else str(slot)
+        external_key = "COMPASS_EXTERNAL" if slot == 1 else f"COMPASS_EXTERN{slot}"
+        params.update(
+            {
+                f"COMPASS_DEV_ID{suffix}": 0,
+                f"COMPASS_USE{suffix}": 0,
+                external_key: 0,
+                f"COMPASS_OFS{suffix}_X": 0,
+                f"COMPASS_OFS{suffix}_Y": 0,
+                f"COMPASS_OFS{suffix}_Z": 0,
+            }
+        )
+    params.update(
+        {
+            "COMPASS_DEV_ID": EXTERNAL_COMPASS_DEVICE_ID,
+            "COMPASS_USE": 1,
+            "COMPASS_EXTERNAL": 1,
+            "COMPASS_OFS_X": -19,
+            "COMPASS_OFS_Y": 156,
+            "COMPASS_OFS_Z": -82,
+            "COMPASS_DEV_ID2": 131594,
+        }
+    )
+    return params
+
+
+class FakeParameters(dict):
+    def __init__(self, values, *, differences=0, load_error=None):
+        super().__init__(values)
+        self.differences = differences
+        self.load_error = load_error
+        self.loaded_path = None
+        self.diffed_path = None
+
+    def load(self, path, *, mav):
+        self.loaded_path = Path(path)
+        if self.load_error is not None:
+            raise self.load_error
+        self["MANAGED_VALUE"] = 2
+        return 1, 1
+
+    def diff(self, path):
+        self.diffed_path = Path(path)
+        return self.differences
+
+
+class FakeDrone:
+    def __init__(self, params):
+        self.params = params
+        self.connection = object()
+        self.downloads = 0
+        self.events = []
+
+    def update_all_parameters(self):
+        self.downloads += 1
+        self.events.append("download")
+        return True
+
+    def single_operation_mode_on(self):
+        self.events.append("pause")
+
+    def disarm(self):
+        self.events.append("disarm")
+
+    def single_operation_mode_off(self):
+        self.events.append("resume")
+
+
+def test_prepare_vehicle_uses_one_download_and_acknowledged_values(tmp_path):
+    managed_path = tmp_path / "managed.params"
+    managed_path.write_text("MANAGED_VALUE 2\n")
+    parameters = FakeParameters(_healthy_parameters())
+    drone = FakeDrone(parameters)
+
+    report = prepare_vehicle_parameters(drone, managed_path)
+
+    assert report.ok, report.errors
+    assert drone.downloads == 1
+    assert drone.events == ["download", "pause", "disarm", "resume"]
+    assert parameters.loaded_path == managed_path
+    assert parameters.diffed_path == managed_path
+    assert parameters["MANAGED_VALUE"] == 2
+
+
+def test_prepare_vehicle_fails_closed_on_unverified_parameter(tmp_path):
+    managed_path = tmp_path / "managed.params"
+    managed_path.write_text("MANAGED_VALUE 2\n")
+    drone = FakeDrone(
+        FakeParameters(_healthy_parameters(), differences=1)
+    )
+
+    with pytest.raises(VehicleParameterVerificationError, match="1 differences"):
+        prepare_vehicle_parameters(drone, managed_path)
+
+
+def test_prepare_vehicle_restores_message_processing_after_write_error(tmp_path):
+    managed_path = tmp_path / "managed.params"
+    managed_path.write_text("MANAGED_VALUE 2\n")
+    drone = FakeDrone(
+        FakeParameters(_healthy_parameters(), load_error=RuntimeError("write failed"))
+    )
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        prepare_vehicle_parameters(drone, managed_path)
+
+    assert drone.events == ["download", "pause", "disarm", "resume"]

--- a/tests/test_rover_capture_profile.py
+++ b/tests/test_rover_capture_profile.py
@@ -158,15 +158,16 @@ def test_boot_launcher_gates_collection_on_fresh_compass_policy_report():
 
 def test_production_parameter_sync_uses_one_combined_mavlink_session():
     launcher = (ROVER_ROOT / "drone_run.sh").read_text()
-    sync_body = launcher.split("sync_vehicle_configuration() {", 1)[1].split(
-        "\n}", 1
-    )[0]
+    sync_body = launcher.split("sync_vehicle_configuration() {", 1)[1].split("\n}", 1)[
+        0
+    ]
 
     assert "--prepare-vehicle-params" in sync_body
     assert '--compass-policy-json "$COMPASS_READY_FILE"' in sync_body
     assert "--load-params" not in sync_body
     assert "--diff-params" not in sync_body
     assert "--save-params" not in sync_body
+    assert "verify_compass_policy_read_only" in sync_body
 
 
 def test_stock_firmware_restore_is_an_explicit_opt_out():

--- a/tests/test_rover_capture_profile.py
+++ b/tests/test_rover_capture_profile.py
@@ -134,6 +134,31 @@ def test_fresh_setup_installs_and_enables_loader_with_mavlink():
     assert "mavlink_controller.service" in enabled_block
 
 
+def test_boot_launcher_gates_collection_on_fresh_compass_policy_report():
+    launcher = (ROVER_ROOT / "drone_run.sh").read_text()
+    assert 'COMPASS_READY_FILE="/home/pi/compass_ready.json"' in launcher
+    assert "compass_policy.py" in launcher
+    assert '--save-params "$COMPASS_PARAMS_FILE"' in launcher
+    assert 'rm -f -- "$COMPASS_READY_FILE"' in launcher
+    assert '--json-output "$COMPASS_READY_FILE"' in launcher
+
+    main_body = launcher.rsplit("main() {", 1)[1]
+    production_body = main_body.split("while true; do", 1)[0]
+    assert production_body.index("sync_vehicle_configuration") < production_body.index(
+        "verify_compass_policy"
+    )
+    assert production_body.index("verify_compass_policy") < production_body.index(
+        "sync_gps_time"
+    )
+
+    validation_block = production_body.split(
+        'if is_true "$BOOT_VALIDATE_ONLY"; then', 1
+    )[1].split("fi", 1)[0]
+    assert validation_block.index("read_only_vehicle_gate") < validation_block.index(
+        "verify_compass_policy"
+    )
+
+
 def test_stock_firmware_restore_is_an_explicit_opt_out():
     configure = (ROVER_ROOT / "configure_direct_usb_boot.sh").read_text()
     assert "production-default" in configure

--- a/tests/test_rover_capture_profile.py
+++ b/tests/test_rover_capture_profile.py
@@ -138,7 +138,6 @@ def test_boot_launcher_gates_collection_on_fresh_compass_policy_report():
     launcher = (ROVER_ROOT / "drone_run.sh").read_text()
     assert 'COMPASS_READY_FILE="/home/pi/compass_ready.json"' in launcher
     assert "compass_policy.py" in launcher
-    assert '--save-params "$COMPASS_PARAMS_FILE"' in launcher
     assert 'rm -f -- "$COMPASS_READY_FILE"' in launcher
     assert '--json-output "$COMPASS_READY_FILE"' in launcher
 
@@ -146,9 +145,6 @@ def test_boot_launcher_gates_collection_on_fresh_compass_policy_report():
     production_body = main_body.split("while true; do", 1)[0]
     post_validation = production_body.rsplit("    fi\n", 1)[1]
     assert post_validation.index("sync_vehicle_configuration") < post_validation.index(
-        "verify_compass_policy"
-    )
-    assert post_validation.index("verify_compass_policy") < post_validation.index(
         "sync_gps_time"
     )
 
@@ -156,8 +152,21 @@ def test_boot_launcher_gates_collection_on_fresh_compass_policy_report():
         'if is_true "$BOOT_VALIDATE_ONLY"; then', 1
     )[1].split("fi", 1)[0]
     assert validation_block.index("read_only_vehicle_gate") < validation_block.index(
-        "verify_compass_policy"
+        "verify_compass_policy_read_only"
     )
+
+
+def test_production_parameter_sync_uses_one_combined_mavlink_session():
+    launcher = (ROVER_ROOT / "drone_run.sh").read_text()
+    sync_body = launcher.split("sync_vehicle_configuration() {", 1)[1].split(
+        "\n}", 1
+    )[0]
+
+    assert "--prepare-vehicle-params" in sync_body
+    assert '--compass-policy-json "$COMPASS_READY_FILE"' in sync_body
+    assert "--load-params" not in sync_body
+    assert "--diff-params" not in sync_body
+    assert "--save-params" not in sync_body
 
 
 def test_stock_firmware_restore_is_an_explicit_opt_out():

--- a/tests/test_rover_capture_profile.py
+++ b/tests/test_rover_capture_profile.py
@@ -144,10 +144,11 @@ def test_boot_launcher_gates_collection_on_fresh_compass_policy_report():
 
     main_body = launcher.rsplit("main() {", 1)[1]
     production_body = main_body.split("while true; do", 1)[0]
-    assert production_body.index("sync_vehicle_configuration") < production_body.index(
+    post_validation = production_body.rsplit("    fi\n", 1)[1]
+    assert post_validation.index("sync_vehicle_configuration") < post_validation.index(
         "verify_compass_policy"
     )
-    assert production_body.index("verify_compass_policy") < production_body.index(
+    assert post_validation.index("verify_compass_policy") < post_validation.index(
         "sync_gps_time"
     )
 


### PR DESCRIPTION
## Summary

Gate rover collection and motion on a fresh compass-policy attestation.

- invalidate the previous `/home/pi/compass_ready.json`;
- replace the existing load-plus-diff pair with one combined MAVLink session;
- download the complete live parameter set once, apply managed changes, verify
  matching `PARAM_VALUE` acknowledgements, diff the resulting in-memory set,
  and run the device-ID-aware checker against that same set;
- refuse GPS-time synchronization, capture, arming, and motion on failure;
- run the same read-only check in `SPF_BOOT_VALIDATE_ONLY=1`;
- document the boot behavior.

This PR is stacked on `agent/rover-compass-stability`.

## Red / green evidence

- Red commit: `a05120e`
- Green commit: `05ba19d`
- Optimization red commit: `5a006e4`
- Optimization green commit: `7e25b2e`

```text
python -m pytest -q \
  tests/test_rover_capture_profile.py \
  tests/test_mavlink_compass_preflight.py \
  tests/test_rover_compass_policy.py \
  tests/test_mavlink_prearm_check.py

29 passed, 1 warning
```

`bash -n`, Python byte-compilation, and `git diff --check` pass. The full suite
is left to CI.

## Boot-time impact and verification contract

Normal production currently downloads all ArduPilot parameters twice:
`--load-params` and then a separate `--diff-params`. This PR replaces both
with one full download, so compass enforcement adds no normal production boot
delay and should remove approximately one 22–25 second transaction based on
the Rover 1/2 measurements.

The one-session verification remains fail closed:

- unchanged managed values are verified by the initial complete snapshot;
- changed values enter the in-memory set only after matching flight-controller
  `PARAM_VALUE` acknowledgements;
- a final diff must be zero;
- message processing is restored even if a parameter write raises;
- compass policy evaluates the complete resulting set.

`SPF_BOOT_VALIDATE_ONLY=1` and `SPF_SKIP_PARAMETER_SYNC=1` remain read-only and
perform one complete download.

## Rollout hold

Keep this PR in draft until the read-only checker passes on every rover. Rover
1 now passes after its backed-up, disarmed policy repair. Rover 2 still
requires a proper low-interference calibration, and Rover 3 remains under
separate control and was not modified. Deploying this branch fleet-wide now
would intentionally stop Rover 2 and Rover 3 before collection or motion.

The optimized command still needs a timed hardware run when Rover 1 or Rover 2
is reachable again; both became unreachable on the bench network before that
non-motion validation could run.

## Retry and terminal-state behavior

**Fresh verification on every launcher start, but no recurring retry or
automatic repair.** Failure stops the launcher before collection or motion.
The production unit has no `Restart=on-failure`, so it remains stopped until
the compass is corrected and the service is restarted or the rover rebooted.
Rebooting reruns the gate but does not cure a persistent policy failure.
