### PR TITLE
Add fail-closed rover compass policy checks

### DIFF
--- a/data_collection/rover/rover_v3.1/PRE_FIELD_CHECKLIST.md
+++ b/data_collection/rover/rover_v3.1/PRE_FIELD_CHECKLIST.md
@@ -374,6 +374,48 @@ bash data_collection/rover/rover_v3.1/device_mapping.sh > ~/device_mapping
 cat ~/device_mapping
 ```
 
+### 3.1 External-compass policy gate
+
+SPF identifies the GPS-mounted external IST8310 by ArduPilot device ID
+`658953`; it does not assume that the compass remains in slot 1. Stop the
+collection service and run the read-only checker against a fresh parameter
+snapshot:
+
+```bash
+sudo systemctl stop mavlink_controller.service
+data_collection/rover/rover_v3.1/check_compass_policy.sh \
+  --json-output /tmp/spf-compass-policy.json
+python3 -m json.tool /tmp/spf-compass-policy.json
+```
+
+Pass:
+
+- exactly one external compass has device ID `658953`;
+- that external compass is the sole compass enabled for yaw;
+- `COMPASS_PRIO1_ID` is `658953`, and all nonzero priorities are unique and
+  refer to currently detected devices;
+- no empty compass slot is enabled;
+- `COMPASS_CAL_FIT` is the ArduPilot default `16`;
+- `COMPASS_DISBLMSK` is zero, because a driver-wide mask can disable both the
+  internal and external IST8310 on some fleet members;
+- the external offset norm is at most ArduPilot's 500 mG pre-arm limit.
+
+An offset norm from 300 through 500 mG passes ArduPilot's hard limit but emits
+an SPF warning; the project target is below 300 mG. A failure means the Rover
+is not field-ready. Do not make an indoor calibration pass by loosening
+`COMPASS_CAL_FIT`, disabling arming checks, or blindly enabling a numbered
+slot. Recalibrate outdoors with the assembled vehicle away from steel,
+magnets, high-current wiring, SDRs, and the Pi. Then rerun this gate and the
+normal ArduPilot pre-arm check.
+
+For offline diagnosis, evaluate a saved MAVProxy/Mission Planner parameter
+export without opening the vehicle:
+
+```bash
+data_collection/rover/rover_v3.1/check_compass_policy.sh \
+  --params rover.params
+```
+
 If this fails, do not repair a radio during collection boot. In a controlled
 provisioning session, inspect and then explicitly apply the serial-aware plan:
 

--- a/data_collection/rover/rover_v3.1/check_compass_policy.sh
+++ b/data_collection/rover/rover_v3.1/check_compass_policy.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SERVICE_NAME="mavlink_controller.service"
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." && pwd)"
+readonly DEFAULT_PYTHON="/home/pi/spf-virtualenv/bin/python"
+readonly PYTHON_BIN="${SPF_PYTHON:-${DEFAULT_PYTHON}}"
+readonly MAVLINK_CONTROLLER="${REPO_ROOT}/spf/mavlink/mavlink_controller.py"
+readonly POLICY_CHECKER="${REPO_ROOT}/spf/mavlink/compass_policy.py"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  check_compass_policy.sh [checker options]
+  check_compass_policy.sh --params SAVED_PARAMS [checker options]
+
+Without --params, download a fresh parameter snapshot over the rover's one
+ArduPilot serial link and evaluate it without writing flight-controller state.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+    echo "ERROR: Python executable not found: ${PYTHON_BIN}" >&2
+    echo "Set SPF_PYTHON to the SPF virtualenv's Python executable." >&2
+    exit 2
+fi
+
+if [[ "${1:-}" == "--params" ]]; then
+    [[ $# -ge 2 ]] || {
+        echo "ERROR: --params requires a parameter file." >&2
+        exit 2
+    }
+    readonly PARAMETER_FILE="$2"
+    shift 2
+    exec "${PYTHON_BIN}" "${POLICY_CHECKER}" "${PARAMETER_FILE}" "$@"
+fi
+
+if systemctl is-active --quiet "${SERVICE_NAME}"; then
+    echo "ERROR: ${SERVICE_NAME} is active and may own the ArduPilot link." >&2
+    echo "Stop it first: sudo systemctl stop ${SERVICE_NAME}" >&2
+    exit 2
+fi
+
+parameter_file="$(mktemp /tmp/spf-compass-params.XXXXXX)"
+cleanup() {
+    rm -f -- "${parameter_file}"
+}
+trap cleanup EXIT
+
+"${PYTHON_BIN}" "${MAVLINK_CONTROLLER}" --save-params "${parameter_file}"
+"${PYTHON_BIN}" "${POLICY_CHECKER}" "${parameter_file}" "$@"

--- a/spf/mavlink/compass_policy.py
+++ b/spf/mavlink/compass_policy.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Evaluate the Rover fleet's device-ID-aware compass policy.
+
+ArduPilot may enumerate a compass in a different numbered slot after a hardware
+or firmware change.  The policy therefore identifies the external GPS compass
+by device ID and ``COMPASS_EXTERN*`` instead of assuming it is always slot 1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+
+EXPECTED_EXTERNAL_COMPASS_DEVICE_ID = 658953
+DEFAULT_COMPASS_CAL_FIT = 16.0
+MAX_EXTERNAL_OFFSET_NORM_MG = 500.0
+
+
+@dataclass(frozen=True)
+class CompassInstance:
+    """One ArduPilot compass slot."""
+
+    slot: int
+    device_id: int
+    external: bool
+    used_for_yaw: bool
+    offset_x_mg: float
+    offset_y_mg: float
+    offset_z_mg: float
+
+    @property
+    def detected(self) -> bool:
+        return self.device_id != 0
+
+    @property
+    def offset_norm_mg(self) -> float:
+        return math.sqrt(
+            self.offset_x_mg**2 + self.offset_y_mg**2 + self.offset_z_mg**2
+        )
+
+
+@dataclass(frozen=True)
+class CompassPolicyReport:
+    """Fail-closed result of evaluating the fleet compass policy."""
+
+    errors: tuple[str, ...]
+    warnings: tuple[str, ...]
+    instances: tuple[CompassInstance, ...]
+    external_compass: CompassInstance | None
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+    def to_dict(self) -> dict:
+        return {
+            "ok": self.ok,
+            "errors": list(self.errors),
+            "warnings": list(self.warnings),
+            "external_compass": (
+                _instance_to_dict(self.external_compass)
+                if self.external_compass is not None
+                else None
+            ),
+            "instances": [_instance_to_dict(instance) for instance in self.instances],
+        }
+
+
+def _instance_to_dict(instance: CompassInstance) -> dict:
+    return {
+        "slot": instance.slot,
+        "device_id": instance.device_id,
+        "external": instance.external,
+        "used_for_yaw": instance.used_for_yaw,
+        "offset_x_mg": instance.offset_x_mg,
+        "offset_y_mg": instance.offset_y_mg,
+        "offset_z_mg": instance.offset_z_mg,
+        "offset_norm_mg": instance.offset_norm_mg,
+    }
+
+
+def _slot_suffix(slot: int) -> str:
+    return "" if slot == 1 else str(slot)
+
+
+def _external_key(slot: int) -> str:
+    return "COMPASS_EXTERNAL" if slot == 1 else f"COMPASS_EXTERN{slot}"
+
+
+def _number(params: Mapping[str, float], key: str, errors: list[str]) -> float:
+    if key not in params:
+        errors.append(f"missing required parameter {key}")
+        return 0.0
+    try:
+        return float(params[key])
+    except (TypeError, ValueError):
+        errors.append(f"parameter {key} is not numeric: {params[key]!r}")
+        return 0.0
+
+
+def _read_instances(
+    params: Mapping[str, float], errors: list[str]
+) -> tuple[CompassInstance, ...]:
+    instances = []
+    for slot in (1, 2, 3):
+        suffix = _slot_suffix(slot)
+        instances.append(
+            CompassInstance(
+                slot=slot,
+                device_id=int(_number(params, f"COMPASS_DEV_ID{suffix}", errors)),
+                external=bool(_number(params, _external_key(slot), errors)),
+                used_for_yaw=bool(_number(params, f"COMPASS_USE{suffix}", errors)),
+                offset_x_mg=_number(params, f"COMPASS_OFS{suffix}_X", errors),
+                offset_y_mg=_number(params, f"COMPASS_OFS{suffix}_Y", errors),
+                offset_z_mg=_number(params, f"COMPASS_OFS{suffix}_Z", errors),
+            )
+        )
+    return tuple(instances)
+
+
+def evaluate_compass_policy(
+    params: Mapping[str, float],
+    *,
+    expected_external_device_id: int = EXPECTED_EXTERNAL_COMPASS_DEVICE_ID,
+) -> CompassPolicyReport:
+    """Evaluate a parameter snapshot without changing the flight controller."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    instances = _read_instances(params, errors)
+
+    if int(_number(params, "COMPASS_ENABLE", errors)) != 1:
+        errors.append("COMPASS_ENABLE must be 1")
+
+    calibration_fitness = _number(params, "COMPASS_CAL_FIT", errors)
+    if not math.isclose(calibration_fitness, DEFAULT_COMPASS_CAL_FIT):
+        errors.append(
+            f"COMPASS_CAL_FIT={calibration_fitness:g}; "
+            f"fleet policy requires {DEFAULT_COMPASS_CAL_FIT:g}"
+        )
+
+    disabled_driver_mask = int(_number(params, "COMPASS_DISBLMSK", errors))
+    if disabled_driver_mask != 0:
+        errors.append(
+            f"COMPASS_DISBLMSK={disabled_driver_mask}; fleet policy resolves "
+            "individual devices by ID and requires the driver mask to be 0"
+        )
+
+    external_candidates = [
+        instance
+        for instance in instances
+        if instance.device_id == expected_external_device_id and instance.external
+    ]
+    external_compass = external_candidates[0] if len(external_candidates) == 1 else None
+    if not external_candidates:
+        errors.append(
+            "expected external GPS compass "
+            f"device ID {expected_external_device_id} was not detected as external"
+        )
+    elif len(external_candidates) > 1:
+        slots = [instance.slot for instance in external_candidates]
+        errors.append(
+            "external GPS compass device ID "
+            f"{expected_external_device_id} appears in multiple slots: {slots}"
+        )
+
+    for instance in instances:
+        if not instance.detected and instance.used_for_yaw:
+            errors.append(f"empty compass slot {instance.slot} is enabled for yaw")
+        if (
+            instance.detected
+            and external_compass is not None
+            and instance.slot != external_compass.slot
+            and instance.used_for_yaw
+        ):
+            errors.append(
+                f"non-primary compass slot {instance.slot} "
+                f"(device ID {instance.device_id}) is enabled for yaw"
+            )
+
+    if external_compass is not None:
+        if not external_compass.used_for_yaw:
+            errors.append(
+                f"external compass slot {external_compass.slot} is disabled for yaw"
+            )
+        if external_compass.offset_norm_mg <= 0:
+            errors.append(
+                f"external compass slot {external_compass.slot} has no calibration"
+            )
+        elif external_compass.offset_norm_mg > MAX_EXTERNAL_OFFSET_NORM_MG:
+            errors.append(
+                f"external compass slot {external_compass.slot} offset norm "
+                f"{external_compass.offset_norm_mg:.1f} mG exceeds "
+                f"{MAX_EXTERNAL_OFFSET_NORM_MG:.1f} mG"
+            )
+        elif external_compass.offset_norm_mg > 300:
+            warnings.append(
+                f"external compass slot {external_compass.slot} offset norm "
+                f"{external_compass.offset_norm_mg:.1f} mG exceeds the "
+                "project target of 300 mG"
+            )
+
+    priorities = [
+        int(_number(params, f"COMPASS_PRIO{priority}_ID", errors))
+        for priority in (1, 2, 3)
+    ]
+    nonzero_priorities = [device_id for device_id in priorities if device_id]
+    if len(nonzero_priorities) != len(set(nonzero_priorities)):
+        errors.append(f"compass priority IDs are not unique: {priorities}")
+
+    if priorities[0] != expected_external_device_id:
+        errors.append(
+            f"compass priority 1 is device ID {priorities[0]}, expected "
+            f"external device ID {expected_external_device_id}"
+        )
+
+    detected_ids = {instance.device_id for instance in instances if instance.detected}
+    stale_priorities = [
+        device_id for device_id in nonzero_priorities if device_id not in detected_ids
+    ]
+    if stale_priorities:
+        errors.append(
+            f"compass priority list contains undetected device IDs: {stale_priorities}"
+        )
+
+    return CompassPolicyReport(
+        errors=tuple(dict.fromkeys(errors)),
+        warnings=tuple(dict.fromkeys(warnings)),
+        instances=instances,
+        external_compass=external_compass,
+    )
+
+
+def parse_parameter_file(path: str | Path) -> dict[str, float]:
+    """Parse MAVProxy whitespace or Mission Planner CSV parameter exports."""
+    params: dict[str, float] = {}
+    with Path(path).open(encoding="utf-8") as parameter_file:
+        for line_number, raw_line in enumerate(parameter_file, start=1):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            fields = [field for field in re.split(r"[\s,]+", line) if field]
+            if len(fields) < 2:
+                raise ValueError(
+                    f"{path}:{line_number}: expected PARAMETER VALUE, got {line!r}"
+                )
+            try:
+                params[fields[0]] = float(fields[1])
+            except ValueError as error:
+                raise ValueError(
+                    f"{path}:{line_number}: invalid value {fields[1]!r}"
+                ) from error
+    return params
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Evaluate a saved ArduPilot parameter snapshot against the Rover "
+            "fleet's external-compass policy. This command is read-only."
+        )
+    )
+    parser.add_argument("parameter_file")
+    parser.add_argument(
+        "--json-output",
+        help="Write the complete machine-readable report to this path.",
+    )
+    parser.add_argument(
+        "--expected-device-id",
+        type=int,
+        default=EXPECTED_EXTERNAL_COMPASS_DEVICE_ID,
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = get_parser().parse_args(argv)
+    try:
+        params = parse_parameter_file(args.parameter_file)
+    except (OSError, ValueError) as error:
+        print(f"ERROR: {error}")
+        return 2
+
+    report = evaluate_compass_policy(
+        params,
+        expected_external_device_id=args.expected_device_id,
+    )
+    if args.json_output:
+        output_path = Path(args.json_output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(report.to_dict(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    if report.external_compass is not None:
+        external = report.external_compass
+        print(
+            f"External compass: slot {external.slot}, "
+            f"device ID {external.device_id}, "
+            f"offset norm {external.offset_norm_mg:.1f} mG"
+        )
+    for warning in report.warnings:
+        print(f"WARNING: {warning}")
+    for error in report.errors:
+        print(f"FAIL: {error}")
+
+    if report.ok:
+        print("PASS: external GPS compass is the sole fleet-approved yaw source")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_rover_compass_policy.py
+++ b/tests/test_rover_compass_policy.py
@@ -1,0 +1,134 @@
+import math
+
+from spf.mavlink.compass_policy import (
+    DEFAULT_COMPASS_CAL_FIT,
+    EXPECTED_EXTERNAL_COMPASS_DEVICE_ID,
+    evaluate_compass_policy,
+    parse_parameter_file,
+)
+
+
+def _healthy_params(*, external_slot=1):
+    params = {
+        "COMPASS_ENABLE": 1,
+        "COMPASS_CAL_FIT": DEFAULT_COMPASS_CAL_FIT,
+        "COMPASS_DISBLMSK": 0,
+        "COMPASS_PRIO1_ID": EXPECTED_EXTERNAL_COMPASS_DEVICE_ID,
+        "COMPASS_PRIO2_ID": 131594,
+        "COMPASS_PRIO3_ID": 0,
+    }
+    for slot in (1, 2, 3):
+        suffix = "" if slot == 1 else str(slot)
+        external_key = "COMPASS_EXTERNAL" if slot == 1 else f"COMPASS_EXTERN{slot}"
+        params.update(
+            {
+                f"COMPASS_DEV_ID{suffix}": 0,
+                f"COMPASS_USE{suffix}": 0,
+                external_key: 0,
+                f"COMPASS_OFS{suffix}_X": 0,
+                f"COMPASS_OFS{suffix}_Y": 0,
+                f"COMPASS_OFS{suffix}_Z": 0,
+            }
+        )
+
+    suffix = "" if external_slot == 1 else str(external_slot)
+    external_key = (
+        "COMPASS_EXTERNAL"
+        if external_slot == 1
+        else f"COMPASS_EXTERN{external_slot}"
+    )
+    params.update(
+        {
+            f"COMPASS_DEV_ID{suffix}": EXPECTED_EXTERNAL_COMPASS_DEVICE_ID,
+            f"COMPASS_USE{suffix}": 1,
+            external_key: 1,
+            f"COMPASS_OFS{suffix}_X": -19,
+            f"COMPASS_OFS{suffix}_Y": 156,
+            f"COMPASS_OFS{suffix}_Z": -82,
+        }
+    )
+
+    internal_slot = 2 if external_slot != 2 else 1
+    suffix = "" if internal_slot == 1 else str(internal_slot)
+    params[f"COMPASS_DEV_ID{suffix}"] = 131594
+    return params
+
+
+def test_accepts_external_compass_in_any_slot():
+    for slot in (1, 2, 3):
+        report = evaluate_compass_policy(_healthy_params(external_slot=slot))
+
+        assert report.ok, report.errors
+        assert report.external_compass.slot == slot
+        assert math.isclose(report.external_compass.offset_norm_mg, 177.99, abs_tol=0.1)
+
+
+def test_rejects_empty_enabled_slot_and_disabled_external_compass():
+    params = _healthy_params(external_slot=3)
+    params["COMPASS_USE"] = 1
+    params["COMPASS_USE3"] = 0
+
+    report = evaluate_compass_policy(params)
+
+    assert not report.ok
+    assert "empty compass slot 1 is enabled for yaw" in report.errors
+    assert "external compass slot 3 is disabled for yaw" in report.errors
+
+
+def test_rejects_large_external_offsets():
+    params = _healthy_params()
+    params.update(
+        {
+            "COMPASS_OFS_X": -147.5,
+            "COMPASS_OFS_Y": -501.7,
+            "COMPASS_OFS_Z": 639.4,
+        }
+    )
+
+    report = evaluate_compass_policy(params)
+
+    assert not report.ok
+    assert report.external_compass.offset_norm_mg > 800
+    assert any("exceeds 500.0 mG" in error for error in report.errors)
+
+
+def test_rejects_permissive_calibration_and_duplicate_priorities():
+    params = _healthy_params()
+    params["COMPASS_CAL_FIT"] = 100
+    params["COMPASS_PRIO2_ID"] = EXPECTED_EXTERNAL_COMPASS_DEVICE_ID
+
+    report = evaluate_compass_policy(params)
+
+    assert not report.ok
+    assert any("COMPASS_CAL_FIT=100" in error for error in report.errors)
+    assert any("priority IDs are not unique" in error for error in report.errors)
+
+
+def test_rejects_driver_mask_and_wrong_primary_priority():
+    params = _healthy_params()
+    params["COMPASS_DISBLMSK"] = 1 << 7
+    params["COMPASS_PRIO1_ID"] = 131594
+
+    report = evaluate_compass_policy(params)
+
+    assert not report.ok
+    assert any("COMPASS_DISBLMSK" in error for error in report.errors)
+    assert any("priority 1" in error for error in report.errors)
+
+
+def test_parse_parameter_file_supports_mavproxy_and_csv(tmp_path):
+    path = tmp_path / "rover.params"
+    path.write_text(
+        """
+# comment
+COMPASS_ENABLE 1
+COMPASS_CAL_FIT,16
+COMPASS_OFS_X -19.5
+""".lstrip()
+    )
+
+    assert parse_parameter_file(path) == {
+        "COMPASS_ENABLE": 1.0,
+        "COMPASS_CAL_FIT": 16.0,
+        "COMPASS_OFS_X": -19.5,
+    }

--- a/tests/test_rover_compass_policy.py
+++ b/tests/test_rover_compass_policy.py
@@ -1,9 +1,11 @@
 import math
+import json
 
 from spf.mavlink.compass_policy import (
     DEFAULT_COMPASS_CAL_FIT,
     EXPECTED_EXTERNAL_COMPASS_DEVICE_ID,
     evaluate_compass_policy,
+    main,
     parse_parameter_file,
 )
 
@@ -33,9 +35,7 @@ def _healthy_params(*, external_slot=1):
 
     suffix = "" if external_slot == 1 else str(external_slot)
     external_key = (
-        "COMPASS_EXTERNAL"
-        if external_slot == 1
-        else f"COMPASS_EXTERN{external_slot}"
+        "COMPASS_EXTERNAL" if external_slot == 1 else f"COMPASS_EXTERN{external_slot}"
     )
     params.update(
         {
@@ -60,7 +60,7 @@ def test_accepts_external_compass_in_any_slot():
 
         assert report.ok, report.errors
         assert report.external_compass.slot == slot
-        assert math.isclose(report.external_compass.offset_norm_mg, 177.99, abs_tol=0.1)
+        assert math.isclose(report.external_compass.offset_norm_mg, 177.26, abs_tol=0.1)
 
 
 def test_rejects_empty_enabled_slot_and_disabled_external_compass():
@@ -132,3 +132,18 @@ COMPASS_OFS_X -19.5
         "COMPASS_CAL_FIT": 16.0,
         "COMPASS_OFS_X": -19.5,
     }
+
+
+def test_cli_writes_machine_readable_report(tmp_path, capsys):
+    params_path = tmp_path / "healthy.params"
+    params_path.write_text(
+        "\n".join(f"{key} {value}" for key, value in _healthy_params().items())
+    )
+    report_path = tmp_path / "report.json"
+
+    assert main([str(params_path), "--json-output", str(report_path)]) == 0
+    report = json.loads(report_path.read_text())
+
+    assert report["ok"] is True
+    assert report["external_compass"]["device_id"] == 658953
+    assert "PASS: external GPS compass" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Add a read-only, fail-closed compass policy checker for the Rover fleet.

- locate the GPS-mounted external IST8310 by device ID `658953` and external
  flag instead of assuming a numbered ArduPilot slot;
- require it to be the sole yaw source and priority 1;
- reject empty enabled slots, duplicate/stale priorities, driver-wide disable
  masks, permissive `COMPASS_CAL_FIT`, and offsets above 500 mG;
- warn above the project target of 300 mG;
- emit a machine-readable JSON attestation;
- fetch a fresh parameter snapshot through the existing rover tooling without
  writing flight-controller state;
- document field pass/fail and outdoor recalibration requirements.

## Red / green evidence

- Red commit: `05adb20`
- Green commit: `30ed3f4`

```text
python -m pytest -q \
  tests/test_rover_compass_policy.py \
  tests/test_mavlink_prearm_check.py

10 passed, 1 warning
```

Black, `bash -n`, and `git diff --check` pass. The full suite is left to CI.

## Fleet evidence

- Rover 1 initially had the correct external device and healthy 177.9 mG
  offsets, but the external compass was disabled while an internal and an empty
  slot were enabled. After a backed-up, disarmed minimal policy repair, a fresh
  885-parameter download passes the checker;
- Rover 2 has the correct sole external yaw source, but still fails on 826.0 mG
  offsets and a stale priority entry. Only `COMPASS_CAL_FIT=16` was applied; it
  remains deliberately blocked pending proper calibration;
- Rover 3: 848.3 mG external offsets, disabled external yaw source, an enabled
  empty slot, and duplicate/wrong priorities.

The PR itself does not write rover parameters. Rover 3 was inspected read-only.

## Rollout

Use this checker first. Remediate and calibrate each physical rover, then merge
the separate boot-gate PR only when its report is green. Do not calibrate
indoors or weaken ArduPilot arming checks to obtain a pass.

## Retry and terminal-state behavior

**Read-only fail-closed diagnostic.** It evaluates one complete snapshot,
writes JSON, and exits nonzero on a violation. It performs no retry or repair.
An operator must correct parameters or perform a low-interference calibration
and rerun it.
