### PR TITLE
Speed rover boot to navigation wait

### DIFF
--- a/data_collection/rover/rover_v3.1/ROVER_BOOT_PROFILING.md
+++ b/data_collection/rover/rover_v3.1/ROVER_BOOT_PROFILING.md
@@ -1,0 +1,145 @@
+# Rover 3.1 Boot Profiling
+
+This document defines the boot endpoint, shows the measured Rover 2 and Rover 3
+critical paths, and records the safe optimizations applied in PR #13.
+
+## Endpoint
+
+For indoor, repeatable testing, boot is considered ready when
+`mavlink_radio_collection.py` first logs:
+
+```text
+Drone startup wait for drone ready: ...
+```
+
+This proves that firmware preparation, radio attestation, repository checking,
+vehicle-parameter verification, and MAVLink startup completed. GPS fix, EKF
+health, and GUIDED readiness are not suitable indoor timing endpoints because
+they depend on sky view and vehicle state.
+
+## Measured baseline
+
+All times below are monotonic seconds since kernel boot.
+
+| Milestone | Rover 2, one Pluto | Rover 3, two Plutos |
+|---|---:|---:|
+| Pluto preparation starts | 10.1 | 10.0 |
+| Pluto preparation completes | 21.2 | 31.4 |
+| Parameter verification completes | 103.6 | 59.5 |
+| GPS-time helper completes | Did not; manually stopped at 211.2 | 62.4 |
+| First indoor GPS/EKF wait | About 231.6 after manual stop | 85.4 |
+
+Rover 2 spent about 53 seconds updating packages and reinstalling an unchanged
+SPF checkout, then entered a 180-second GPS-time wait. Rover 3 already had GPS
+UTC and therefore did not pay the timeout, but heavy imports still preceded the
+first readiness message.
+
+## Optimized behavior
+
+The normal boot path now:
+
+1. Performs the repository update check.
+2. Skips `apt` and `pip install -e` when `HEAD` is unchanged.
+3. Performs the full dependency refresh, editable install, unit reconciliation,
+   and reboot when an update actually changes `HEAD`.
+4. Verifies all committed vehicle parameters exactly as before.
+5. Uses a plausible RTC/NTP system time for boot filenames and defers GPS UTC
+   refresh until after a successful capture.
+6. Starts MAVLink readiness reporting before importing the heavy collector,
+   Torch, Zarr, and SDR modules.
+7. Emits the GPS-time tune once when that helper is explicitly needed, rather
+   than once per polling iteration.
+
+No firmware, radio, parameter, update, GPS-time, or collection function is
+removed.
+
+## Rover 2 result
+
+On commit `920bc6380a03ebf88b70166866aa415d676b0206`, a complete Rover 2
+reboot reached the indoor GPS/EKF wait at 56.3 seconds:
+
+| Milestone | Seconds since kernel boot |
+|---|---:|
+| Pluto preparation completes | 20.0 |
+| Unchanged repository check completes | 22.0 |
+| Parameter verification reports zero differences | 46.3 |
+| GPS UTC is deferred due to plausible clock | 46.8 |
+| First indoor GPS/EKF wait | 56.3 |
+
+Compared with the approximately 231-second pre-change path, this is about 175
+seconds faster (76%).
+
+## Audible-tone verification
+
+A RØDE VideoMic GO II (`19f7:001c`) was used as an independent check.
+Recordings were made at 48 kHz, mono, signed 16-bit:
+
+```bash
+arecord -q -D hw:3,0 -f S16_LE -r 48000 -c 1 \
+  -d 150 /tmp/rover2_boot.wav
+```
+
+The test captured:
+
+- a 15-second quiet baseline;
+- one deliberately requested GPS tune;
+- the old `--get-time` loop, which produced repeating matching tone clusters
+  until the process was terminated;
+- a patched 150-second full reboot.
+
+The patched full reboot had only bounded startup/parameter notification groups,
+all ending by 45.3 seconds, and no matching GPS-tune clusters after 60 seconds.
+
+## Profiling commands
+
+Show the current boot milestones:
+
+```bash
+sudo journalctl -b \
+  -u spf-pluto-direct-usb.service \
+  -u mavlink_controller.service \
+  --no-pager -o short-monotonic
+```
+
+Show the current state:
+
+```bash
+systemctl is-active \
+  spf-pluto-direct-usb.service \
+  mavlink_controller.service
+```
+
+Measure the systemd portion:
+
+```bash
+systemd-analyze
+systemd-analyze critical-chain mavlink_controller.service
+```
+
+## Remaining bottlenecks
+
+The largest remaining measured costs are:
+
+- Pluto preparation: about 11 seconds for one radio and 21 seconds for two;
+- full MAVLink parameter download/verification: about 18–28 seconds;
+- cold lightweight collection startup: about 10 seconds on Rover 2.
+
+Future work should preserve exact verification. The safest next architectural
+optimization is to run independent Pluto preparation and vehicle-parameter
+verification in parallel, then gate collection on both successful results.
+
+## Rollback
+
+PR #13 is isolated on `agent/boot-critical-path`. To return a test rover to
+production after validation:
+
+```bash
+sudo systemctl stop mavlink_controller.service
+git -C /home/pi/spf checkout main
+git -C /home/pi/spf pull --ff-only
+sudo systemctl restart spf-pluto-direct-usb.service
+sudo systemctl start mavlink_controller.service
+```
+
+Restarting the Pluto service is required after changing SPF commits because the
+ready manifest intentionally records and verifies `spf_git_sha`.

