### PR TITLE
Alarm and shut down when a radio is missing

### DIFF
--- a/data_collection/rover/rover_v3.1/PRE_FIELD_CHECKLIST.md
+++ b/data_collection/rover/rover_v3.1/PRE_FIELD_CHECKLIST.md
@@ -355,6 +355,10 @@ Also verify:
 - [ ] Rover 1/3 show two Plutos; Rover 2 shows one.
 - [ ] USB physical ports agree with `device_mapping` and the receiver-port
       assignments.
+- [ ] Confirm the 15-second GPS/EKF readiness chirp is audible, or deliberately
+      create `~/disable_annoying_tones` when quiet operation is required.
+- [ ] Confirm operators know that three descending missing-radio alarms are
+      followed by a clean shutdown and require a physical power cycle.
 - [ ] Both channels and antenna cables are connected to every receiver.
 - [ ] YAML antenna spacing equals the measured physical spacing.
 - [ ] Pi Wi-Fi is disabled.

--- a/data_collection/rover/rover_v3.1/ROVER_BOOT_PROFILING.md
+++ b/data_collection/rover/rover_v3.1/ROVER_BOOT_PROFILING.md
@@ -53,6 +53,35 @@ The normal boot path now:
 No firmware, radio, parameter, update, GPS-time, or collection function is
 removed.
 
+## Audible readiness and missing-radio policy
+
+While the collector is waiting for GPS/EKF readiness, it emits one short
+double chirp every 15 seconds. This is a low-duty field indication that the
+rover is alive but not navigation-ready. Disable these periodic readiness
+chirps dynamically with:
+
+```bash
+touch ~/disable_annoying_tones
+```
+
+Remove the file to re-enable them:
+
+```bash
+rm ~/disable_annoying_tones
+```
+
+The disable file does not suppress critical missing-radio alarms. If bounded
+USB discovery finds fewer Plutos than the production YAML configures, boot:
+
+1. logs the expected and observed counts;
+2. plays the distinct descending `radio-missing` alarm exactly three times;
+3. requests a clean, non-blocking system poweroff.
+
+The radios are externally powered, so restarting only the collector cannot
+recover a missing radio. The operator must restore the radio connection and
+power-cycle the rover. An excess-radio count remains a fail-closed
+configuration error and is not misreported as a missing-radio condition.
+
 ## Rover 2 result
 
 On commit `920bc6380a03ebf88b70166866aa415d676b0206`, a complete Rover 2

--- a/data_collection/rover/rover_v3.1/prepare_direct_usb_boot.sh
+++ b/data_collection/rover/rover_v3.1/prepare_direct_usb_boot.sh
@@ -9,6 +9,7 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_DIR
 readonly LOADER="${SCRIPT_DIR}/load_direct_usb_firmware.sh"
 readonly MAPPING_SCRIPT="${SCRIPT_DIR}/device_mapping.sh"
+readonly RADIO_MISSING_HANDLER="${SCRIPT_DIR}/radio_missing_shutdown.sh"
 readonly READY_FILE="${SPF_DIRECT_USB_READY_FILE:-/run/spf/direct_usb_ready.json}"
 readonly READY_DIR="$(dirname -- "$READY_FILE")"
 
@@ -113,9 +114,12 @@ while true; do
         "$attached_radios" "$configured_radios"
     sleep 1
 done
-[[ "$attached_radios" -gt 0 ]] || die "No runtime Pluto radios are attached."
-[[ "$attached_radios" -eq "$configured_radios" ]] ||
+if [[ "$attached_radios" -lt "$configured_radios" ]]; then
+    "$RADIO_MISSING_HANDLER" "$configured_radios" "$attached_radios"
+    die "Config has ${configured_radios} receivers but only ${attached_radios} Plutos are attached."
+elif [[ "$attached_radios" -gt "$configured_radios" ]]; then
     die "Config has ${configured_radios} receivers but ${attached_radios} Plutos are attached."
+fi
 
 # The persistent AD9361/2r2t configuration is established once during Rover
 # provisioning (check_and_set_pluto.sh); it is NOT re-checked per boot. That

