### PR TITLE
Verify Pluto firmware without mounting updater volumes

### DIFF
--- a/data_collection/rover/rover_v3.1/PLUTO_QSPI_FLASH.md
+++ b/data_collection/rover/rover_v3.1/PLUTO_QSPI_FLASH.md
@@ -86,27 +86,32 @@ then `dfu-util -a firmware.dfu -D pluto.dfu`. Both ultimately go through U-Boot'
 After flashing, the Pluto cold-boots the gain/RSSI FIT from QSPI and
 `grep device-fw /opt/VERSIONS` reads `v0.38_plutoplus_with_timestamping-9-g7b02`.
 
-## 5. Boot flow: check version, flash only on mismatch
+## 5. Boot flow: check version over USB-IIO, flash only on mismatch
 
 Replace the unconditional per-boot RAM-load with a verify-first check. Expected
 version comes from the canonical config manifest (the release's `device-fw`
-string). Per attached Pluto:
+string). The active version is a standard libiio context attribute, so the
+normal path does not mount the updater volume and does not use the duplicate
+`192.168.2.1` USB-network address. Per attached Pluto:
 
 ```
-running=$(ssh_pluto "grep device-fw /opt/VERSIONS | cut -d' ' -f2")
+uri="usb:${bus}.${device_address}.5"   # bus/address bound to this USB serial
+running=$(iio_attr -T 2000 -u "$uri" -C fw_version |
+          sed -n 's/^fw_version:[[:space:]]*//p')
 if [ "$running" = "$EXPECTED_DEVICE_FW" ]; then
-    : # already correct — radio booted the right QSPI firmware; do nothing (fast)
+    : # correct: do not open the updater volume
 else
-    flash pluto.frm (section 4)   # one-time, or after a QSPI revert
+    mount only this serial's updater volume and flash pluto.frm (section 4)
     reset + wait for re-enumerate
-    re-verify running == EXPECTED_DEVICE_FW  (else fail closed)
+    re-verify over USB-IIO that running == EXPECTED_DEVICE_FW (else fail closed)
 fi
 ```
 
 Result: the **first** boot after provisioning flashes QSPI; **every subsequent
 boot** finds the version already correct and does nothing — no RAM-load, no DFU
-re-enumeration flap, no ~104 s. This is the mechanism the maintainer recalled
-("it used to check the version and only flash if different").
+re-enumeration flap, no updater-volume mount, and no ~104 s. The ready manifest
+then independently checks the vendor direct-USB gadget SHA, protocol, and
+metadata capabilities before collection is authorized.
 
 ## 6. Safety / recovery
 

--- a/data_collection/rover/rover_v3.1/ensure_pluto_qspi.sh
+++ b/data_collection/rover/rover_v3.1/ensure_pluto_qspi.sh
@@ -3,11 +3,16 @@
 # Version-conditional persistent QSPI firmware for the direct-USB gain/RSSI build.
 #
 # This replaces the per-boot RAM load. For each attached Pluto it reads the
-# firmware the radio is *currently running* (which, with RAM loading disabled,
-# is exactly what is in QSPI) and:
+# active firmware through the standard USB-IIO interface (which, with RAM
+# loading disabled, is exactly what booted from QSPI) and:
 #   - if it already matches the expected build  -> SKIP (the fast steady state)
 #   - otherwise                                 -> flash pluto.frm to QSPI and
 #     wait for the radio to reboot into the expected build.
+#
+# The steady-state check never mounts the Pluto updater volume.
+# Mass storage is opened only after an explicit USB-IIO mismatch, when a write
+# is actually required. The custom direct-USB build identity and capabilities
+# are verified later by the ready-manifest path before capture is authorized.
 #
 # The flash uses the on-device mass-storage updater (copy pluto.frm, eject),
 # which writes ONLY the firmware partition (/dev/mtdblock3). It never writes the
@@ -35,13 +40,20 @@ FLASH_TIMEOUT="${SPF_PLUTO_FLASH_TIMEOUT:-180}"
 MSD_READY_TIMEOUT="${SPF_PLUTO_MSD_TIMEOUT:-45}"
 EXPECTED_COUNT="${1:?expected Pluto count required}"
 MNT="/run/spf-pluto-msd"
+USB_ROOT="${SPF_PLUTO_USB_ROOT:-/sys/bus/usb/devices}"
 
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
 [[ "$EXPECTED_COUNT" =~ ^[1-9][0-9]*$ ]] || die "bad expected count: ${EXPECTED_COUNT}"