--- a/data_collection/rover/rover_v3.1/drone_run.sh
+++ b/data_collection/rover/rover_v3.1/drone_run.sh
@@ -154,23 +154,25 @@ maybe_self_update() {
         printf 'No internet connectivity; continuing with checked-out code.\n'
         return 0
     fi
-    sleep 3  # brief settle before apt/git, only when actually online
-
-    "$PYTHON" "$MAVLINK_CONTROLLER" --buzzer git
     printf 'Checking for repository updates.\n'
-    bash "${SCRIPT_DIR}/install_deps.sh"
     current_hash="$(git -C "$REPO_ROOT" rev-parse --verify HEAD)"
     git -C "$REPO_ROOT" pull --ff-only
     new_hash="$(git -C "$REPO_ROOT" rev-parse --verify HEAD)"
-    if [[ "$current_hash" != "$new_hash" ]]; then
-        printf 'Repository updated; reconciling boot units before reboot.\n'
-        reconcile_boot_units_or_reboot
-        printf 'Repository changed without boot-unit drift; rebooting.\n'
-        sleep 15
-        sudo reboot
-        exit 0
+    if [[ "$current_hash" == "$new_hash" ]]; then
+        printf 'Repository is unchanged; skipping dependency reinstall.\n'
+        return 0
     fi
+
+    "$PYTHON" "$MAVLINK_CONTROLLER" --buzzer git
+    printf 'Repository updated; refreshing dependencies and editable install.\n'
+    bash "${SCRIPT_DIR}/install_deps.sh"
     "$PYTHON" -m pip install -e "$REPO_ROOT"
+    printf 'Repository updated; reconciling boot units before reboot.\n'
+    reconcile_boot_units_or_reboot
+    printf 'Repository changed without boot-unit drift; rebooting.\n'
+    sleep 15
+    sudo reboot
+    exit 0
 }
 
 wait_for_radios() {
@@ -225,7 +227,20 @@ sync_vehicle_configuration() {
     fi
 }
 
+system_clock_is_plausible() {
+    # Raspberry Pi 5 has an RTC and may also have NTP. A plausible clock is
+    # sufficient for boot filenames; GPS UTC is refreshed after a completed
+    # capture, when the vehicle necessarily has a usable navigation solution.
+    [[ "$(date +%s)" -ge 1735689600 ]]  # 2025-01-01T00:00:00Z
+}
+
 sync_gps_time() {
+    local phase="${1:-capture}"
+    if [[ "$phase" == "boot" ]] && system_clock_is_plausible; then
+        printf '%s\n' \
+            'System clock is plausible; deferring GPS UTC refresh until after capture.'
+        return 0
+    fi
     # --get-time blocks until the FC has GPS UTC time. Bound the first attempt so
     # a no-sky / cold-TTFF boot cannot hang forever before the governor and
     # capture loop; the loop below keeps re-syncing and sets the clock the moment
@@ -292,7 +307,7 @@ main() {
     fi
 
     sync_vehicle_configuration
-    sync_gps_time
+    sync_gps_time boot
     printf 'performance\n' | sudo tee \
         /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor >/dev/null
 
@@ -300,7 +315,7 @@ main() {
         run_capture
         is_true "$RUN_ONCE" && break
         sleep 8
-        sync_gps_time
+        sync_gps_time capture
         sleep 2
     done
 }

--- a/spf/mavlink/mavlink_controller.py
+++ b/spf/mavlink/mavlink_controller.py
@@ -1235,7 +1235,6 @@ def mavlink_controller_run(args):
             # 1970 timestamp; drone_run.sh sync_gps_time guards `date -s` against
             # that so the system clock is never set to 1970 (poll shortened 5->1s).
             while drone.gps_time == 0 and drone.gps_fix_type != "GPS_FIX_TYPE_3D_FIX":
-                drone.buzzer(tones["gps-time"])
                 time.sleep(1)
 
             gps_time = datetime.fromtimestamp(drone.gps_time).strftime(

--- a/spf/mavlink_radio_collection.py
+++ b/spf/mavlink_radio_collection.py
@@ -9,18 +9,10 @@ from datetime import datetime
 import yaml
 from pymavlink import mavutil
 
-from spf.data_collector import (
-    DroneDataCollectorRaw,
-    DroneDataCollectorRawV6,
-    DroneDataCollectorRawV7,
-)
 from spf.capture_schema import (
     normalize_capture_config,
     validate_transport_schema,
 )
-from spf.dataset.spf_dataset import training_only_keys, v5inferencedataset
-from spf.dataset.spf_nn_dataset_wrapper import v5spfdataset_nn_wrapper
-from spf.distance_finder.distance_finder_controller import DistanceFinderController
 from spf.gps.boundaries import boundaries  # crissy_boundary_convex
 from spf.gps.boundaries import find_closest_boundary
 from spf.mavlink.mavlink_controller import (
@@ -28,7 +20,6 @@ from spf.mavlink.mavlink_controller import (
     drone_get_planner,
     get_ardupilot_serial,
 )
-from spf.scripts.train_utils import load_config_from_fn
 from spf.utils import (
     DataVersionNotImplemented,
     filenames_from_time_in_seconds,
@@ -223,6 +214,10 @@ if __name__ == "__main__":
     # A fake-drone run must be hardware-independent.  In particular, do not
     # initialize RPi.GPIO merely because the tests happen to run on a Pi.
     if is_pi() and args.ultrasonic and not args.fake_drone:
+        from spf.distance_finder.distance_finder_controller import (
+            DistanceFinderController,
+        )
+
         distance_finder = DistanceFinderController(
             trigger=yaml_config["distance-finder"]["trigger"],
             echo=yaml_config["distance-finder"]["echo"],
@@ -257,6 +252,16 @@ if __name__ == "__main__":
         )
         time.sleep(2)
 
+    # The collector imports NumPy/Torch, Zarr, and the SDR stack. Keep them off
+    # the preflight critical path so MAVLink status and readiness monitoring
+    # begin promptly after boot. Collector construction remains in the same
+    # place below, after navigation readiness and planner setup.
+    from spf.data_collector import (
+        DroneDataCollectorRaw,
+        DroneDataCollectorRawV6,
+        DroneDataCollectorRawV7,
+    )
+
     boundary_name = yaml_config.get("boundary", "franklin_safe")
     if boundary_name == "auto":
         # find out which one is closest
@@ -280,6 +285,8 @@ if __name__ == "__main__":
 
     if args.checkpoint:
         # load model config and use that theta
+        from spf.scripts.train_utils import load_config_from_fn
+
         config = load_config_from_fn(args.checkpoint_config)
         assert args.nthetas is None, "nthetas cannot be set when loading checkpoint"
         args.nthetas = config["global"]["nthetas"]
@@ -288,6 +295,9 @@ if __name__ == "__main__":
         args.nthetas = 65
 
     if args.realtime:
+        from spf.dataset.spf_dataset import training_only_keys, v5inferencedataset
+        from spf.dataset.spf_nn_dataset_wrapper import v5spfdataset_nn_wrapper
+
         v5inf = v5inferencedataset(
             yaml_fn=temp_filenames["yaml"],
             nthetas=args.nthetas,

--- a/tests/test_rover_boot_critical_path.py
+++ b/tests/test_rover_boot_critical_path.py
@@ -1,0 +1,64 @@
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROVER_ROOT = REPO_ROOT / "data_collection/rover/rover_v3.1"
+
+
+def test_unchanged_checkout_skips_dependency_reinstall():
+    launcher = (ROVER_ROOT / "drone_run.sh").read_text()
+    update_body = launcher.split("maybe_self_update() {", 1)[1].split(
+        "\n}\n", 1
+    )[0]
+
+    unchanged_guard = 'if [[ "$current_hash" == "$new_hash" ]]'
+    assert unchanged_guard in update_body
+    assert update_body.index(unchanged_guard) < update_body.index("install_deps.sh")
+    guard_body = update_body.split(unchanged_guard, 1)[1].split("fi", 1)[0]
+    assert "return 0" in guard_body
+
+
+def test_plausible_clock_defers_blocking_gps_time_sync_at_boot():
+    launcher = (ROVER_ROOT / "drone_run.sh").read_text()
+
+    assert "system_clock_is_plausible" in launcher
+    assert "sync_gps_time boot" in launcher
+    assert "sync_gps_time capture" in launcher
+    sync_body = launcher.split("sync_gps_time() {", 1)[1].split("\n}\n", 1)[0]
+    assert '[[ "$phase" == "boot" ]] && system_clock_is_plausible' in sync_body
+    assert sync_body.index("system_clock_is_plausible") < sync_body.index(
+        'timeout "${SPF_GPS_TIME_TIMEOUT:-180}"'
+    )
+
+
+def test_gps_time_wait_notifies_once_instead_of_beeping_each_poll():
+    source = (REPO_ROOT / "spf/mavlink/mavlink_controller.py").read_text()
+    get_time_body = source.split("if args.get_time is not None:", 1)[1].split(
+        "\n    if (", 1
+    )[0]
+
+    assert get_time_body.count('drone.buzzer(tones["gps-time"])') == 1
+
+
+def test_heavy_collection_imports_are_deferred_until_after_drone_ready_wait():
+    path = REPO_ROOT / "spf/mavlink_radio_collection.py"
+    source = path.read_text()
+    module = ast.parse(source)
+    deferred_modules = {
+        "spf.data_collector",
+        "spf.dataset.spf_dataset",
+        "spf.dataset.spf_nn_dataset_wrapper",
+        "spf.distance_finder.distance_finder_controller",
+        "spf.scripts.train_utils",
+    }
+    eager_imports = {
+        node.module
+        for node in module.body
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    }
+
+    assert deferred_modules.isdisjoint(eager_imports)
+    assert source.index("Drone startup wait for drone ready") < source.index(
+        "from spf.data_collector import"
+    )


### PR DESCRIPTION
## What changed

- Skip `apt` and editable-package reinstall when `git pull --ff-only` leaves the checkout unchanged.
- Preserve the self-update path: when code changes, refresh dependencies, reinstall SPF, reconcile units, and reboot.
- If the system clock is already plausible, defer GPS UTC refresh until after a successful capture instead of blocking boot for up to 180 seconds.
- Make the GPS-time helper sound its tune once, rather than once per polling iteration.
- Defer the heavy collector/Torch/Zarr/SDR imports until after MAVLink has begun reporting vehicle readiness.
- Add focused critical-path regression tests.

## Root cause

On Rover 2, a normal unchanged boot spent roughly 53 seconds running `apt` and `pip install -e`, then entered a 180-second GPS-time wait indoors. The GPS helper emitted its multi-note tune once per second, which sounded like continuous rapid beeping. Heavy collector imports also delayed the first MAVLink GPS/EKF readiness message by about 20 seconds.

## Hardware evidence

Using a RØDE VideoMic GO II, we captured:

- a 15-second quiet baseline with no sustained repeating tone;
- a deliberate single GPS-tune reference;
- a controlled reproduction of the old `--get-time` loop, with repeated matching tone-energy clusters until the process was terminated.

The sound stopped immediately when that helper was terminated.

## Safety and behavior

No boot function is removed. Firmware preparation, radio verification, parameter verification, repository update checks, GPS UTC synchronization, and collection remain present. The normal unchanged/plausible-clock path avoids unnecessary work; actual code changes still trigger dependency refresh and reboot, and GPS time still refreshes after capture.

## Checks

- `bash -n data_collection/rover/rover_v3.1/drone_run.sh`
- `python -m py_compile` on changed Python/test files
- focused `tests/test_rover_boot_critical_path.py`
- `git diff --check`

Full tests are left to CI per the workstation safety constraint.

## Rover 2 validation

Tested on Rover 2 (`192.168.1.42`, one Pluto) with a complete reboot:

- direct-USB firmware preparation completed and the ready manifest verified;
- the unchanged self-update path skipped dependency reinstall;
- parameter verification reported zero differences;
- the plausible system clock deferred the blocking GPS wait;
- first indoor GPS/EKF readiness wait appeared at 56.3 seconds after kernel boot;
- the comparable pre-change timeline was about 231 seconds;
- both production services remained active.

The 150-second microphone capture contained only bounded startup/parameter
notification groups, all ending by 45.3 seconds. It contained zero matching
GPS-tune clusters after 60 seconds.