--- a/data_collection/rover/rover_v3.1/radio_missing_shutdown.sh
+++ b/data_collection/rover/rover_v3.1/radio_missing_shutdown.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Audible, fail-closed response when fewer Plutos are attached than configured.
+# Radios are powered outside the Pi, so retrying the collector cannot recover
+# this condition. The operator must restore the radio and power-cycle the rover.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+readonly MAVLINK_CONTROLLER="${SCRIPT_DIR}/../../../spf/mavlink/mavlink_controller.py"
+readonly TONE_REPEATS=3
+
+PYTHON="${SPF_PYTHON:-/home/pi/spf-virtualenv/bin/python3}"
+ACTION="${SPF_RADIO_MISSING_ACTION:-poweroff}"
+TONE_GAP_SECONDS="${SPF_RADIO_MISSING_TONE_GAP_SECONDS:-1}"
+TONE_TIMEOUT_SECONDS="${SPF_RADIO_MISSING_TONE_TIMEOUT_SECONDS:-10}"
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 2
+}
+
+expected_radios="${1:-}"
+found_radios="${2:-}"
+[[ "$expected_radios" =~ ^[1-9][0-9]*$ ]] ||
+    die "expected radio count must be a positive integer"
+[[ "$found_radios" =~ ^[0-9]+$ ]] ||
+    die "found radio count must be a non-negative integer"
+(( found_radios < expected_radios )) ||
+    die "radio-missing handler requires found < expected"
+[[ "$TONE_GAP_SECONDS" =~ ^[0-9]+([.][0-9]+)?$ ]] ||
+    die "SPF_RADIO_MISSING_TONE_GAP_SECONDS must be non-negative"
+[[ "$TONE_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] ||
+    die "SPF_RADIO_MISSING_TONE_TIMEOUT_SECONDS must be a positive integer"
+case "$ACTION" in
+    poweroff|log-only) ;;
+    *) die "SPF_RADIO_MISSING_ACTION must be poweroff or log-only" ;;
+esac
+
+printf 'CRITICAL: found %s of %s configured Pluto radios.\n' \
+    "$found_radios" "$expected_radios" >&2
+printf '%s\n' \
+    'Recovery requires restoring the externally powered radio and power-cycling the rover.' \
+    >&2
+
+for attempt in $(seq 1 "$TONE_REPEATS"); do
+    printf 'Playing radio-missing alarm %s/%s.\n' "$attempt" "$TONE_REPEATS"
+    if ! timeout --foreground "$TONE_TIMEOUT_SECONDS" \
+        "$PYTHON" "$MAVLINK_CONTROLLER" --buzzer radio-missing; then
+        printf 'WARNING: radio-missing alarm %s/%s could not be played.\n' \
+            "$attempt" "$TONE_REPEATS" >&2
+    fi
+    if (( attempt < TONE_REPEATS )); then
+        sleep "$TONE_GAP_SECONDS"
+    fi
+done
+
+if [[ "$ACTION" == "log-only" ]]; then
+    printf 'TEST MODE: system poweroff inhibited.\n'
+    exit 0
+fi
+
+printf 'The three radio-missing alarms completed; requesting clean system poweroff.\n' \
+    >&2
+sync
+systemctl --no-block poweroff

--- a/spf/mavlink/mavlink_controller.py
+++ b/spf/mavlink/mavlink_controller.py
@@ -168,6 +168,10 @@ tones = {
     "wait": "MFT240L8 G P4 < G P4 < G P4 > > G P4 < G P4 < G",
     "ready": "MFT240L8 G P8 < G P8 < G P8 > > G P8 < G P8 < G",
     "failure": "MFT240L8 D D D P4 D D D P4 L8dddddc",
+    # A short, unobtrusive double chirp for the 15-second readiness watchdog.
+    "readiness-wait": "MFT240L8 G P8 G",
+    # Three long descending notes, deliberately unlike the GPS/check tones.
+    "radio-missing": "MFT180L4 A F D P2",
 }
 tones = {k: v.replace(" ", "").encode() for k, v in tones.items()}
 

--- a/spf/mavlink_radio_collection.py
+++ b/spf/mavlink_radio_collection.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import time
 from datetime import datetime
+from pathlib import Path
 
 import yaml
 from pymavlink import mavutil
