### PR TITLE
Fix pymavlink pre-arm command compatibility

### DIFF
--- a/spf/mavlink/check_prearm.py
+++ b/spf/mavlink/check_prearm.py
@@ -61,6 +61,7 @@ def run_prearm_checks(connection, timeout_s: float = 8.0) -> PrearmResult:
         0,
         0,
         0,
+        0,
     )
 
     command_result = None

--- a/tests/test_mavlink_prearm_check.py
+++ b/tests/test_mavlink_prearm_check.py
@@ -14,8 +14,35 @@ class FakeMav:
     def __init__(self):
         self.commands = []
 
-    def command_long_send(self, *args):
-        self.commands.append(args)
+    def command_long_send(
+        self,
+        target_system,
+        target_component,
+        command,
+        confirmation,
+        param1,
+        param2,
+        param3,
+        param4,
+        param5,
+        param6,
+        param7,
+    ):
+        self.commands.append(
+            (
+                target_system,
+                target_component,
+                command,
+                confirmation,
+                param1,
+                param2,
+                param3,
+                param4,
+                param5,
+                param6,
+                param7,
+            )
+        )
 
 
 class FakeConnection:
@@ -67,6 +94,7 @@ def test_prearm_pass_uses_ack_and_health_bit():
     )
     assert result.passed
     assert connection.mav.commands[0][2] == PREARM_COMMAND
+    assert connection.mav.commands[0][3:] == (0,) * 8
 
 
 def test_prearm_failure_collects_unique_failure_messages():


### PR DESCRIPTION
## Summary

Send all seven required command parameters for
`MAV_CMD_RUN_PREARM_CHECKS` and make the test double enforce the real
pymavlink method signature.

## Root cause

The checker passed only six command parameters. The permissive `*args` unit
test double accepted the malformed call, but the installed rover pymavlink
raised:

```text
TypeError: MAVLink.command_long_send() missing 1 required positional argument: 'param7'
```

## Red / green evidence

- Red commit: `a88b136`
- Green commit: `9de9b13`

```text
python -m pytest -q tests/test_mavlink_prearm_check.py
3 passed, 1 warning
```

Black and `git diff --check` pass. The full suite remains delegated to CI.

## Hardware evidence

The fixed script was copied to `/tmp` and run without installation on Rover 1
and Rover 2. Both received a real heartbeat, ArduPilot accepted the command,
and the authoritative pre-arm health bit reported PASS. Neither rover was
armed, rebooted, or moved.

## Retry and terminal-state behavior

**Diagnostic compatibility fix only.** The checker reports pass, confirmed
failure, or inconclusive status and exits. It never changes parameters, arms
the rover, retries a failed condition, or repairs the reported problem.