-for cmd in udevadm mount umount eject sync; do
-    command -v "$cmd" >/dev/null 2>&1 || die "missing required command: ${cmd}"
-done
+command -v iio_attr >/dev/null 2>&1 || die "missing required command: iio_attr"
+
+require_flash_commands() {
+    local cmd
+    for cmd in udevadm mount umount eject sync; do
+        command -v "$cmd" >/dev/null 2>&1 ||
+            die "missing firmware-flash command: ${cmd}"
+    done
+}
 
 serial_of() {  # $1=/dev/sdX -> ID_SERIAL_SHORT
     udevadm info --query=property --name="$1" 2>/dev/null |
@@ -50,7 +62,7 @@ serial_of() {  # $1=/dev/sdX -> ID_SERIAL_SHORT
 
 pluto_usb_serials() {  # serials of attached runtime Plutos (USB 0456:b673)
     local dev v p
-    for dev in /sys/bus/usb/devices/*/; do
+    for dev in "$USB_ROOT"/*/; do
         v="$(cat "${dev}idVendor" 2>/dev/null || true)"
         p="$(cat "${dev}idProduct" 2>/dev/null || true)"
         [[ "$v" == "0456" && "$p" == "b673" ]] || continue
@@ -58,11 +70,60 @@ pluto_usb_serials() {  # serials of attached runtime Plutos (USB 0456:b673)
     done
 }
 
+runtime_device_for_serial() {  # $1=serial -> runtime sysfs directory
+    local serial="$1" dev v p candidate=""
+    for dev in "$USB_ROOT"/*/; do
+        v="$(cat "${dev}idVendor" 2>/dev/null || true)"
+        p="$(cat "${dev}idProduct" 2>/dev/null || true)"
+        [[ "$v" == "0456" && "$p" == "b673" ]] || continue
+        [[ "$(cat "${dev}serial" 2>/dev/null || true)" == "$serial" ]] || continue
+        [[ -z "$candidate" ]] || return 1
+        candidate="$dev"
+    done
+    [[ -n "$candidate" ]] || return 1
+    printf '%s' "$candidate"
+}
+
+iio_uri_for_serial() {  # $1=serial -> usb:BUS.DEV.5
+    local dev bus address
+    dev="$(runtime_device_for_serial "$1")" || return 1
+    bus="$(cat "${dev}busnum" 2>/dev/null || true)"
+    address="$(cat "${dev}devnum" 2>/dev/null || true)"
+    [[ "$bus" =~ ^[0-9]+$ && "$address" =~ ^[0-9]+$ ]] || return 1
+    printf 'usb:%s.%s.5' "$bus" "$address"
+}
+
+active_firmware_for_serial() {  # $1=serial -> active fw_version
+    local uri output version
+    uri="$(iio_uri_for_serial "$1")" || return 1
+    output="$(iio_attr -T 2000 -u "$uri" -C fw_version 2>/dev/null)" || return 1
+    version="$(
+        printf '%s\n' "$output" |
+            sed -n 's/^fw_version:[[:space:]]*//p' |
+            head -1
+    )"
+    [[ -n "$version" ]] || return 1
+    printf '%s' "$version"
+}
+
 blkdev_for_serial() {  # $1=serial -> /dev/sdX (or fail)
     local d
     for d in /dev/sd?; do
         [[ -b "$d" ]] || continue
         [[ "$(serial_of "$d")" == "$1" ]] && { printf '%s' "$d"; return 0; }
+    done
+    return 1
+}
+
+wait_blkdev_for_serial() {  # $1=serial -> settled /dev/sdX
+    local serial="$1" deadline=$((SECONDS + MSD_READY_TIMEOUT)) candidate
+    while (( SECONDS < deadline )); do
+        if candidate="$(blkdev_for_serial "$serial" 2>/dev/null)" &&
+            [[ -b "${candidate}1" ]]; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+        sleep 1
     done
     return 1
 }
@@ -82,21 +143,6 @@ mount_msd() {  # $1=/dev/sdX ; $2 mode ; 0 mounted, 1 never became ready
         sleep 1
     done
     return 1
-}
-
-# A radio is "on expected" iff its mass-storage info page -- regenerated on every
-# Pluto boot with the running device-fw -- CONTAINS the exact expected device-fw
-# string. A substring presence test is more robust than parsing: info.html also
-# lists u-boot, IIO and template versions, so picking "the version" by position
-# is unreliable (that read the template "v0.15" instead of the build).
-# Returns: 0 = on expected, 1 = readable but wrong firmware, 2 = not readable
-# (radio not enumerating stably) -- the caller must NOT treat 2 as "flash it".
-radio_on_expected() {  # $1=/dev/sdX
-    local d="$1" rc=1
-    mount_msd "$d" ro || return 2
-    grep -qF "$EXPECTED_FW" "$MNT/info.html" 2>/dev/null && rc=0
-    umount "$MNT" 2>/dev/null || true
-    return "$rc"
 }
 
 build_frm() {
@@ -134,52 +180,46 @@ flash_radio() {  # $1=serial $2=/dev/sdX ; writes pluto.frm to mtd3, waits for r
 }
 
 main() {
-    build_frm
-
-    # Snapshot the attached Pluto serials up front (device nodes shuffle on reset).
-    # A block device is a Pluto MSD iff its ID_SERIAL_SHORT matches an attached
-    # runtime Pluto (0456:b673) -- the MSD's ID_MODEL is the generic
-    # "File-Stor_Gadget", so identify by USB VID/serial instead.
-    local pluto_set d ser
-    pluto_set=" $(pluto_usb_serials | tr '\n' ' ') "
+    # Enumerate by runtime USB identity. Do not require or touch updater block
+    # devices unless an explicit active-firmware mismatch requires a flash.
     local serials=()
-    for d in /dev/sd?; do
-        [[ -b "$d" ]] || continue
-        ser="$(serial_of "$d")"
-        [[ -n "$ser" && "$pluto_set" == *" $ser "* ]] || continue
-        serials+=("$ser")
-    done
+    mapfile -t serials < <(pluto_usb_serials)
     [[ "${#serials[@]}" -eq "$EXPECTED_COUNT" ]] ||
-        die "expected ${EXPECTED_COUNT} Pluto mass-storage disks, found ${#serials[@]}"
+        die "expected ${EXPECTED_COUNT} runtime Plutos, found ${#serials[@]}"
 
-    local ser d state
+    local ser d actual deadline
     for ser in "${serials[@]}"; do
-        d="$(blkdev_for_serial "$ser")" || die "${ser}: block device vanished"
-        state=0
-        radio_on_expected "$d" || state=$?
-        case "$state" in
-            0)
-                printf '%s: already on expected firmware (%s); skip\n' \
-                    "$ser" "$EXPECTED_FW"
-                continue
-                ;;
-            2)
-                die "${ser}: mass-storage not readable within ${MSD_READY_TIMEOUT}s;" \
-                    "radio is not enumerating stably (hardware) -- refusing to flash blind"
-                ;;
-        esac
-        # state 1: readable but running a different firmware -> flash it.
-        printf '%s: not on expected firmware "%s" -> flashing\n' "$ser" "$EXPECTED_FW"
+        actual="$(active_firmware_for_serial "$ser")" ||
+            die "${ser}: active firmware unavailable over USB-IIO; refusing to flash blind"
+        if [[ "$actual" == "$EXPECTED_FW" ]]; then
+            printf '%s: active firmware matches via USB-IIO; skip (%s)\n' \
+                "$ser" "$EXPECTED_FW"
+            continue
+        fi
+
+        printf '%s: active firmware %q != expected %q -> flashing QSPI\n' \
+            "$ser" "$actual" "$EXPECTED_FW"
+        require_flash_commands
+        build_frm
+        d="$(wait_blkdev_for_serial "$ser")" ||
+            die "${ser}: updater block device did not become ready after firmware mismatch"
         flash_radio "$ser" "$d"
-        d="$(blkdev_for_serial "$ser")" || die "${ser}: gone after flash"
-        state=0
-        radio_on_expected "$d" || state=$?
-        [[ "$state" -eq 0 ]] ||
-            die "${ser}: after flash still not on expected firmware" \
-                "'${EXPECTED_FW}' (state ${state})"
-        printf '%s: now booting expected firmware from QSPI (%s)\n' "$ser" "$EXPECTED_FW"
+
+        deadline=$((SECONDS + FLASH_TIMEOUT))
+        actual=""
+        while (( SECONDS < deadline )); do
+            actual="$(active_firmware_for_serial "$ser" 2>/dev/null || true)"
+            [[ "$actual" == "$EXPECTED_FW" ]] && break
+            sleep 1
+        done
+        [[ "$actual" == "$EXPECTED_FW" ]] ||
+            die "${ser}: after flash active firmware is ${actual:-unavailable};" \
+                "expected ${EXPECTED_FW}"
+        printf '%s: active expected firmware after QSPI flash (%s)\n' \
+            "$ser" "$EXPECTED_FW"
     done
-    printf 'PASS: %s Pluto(s) on expected QSPI firmware %s\n' "$EXPECTED_COUNT" "$EXPECTED_FW"
+    printf 'PASS: %s Pluto(s) on expected active firmware %s\n' \
+        "$EXPECTED_COUNT" "$EXPECTED_FW"
 }
 
 main

--- a/data_collection/rover/rover_v3.1/prepare_direct_usb_boot.sh
+++ b/data_collection/rover/rover_v3.1/prepare_direct_usb_boot.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # Root-only boot preparation for the recoverable multi-Pluto direct-USB path.
-# This script never writes Pluto QSPI.
+# The normal matching path is read-only. An explicit active-firmware mismatch
+# may update only the Pluto firmware partition in QSPI via pluto.frm.
 
 set -euo pipefail
 
@@ -133,10 +134,9 @@ if is_true "$RAM_LOAD"; then
 else
     # Default: ensure the gain/RSSI image is persistently in QSPI. Downloads/verifies
     # the pinned image into the local cache (no network if already cached), then
-    # flashes pluto.frm (mtd3 only) to any radio whose running firmware != expected.
-    # Radios are addressed by USB serial via their mass-storage device -- no ssh,
-    # no shared 192.168.2.1 -- so radios already on the expected build are skipped
-    # with no DFU dance and no reboot.
+    # reads each active version over USB-IIO. A matching radio never mounts its
+    # updater volume. Only an explicit mismatch opens that serial's mass-storage
+    # device to flash pluto.frm (mtd3 only). No ssh/shared-192.168.2.1 race.
     run_loader download
     SPF_PLUTO_EXPECTED_DEVICE_FW="$EXPECTED_DEVICE_FW" \
     SPF_FIRMWARE_DFU="${FIRMWARE_CACHE}/${firmware_asset_name}" \

--- a/data_collection/rover/rover_v3.1/spf-pluto-direct-usb.service
+++ b/data_collection/rover/rover_v3.1/spf-pluto-direct-usb.service
@@ -1,8 +1,9 @@
 [Unit]
-Description=RAM-load and verify SPF direct-USB firmware on every Pluto
-# The RAM load needs no LAN/internet: the image is pre-cached locally and every
-# Pluto is reached over its point-to-point USB-gadget net (192.168.2.1) inside a
-# private namespace. Waiting on network-online.target only added
+Description=Ensure and verify SPF direct-USB firmware on every Pluto
+# Ensure and verify direct-USB firmware on every Pluto. Matching firmware is
+# checked over USB-IIO without mounting the updater volume; only a mismatch
+# enters the persistent QSPI update path. Neither path needs LAN/internet.
+# Waiting on network-online.target only added
 # NetworkManager-wait-online (~9.6s) to the front of the critical path. The
 # loader waits for the Plutos to USB-enumerate itself (prepare_direct_usb_boot.sh).
 After=local-fs.target

--- a/tests/test_pluto_qspi_usb_probe.py
+++ b/tests/test_pluto_qspi_usb_probe.py
@@ -1,0 +1,96 @@
+import os
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ENSURE_SCRIPT = (
+    REPO_ROOT / "data_collection/rover/rover_v3.1/ensure_pluto_qspi.sh"
+)
+EXPECTED_FW = "v0.38_plutoplus_with_timestamping-9-g7b02"
+
+
+def _add_runtime_pluto(root: Path, *, serial: str = "SERIAL_A") -> None:
+    device = root / "1-1.1"
+    device.mkdir(parents=True)
+    (device / "idVendor").write_text("0456\n")
+    (device / "idProduct").write_text("b673\n")
+    (device / "serial").write_text(f"{serial}\n")
+    (device / "busnum").write_text("1\n")
+    (device / "devnum").write_text("3\n")
+
+
+def _write_fake_command(path: Path, body: str) -> None:
+    path.write_text("#!/usr/bin/env bash\nset -eu\n" + body)
+    path.chmod(0o755)
+
+
+def _run_ensure(tmp_path: Path, *, iio_body: str) -> tuple[subprocess.CompletedProcess, list[str]]:
+    usb_root = tmp_path / "usb"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _add_runtime_pluto(usb_root)
+    command_log = tmp_path / "commands.log"
+
+    _write_fake_command(
+        fake_bin / "iio_attr",
+        'printf "iio_attr %s\\n" "$*" >>"$SPF_TEST_COMMAND_LOG"\n' + iio_body,
+    )
+    for command in ("mount", "umount", "eject"):
+        _write_fake_command(
+            fake_bin / command,
+            f'printf "{command} %s\\n" "$*" >>"$SPF_TEST_COMMAND_LOG"\n'
+            "exit 97\n",
+        )
+
+    firmware = tmp_path / "pluto.dfu"
+    firmware.write_bytes(b"not needed on the matching fast path")
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "PATH": f"{fake_bin}:{environment['PATH']}",
+            "SPF_PLUTO_USB_ROOT": str(usb_root),
+            "SPF_PLUTO_EXPECTED_DEVICE_FW": EXPECTED_FW,
+            "SPF_FIRMWARE_DFU": str(firmware),
+            "SPF_PLUTO_FRM": str(tmp_path / "pluto.frm"),
+            "SPF_TEST_COMMAND_LOG": str(command_log),
+        }
+    )
+    result = subprocess.run(
+        ["bash", str(ENSURE_SCRIPT), "1"],
+        cwd=REPO_ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    calls = command_log.read_text().splitlines() if command_log.exists() else []
+    return result, calls
+
+
+def test_matching_active_firmware_uses_usb_iio_without_mounting(tmp_path):
+    result, calls = _run_ensure(
+        tmp_path,
+        iio_body=f'printf "fw_version: {EXPECTED_FW}\\n"\n',
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert calls == ["iio_attr -T 2000 -u usb:1.3.5 -C fw_version"]
+    assert "active firmware matches via USB-IIO; skip" in result.stdout
+    assert "PASS: 1 Pluto(s) on expected active firmware" in result.stdout
+
+
+def test_unreadable_usb_iio_fails_closed_without_mounting_or_flashing(tmp_path):
+    result, calls = _run_ensure(tmp_path, iio_body="exit 1\n")
+
+    assert result.returncode != 0
+    assert calls == ["iio_attr -T 2000 -u usb:1.3.5 -C fw_version"]
+    assert "active firmware unavailable over USB-IIO" in result.stderr
+    assert "refusing to flash blind" in result.stderr
+
+
+def test_qspi_script_documents_mass_storage_as_mismatch_only():
+    source = ENSURE_SCRIPT.read_text()
+
+    assert "Mass storage is opened only after an explicit USB-IIO mismatch" in source
+    assert "iio_attr" in source


### PR DESCRIPTION
## What changed

- Read each Pluto active `fw_version` over its serial-bound USB-IIO context.
- Skip updater-volume discovery, mounting, and `pluto.frm` generation when firmware matches.
- Enter the mass-storage/QSPI update path only after an explicit version mismatch.
- Fail closed without flashing when USB-IIO readback is unavailable.
- Re-verify active firmware over USB-IIO after a real flash.
- Update the service description and QSPI documentation.

The ready-manifest path remains the second gate: it independently validates the direct-USB gadget Git SHA, protocol, metadata capabilities, USB serial, and dual-RX support.

## Why

Rover 3 unstable Pluto disappeared while the old boot path was mounting updater volumes merely to read `info.html`. The active firmware identity is already available through USB-IIO. Removing the mount makes normal boot faster and eliminates an unnecessary operation while retaining mismatch-only recovery.

## Red / green evidence

- Red commit: `58955ed`
- Green commit: `b610464`
- 34 focused tests passed
- `bash -n`
- `shellcheck` on the changed QSPI script
- `systemd-analyze verify`
- `git diff --check`

The full local suite was intentionally not run; CI owns it.

## Rover 3 evidence

The new script was run against the one Pluto currently remaining on Rover 3:

- active firmware matched over USB-IIO;
- no updater volume was mounted;
- no flash or reset was requested;
- elapsed time was 0.447 seconds;
- the radio remained available at `usb:1.4.5`.

A complete two-radio boot test remains pending because Rover 3 Pluto on path `1-1.1`, serial ending `a5d4d`, is still offline.

## Safety

A matching or unreadable radio cannot enter the flash path. Only a successfully read, explicit version mismatch permits mounting and QSPI update.