@@ -19,6 +20,7 @@ from spf.mavlink.mavlink_controller import (
     Drone,
     drone_get_planner,
     get_ardupilot_serial,
+    tones,
 )
 from spf.utils import (
     DataVersionNotImplemented,
@@ -26,6 +28,27 @@ from spf.utils import (
     is_pi,
     load_config,
 )
+
+
+READINESS_TONE_INTERVAL_SECONDS = 15.0
+ANNOYING_TONES_DISABLE_PATH = Path.home() / "disable_annoying_tones"
+
+
+def maybe_play_readiness_wait_tone(
+    drone,
+    *,
+    now: float,
+    next_tone_at: float,
+    disable_path: Path = ANNOYING_TONES_DISABLE_PATH,
+) -> float:
+    """Play one low-duty readiness chirp unless the operator disabled it."""
+    if now < next_tone_at:
+        return next_tone_at
+    while next_tone_at <= now:
+        next_tone_at += READINESS_TONE_INTERVAL_SECONDS
+    if not disable_path.exists():
+        drone.buzzer(tones["readiness-wait"])
+    return next_tone_at
 
 
 def yaml_defaults(yaml_config, device_mapping_fn):
@@ -246,9 +269,15 @@ if __name__ == "__main__":
             ignore_mode=args.ignore_mode,
         )
 
+    next_readiness_tone_at = time.monotonic() + READINESS_TONE_INTERVAL_SECONDS
     while not args.fake_drone and not drone.drone_ready:
         logging.info(
             f"Drone startup wait for drone ready: gps:{str(drone.gps)} , ekf:{str(drone.ekf_healthy)}"
+        )
+        next_readiness_tone_at = maybe_play_readiness_wait_tone(
+            drone,
+            now=time.monotonic(),
+            next_tone_at=next_readiness_tone_at,
         )
         time.sleep(2)
 

--- a/tests/test_radio_missing_shutdown.py
+++ b/tests/test_radio_missing_shutdown.py
@@ -1,0 +1,69 @@
+import os
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROVER_ROOT = REPO_ROOT / "data_collection/rover/rover_v3.1"
+HANDLER = ROVER_ROOT / "radio_missing_shutdown.sh"
+
+
+def test_missing_radio_alarm_plays_exactly_three_times_without_poweroff(tmp_path):
+    call_log = tmp_path / "controller.log"
+    fake_python = tmp_path / "python"
+    fake_python.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf '%s\\n' \"$*\" >>\"$SPF_TEST_CONTROLLER_LOG\"\n"
+    )
+    fake_python.chmod(0o755)
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "SPF_PYTHON": str(fake_python),
+            "SPF_RADIO_MISSING_ACTION": "log-only",
+            "SPF_RADIO_MISSING_TONE_GAP_SECONDS": "0",
+            "SPF_TEST_CONTROLLER_LOG": str(call_log),
+        }
+    )
+
+    result = subprocess.run(
+        [str(HANDLER), "2", "1"],
+        cwd=REPO_ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    calls = call_log.read_text().splitlines()
+    assert len(calls) == 3
+    assert all(call.endswith("--buzzer radio-missing") for call in calls)
+    assert result.stdout.count("radio-missing alarm 1/3") == 1
+    assert result.stdout.count("radio-missing alarm 2/3") == 1
+    assert result.stdout.count("radio-missing alarm 3/3") == 1
+    assert "TEST MODE: system poweroff inhibited" in result.stdout
+
+
+def test_boot_preparation_only_shuts_down_when_radio_count_is_low():
+    source = (ROVER_ROOT / "prepare_direct_usb_boot.sh").read_text()
+
+    assert "radio_missing_shutdown.sh" in source
+    assert '[[ "$attached_radios" -lt "$configured_radios" ]]' in source
+    assert '[[ "$attached_radios" -gt "$configured_radios" ]]' in source
+    low_count_branch = source.split(
+        'if [[ "$attached_radios" -lt "$configured_radios" ]]', 1
+    )[1].split("elif", 1)[0]
+    high_count_branch = source.split(
+        'elif [[ "$attached_radios" -gt "$configured_radios" ]]', 1
+    )[1].split("fi", 1)[0]
+    assert "radio_missing_shutdown" in low_count_branch
+    assert "radio_missing_shutdown" not in high_count_branch
+
+
+def test_radio_missing_tone_is_named_and_distinct():
+    source = (REPO_ROOT / "spf/mavlink/mavlink_controller.py").read_text()
+    tones = source.split("tones = {", 1)[1].split("}", 1)[0]
+
+    assert '"radio-missing"' in tones
+    assert '"radio-missing"' not in {'"failure"', '"gps-time"'}

--- a/tests/test_radio_missing_shutdown.py
+++ b/tests/test_radio_missing_shutdown.py
@@ -2,6 +2,8 @@ import os
 from pathlib import Path
 import subprocess
 
+from spf.mavlink.mavlink_controller import tones
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ROVER_ROOT = REPO_ROOT / "data_collection/rover/rover_v3.1"
@@ -57,13 +59,10 @@ def test_boot_preparation_only_shuts_down_when_radio_count_is_low():
     high_count_branch = source.split(
         'elif [[ "$attached_radios" -gt "$configured_radios" ]]', 1
     )[1].split("fi", 1)[0]
-    assert "radio_missing_shutdown" in low_count_branch
-    assert "radio_missing_shutdown" not in high_count_branch
+    assert '"$RADIO_MISSING_HANDLER"' in low_count_branch
+    assert '"$RADIO_MISSING_HANDLER"' not in high_count_branch
 
 
 def test_radio_missing_tone_is_named_and_distinct():
-    source = (REPO_ROOT / "spf/mavlink/mavlink_controller.py").read_text()
-    tones = source.split("tones = {", 1)[1].split("}", 1)[0]
-
-    assert '"radio-missing"' in tones
-    assert '"radio-missing"' not in {'"failure"', '"gps-time"'}
+    assert "radio-missing" in tones
+    assert tones["radio-missing"] not in {tones["failure"], tones["gps-time"]}

--- a/tests/test_readiness_wait_tone.py
+++ b/tests/test_readiness_wait_tone.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from spf.mavlink.mavlink_controller import tones
+from spf.mavlink_radio_collection import (
+    READINESS_TONE_INTERVAL_SECONDS,
+    maybe_play_readiness_wait_tone,
+)
+
+
+class FakeDrone:
+    def __init__(self):
+        self.played = []
+
+    def buzzer(self, tone):
+        self.played.append(tone)
+
+
+def test_readiness_tone_plays_at_fifteen_second_intervals(tmp_path: Path):
+    drone = FakeDrone()
+    disable_path = tmp_path / "disable_annoying_tones"
+
+    next_at = maybe_play_readiness_wait_tone(
+        drone, now=14.9, next_tone_at=15.0, disable_path=disable_path
+    )
+    assert next_at == 15.0
+    assert drone.played == []
+
+    next_at = maybe_play_readiness_wait_tone(
+        drone, now=15.0, next_tone_at=next_at, disable_path=disable_path
+    )
+    assert next_at == 15.0 + READINESS_TONE_INTERVAL_SECONDS
+    assert drone.played == [tones["readiness-wait"]]
+
+    next_at = maybe_play_readiness_wait_tone(
+        drone, now=30.0, next_tone_at=next_at, disable_path=disable_path
+    )
+    assert next_at == 30.0 + READINESS_TONE_INTERVAL_SECONDS
+    assert drone.played == [tones["readiness-wait"], tones["readiness-wait"]]
+
+
+def test_disable_annoying_tones_flag_suppresses_readiness_chirp(tmp_path: Path):
+    drone = FakeDrone()
+    disable_path = tmp_path / "disable_annoying_tones"
+    disable_path.touch()
+
+    next_at = maybe_play_readiness_wait_tone(
+        drone, now=15.0, next_tone_at=15.0, disable_path=disable_path
+    )
+
+    assert next_at == 30.0
+    assert drone.played == []


### PR DESCRIPTION
## What changed

- Add a distinct descending `radio-missing` alarm.
- After bounded USB discovery finds fewer Plutos than the production configuration requires, play that alarm exactly three times and request a clean system poweroff.
- Do not misclassify an excess-radio/configuration error as a missing-radio condition.
- Add a short readiness chirp every 15 seconds while the collector waits for GPS/EKF.
- Dynamically suppress periodic readiness chirps with `/home/pi/disable_annoying_tones`; the critical missing-radio alarm is never suppressed by that flag.
- Document field behavior and operator recovery.

## Why

Plutos are externally powered. Once a required radio is absent during boot, restarting only the collector cannot recover it. Previously the firmware service failed silently from the operator's perspective and left MAVLink collection inactive. The new policy gives a bounded, recognizable alarm and leaves the rover safely powered down for physical inspection and power-cycle recovery.

## Safety

The real poweroff action is the production default. Focused tests use an explicit `log-only` action, exercise all three buzzer calls, and cannot halt the test host. Buzzer failure does not prevent the subsequent clean shutdown request.

The periodic 15-second readiness chirp is separate from the critical alarm and can be disabled without restarting collection.

## Validation

- Red commit: `33c113e`
- Green implementation: `c0e5da3`
- `bash -n` on both affected shell scripts
- `py_compile` on affected Python and tests
- 9 focused tests passed
- `git diff --check`

No full local test suite was run; CI owns that per the workstation safety constraint.
