### PR TITLE
Document July 31 rover field failures

### DIFF
--- a/data_collection/rover/rover_v3.1/field_reports/2026_07_31.md
+++ b/data_collection/rover/rover_v3.1/field_reports/2026_07_31.md
@@ -1,0 +1,368 @@
+# Rover field report: 2026-07-31
+
+## Executive summary
+
+Rover 2 and Rover 3 each produced two complete data-version-7 captures. Rover 1
+remained running for more than 40 minutes, but produced no complete Zarr. The
+Rover 1 evidence shows two separate partial capture attempts rather than one
+continuous 40-minute write: approximately 12 minutes 35 seconds of samples in
+the first store and 9 minutes 18 seconds in the second.
+
+The immediate reason Rover 1 has no final `.zarr` is deterministic: neither
+attempt reached the configured 3,000 records per receiver and completed the
+close, shrink, and `.tmp`-to-final rename sequence. The first store was left
+marked `in_progress`, consistent with abrupt interruption. The second was
+explicitly marked `incomplete` after a `TypeError`; cleanup also reported that
+the Pluto was no longer available. A later hard shutdown removed the remaining
+opportunity for orderly shutdown and left the earlier journal unavailable.
+
+At the end of the investigation, all three Raspberry Pis had adequate disk
+space, no throttling or undervoltage, no OOM or storage-I/O failures, and no
+failed systemd units. The MAVLink controller services were inactive because an
+operator explicitly stopped them at approximately 22:12, not because they had
+crashed.
+
+## Evidence and method
+
+This report correlates:
+
+- `mavlink_controller.service` journals;
+- system boot and shutdown journals;
+- kernel USB messages;
+- the lifecycle attributes stored in each V7 LMDB-backed Zarr;
+- nonzero `system_timestamp` rows and IQ chunk keys;
+- collector start, quit, shrink, clean-exit, and final-rename messages.
+
+The Zarr frame spans below come from the first and last nonzero stored
+`system_timestamp`. They are useful for partial captures whose collector journal
+was lost. Normal completed-run durations use explicit `Collector thread is
+running` and `Collector tell threads to quit` messages.
+
+Rover 1's persistent journal does not retain the boots containing the two large
+partial captures. Consequently, the Zarr lifecycle attributes prove how far the
+captures progressed, but the precise source line for the second error and the
+trigger for the first interruption cannot be reconstructed.
+
+Subsequent source review did identify why the second capture reported a generic
+`TypeError` instead of its original direct-USB error; see the root-cause section
+below.
+
+## Collection results
+
+| Rover | Store start | Result | Records by receiver | Measured collection duration | Notes |
+| --- | --- | --- | ---: | ---: | --- |
+| Rover 1 | 18:35:35 | Partial `.zarr.tmp` | 1,070 / 1,069 | 12m 35s | Still marked `in_progress`; no orderly finalizer ran. |
+| Rover 1 | 18:49:02 | Partial `.zarr.tmp` | 962 / 961 | 9m 18s | Marked `incomplete`; primary error was `TypeError: 'NoneType' object is not subscriptable`. Pluto cleanup also failed with `No such device`. |
+| Rover 2 | 18:35:23 | Complete `.zarr` | 3,500 | 30m 19s | Clean close, shrink, and promotion at 19:07. |
+| Rover 2 | 21:09:45 | Complete `.zarr` | 3,500 | 31m 33s | Clean close, shrink, and promotion at 21:47. |
+| Rover 3 | 20:01:46 | Partial `.zarr.tmp` | 465 / 465 | 4m 24s | Interrupted by a service stop; not promoted. |
+| Rover 3 | 20:11:15 | Complete `.zarr` | 3,000 / 3,000 | 27m 57s | Clean close, shrink, and promotion at 20:41. |
+| Rover 3 | 21:18:45 | Complete `.zarr` | 3,000 / 3,000 | 27m 53s | Clean close, shrink, and promotion at 21:48. |
+
+Several other `.zarr.tmp` stores contain zero records. These were created while
+the collector was starting or waiting for planner/GUIDED control and were
+stopped before frame collection began. Their existence does not indicate that
+IQ data was lost.
+
+### Why Rover 1 ran for over 40 minutes without a complete Zarr
+
+The rover being powered and its service appearing active is not proof that its
+collector is still writing frames. The two Rover 1 stores account for about 21
+minutes 53 seconds of actual recorded frame span across two attempts. The rover
+then remained powered after collection had stopped or failed.
+
+The relevant operating-system session ran for approximately 1 hour 33 minutes,
+from 18:16:59 until the hard power cycle at 19:49:38. The first store appeared
+at 18:35:35; the second appeared at 18:49:02. Frame writing in the second store
+ended at approximately 18:58, leaving roughly 51 minutes in which the rover was
+still powered but no mission frames were being added.
+
+SPF deliberately creates all three outputs with `.tmp` suffixes. Only after the
+requested record count is reached does the normal path:
+
+1. stop and join the receiver threads;
+2. close the radios and LMDB store;
+3. shrink the preallocated Zarr;
+4. report a clean collector exit; and
+5. rename the Zarr, YAML, and log from `.tmp` to their final names.
+
+Neither Rover 1 attempt reached step 5:
+
+- The 18:35 store has a target shape of 3,000 records but only 1,070/1,069
+  written frames. Its lifecycle remains `in_progress`, which means execution
+  ended without reaching the exception-aware finalizer.
+- The 18:49 store has only 962/961 frames. Its lifecycle records a caught
+  `TypeError` and an additional cleanup failure while muting TX because the SDR
+  returned `Errno 19: No such device`. It was correctly left as
+  `capture_status=incomplete` rather than being mislabeled complete.
+- The hard power-off prevented any later orderly flush or diagnostic journal
+  preservation. It explains why an interrupted store cannot be promoted, but
+  the stored timestamps show that Rover 1 was not continuously writing IQ for
+  the full time it appeared to be running.
+
+The first partial store is about 4.96 GB and the second about 4.44 GB in logical
+LMDB size. They should be preserved until a read-only recovery/export procedure
+has copied the valid common prefix of both receivers. They must not simply be
+renamed to `.zarr`, because that would falsely represent incomplete captures as
+complete ones.
+
+## Rover 1 root-cause analysis
+
+### Failure 1: the 18:35 capture was externally interrupted
+
+Confidence: high for abrupt external termination; insufficient evidence to name
+the exact operator or boot command.
+
+The current collector wraps acquisition in a `try/finally` that writes either
+`complete` or `incomplete`, records per-receiver progress, closes the radios, and
+finalizes the store. The first Rover 1 store still says `in_progress` with stale
+zero lifecycle counters despite containing 1,070/1,069 IQ frames. This state is
+only consistent with the process not being allowed to execute that finalizer,
+for example because of power loss, `SIGKILL`, or a systemd target/process
+restart.
+
+`wtmp` records a new runlevel and a replacement console-getty process at
+18:48:26, immediately after the stored frame span ends. A new collector output
+was created 36 seconds later. The MAVLink unit has `Restart=no`, so this was not
+the collector automatically retrying or splitting a long recording. An external
+system/service start caused a second invocation. The prior journal that would
+distinguish a commanded restart from an unclean reset was not retained.
+
+Root-cause chain:
+
+```text
+external process/system interruption
+    -> collector finalizer does not run
+    -> first store remains in_progress
+    -> boot/target starts MAVLink service again
+    -> a new timestamp creates a second independent store
+```
+
+### Failure 2: a direct-USB error was masked by a retry bug
+
+Confidence: high that a Pluto became unavailable; medium on whether the initiating
+cause was its cable, power, firmware, or USB-host path.
+
+The deployed `ThreadedRX.get_rx()` deliberately permits only one attempt for
+direct USB so it cannot hide a failed frame by creating a new stream generation.
+There is an off-by-one error in that failure path:
+
+1. `PPlus.rx()` raises the real direct-USB exception.
+2. `get_rx()` catches it and increments `tries` from zero to one.
+3. The code tests `tries > max_retries`; for one attempt, `1 > 1` is false.
+4. The loop ends and returns `None`, discarding the original exception.
+5. `ThreadedRXRaw.get_data()` immediately evaluates
+   `sdr_rx["signal_matrix"]` without checking for `None`.
+6. Python raises the recorded secondary error:
+   `TypeError: 'NoneType' object is not subscriptable`.
+
+The cleanup path then attempted to mute TX through the Pluto control interface
+and received `OSError: [Errno 19] No such device`. That independently confirms
+that a Pluto was unavailable by cleanup time. The same error signature was
+observed on Rover 3 on July 30 immediately after a kernel `USB disconnect`, which
+strengthens the USB-disappearance diagnosis. Rover 1's missing kernel journal
+prevents attribution to one specific cable or physical port.
+
+Root-cause chain:
+
+```text
+Pluto/direct-USB operation fails
+    -> real USB exception is caught
+    -> retry boundary returns None instead of re-raising
+    -> caller indexes None and records misleading TypeError
+    -> cleanup reaches the absent Pluto and records Errno 19
+    -> capture is correctly marked incomplete but not promoted
+```
+
+### Why the rover looked as though it was still collecting
+
+The system had no durable operator-facing transition from `collecting` to
+`failed`, and the per-capture `.log.tmp` files are empty. After the second
+collector stopped writing frames, the Raspberry Pi could therefore remain
+powered and otherwise responsive without producing a final artifact. This made
+uptime appear to be collection time.
+
+## Faults and issues
+
+### P0: capture failure was not obvious to the operator
+
+Rover 1 remained powered after recording stopped, with no final Zarr and no
+clear operator-facing indication that the capture had failed. The `.log.tmp`
+files for all three rovers are zero bytes, so the only detailed runtime evidence
+was journald. Rover 1's hard shutdown then made the relevant journal unavailable.
+
+This is the most important collection-software failure of the day: a rover can
+look alive while no longer producing a usable mission artifact.
+
+### P0: compass and EKF readiness
+
+| Rover | Observed issue |
+| --- | --- |
+| Rover 1 | Three `PreArm: Compass not healthy` messages; EKF never became healthy in the retained current boot. |
+| Rover 2 | 34 `Compass not healthy` messages plus magnetic XY disagreement around 100-113 against a limit of 100. It was indoors, so weak GPS was expected, but the compass still requires an outdoor check. |
+| Rover 3 | Magnetic magnitude 1,024-1,548 against a maximum of 875, plus XY disagreement of 421 and 537. It did briefly obtain 11-12 satellites and healthy EKF outdoors. |
+
+No mission should proceed until compass selection, orientation, offsets, and
+EKF readiness pass outdoors, away from vehicles and other ferrous material,
+with motors disabled.
+
+### P1: MAVLink interruptions and parameter download
+
+- Rover 1 logged one heartbeat timeout and recovered in under a second.
+- Rover 2 logged six heartbeat timeouts; all reconnected automatically.
+- Rover 3 logged four short heartbeat/initial-connection interruptions; the
+  observed attempts recovered.
+- Rover 2 twice received an almost complete parameter set: 884/885 and 882/885.
+  The latter exhausted the current attempts and caused the controller service to
+  exit.
+- A near-simultaneous interruption around 22:10 affected all three rovers but
+  had no corresponding Pixhawk USB disconnect. It is more consistent with a
+  coordinated controller/test restart than three independent hardware faults.
+
+### P1: Pluto USB and firmware preparation
+
+- Rover 2 had one firmware-preparation run in which its Pluto did not
+  re-enumerate within the 180-second limit. Later boots passed.
+- Rover 3 previously failed collection with `Errno 19: No such device` and had
+  repeated USB disconnects and protocol `error -71` on physical path `1-1.1`.
+  Replacing radios and swapping power supplies did not move the failure;
+  replacing the data USB cable did. Eight subsequent reboot/capture trials
+  passed with both radios, 800 frames per radio total, approximately 1.88-1.94
+  frames/s, and zero USB disconnects.
+- Rover 3's replacement radio took longer than 180 seconds to return after its
+  first persistent QSPI update. Later verification passed.
+- The Rover 1 incomplete capture's cleanup metadata shows that at least one SDR
+  was unavailable when cleanup ran. The missing historical journal prevents us
+  from determining whether this was a radio/cable disconnect, shutdown timing,
+  or a consequence of another primary failure.
+
+### P1: shutdown and journal integrity
+
+Rover 2 and Rover 3 repeatedly reported journals recovered after unclean
+shutdowns. Many correspond to deliberate rapid reboot and power-cycle testing.
+Rover 1 retained only its current boot journal after the hard shutdown, removing
+the traceback needed to finish the root-cause analysis of its partial captures.
+
+Repeated transient `run-credentials-systemd-tmpfiles-setup.service.mount`
+failures also occurred around shutdown/reboot on Rover 2 and Rover 3. There was
+no evidence of underlying SD-card or filesystem I/O failure.
+
+### P2: ignored udev rule
+
+Rover 2 and Rover 3 report an invalid line 39 in
+`/etc/udev/rules.d/99-com.rules`:
+
+```text
+SUBSYSTEM==usb_device, MODE=0664, GROUP=usb
+```
+
+systemd-udevd ignores the line. Current Pixhawk and Pluto symlinks still resolve,
+so it was not the cause of today's capture failures, but the fleet configuration
+should be made consistent and the corrected rule tested after re-enumeration.
+
+## Successes
+
+- Rover 2 produced two complete V7 captures with 3,500 records each.
+- Rover 3 produced two complete V7 captures with 3,000 records per radio.
+- Completed captures reached the expected clean-close, shrink, and final rename
+  path.
+- Rover 3's USB cable root cause was isolated through radio, power-supply, port,
+  and cable substitution, followed by eight successful trials.
+- Direct-USB firmware verification and hardware fingerprints were present in
+  the Rover 1 partial stores for both physical radios.
+- Current USB topology and radio serial mappings were correct on all rovers.
+- At final inspection, all systems had ample disk space and no undervoltage,
+  throttling, OOM, thermal, or storage-I/O errors.
+- No current boot showed an unexplained USB disconnect.
+
+## Mitigation plan
+
+### P0: make capture progress and failure unmistakable
+
+1. Emit a distinct capture-failed tone and enter an explicit failed state when
+   the collector exits without a final artifact. Do not silently remain powered
+   in a state that resembles collection.
+2. Publish a lightweight progress record containing capture name, state,
+   records written per receiver, current frames/s, elapsed time, and estimated
+   completion time. Make it visible through the standard rover status command.
+3. Persist lifecycle counters periodically and atomically, not only during final
+   cleanup. A hard shutdown should leave a recent durable record count.
+4. Add an expected-duration watchdog. It should warn when observed throughput
+   makes the requested record count materially late, without discarding data.
+5. Repair per-capture logging so `.log.tmp` contains useful output, while
+   retaining persistent journald as the authoritative system log.
+
+Pass condition: disconnecting a radio or injecting a collector exception causes
+an unmistakable failed status and tone, preserves the primary exception and
+per-radio record counts, and never creates a final `.zarr`.
+
+### P0: safe partial-capture recovery
+
+Create a read-only-first recovery command that:
+
+1. verifies LMDB and Zarr metadata;
+2. counts valid rows independently for every receiver;
+3. chooses only the aligned common prefix;
+4. validates timestamps, direct-USB sequence, gain/RSSI metadata, and IQ chunk
+   presence;
+5. writes a new recovered artifact rather than modifying the original;
+6. records `capture_status=recovered_incomplete`, original path, source hashes,
+   recovered record count, and reason; and
+7. validates the resulting V7 store with the normal reader.
+
+Pass condition: both Rover 1 partial stores can be opened and their valid common
+prefixes copied without changing the originals; the outputs remain clearly
+distinguishable from naturally completed captures.
+
+### P1: harden collection lifecycle
+
+- Handle `SIGTERM` by stopping acquisition, joining receiver threads, persisting
+  incomplete state, closing LMDB, and synchronizing storage within systemd's
+  stop timeout.
+- Keep hard-power-loss handling separate: signal handlers cannot run after power
+  is removed, so periodic durable progress and recovery tooling are required.
+- Add red/green tests for radio loss, MAVLink state becoming unavailable during
+  a write, cleanup failure, service stop, and simulated abrupt termination.
+- Ensure primary capture exceptions cannot be replaced or obscured by TX-mute
+  and radio-close cleanup errors.
+- Fix the direct-USB one-attempt path to re-raise the original transport
+  exception. Test that `PPlus.rx()` raising a sentinel USB exception produces
+  that same exception as `collection_error`, never a secondary `NoneType`
+  failure.
+
+### P1: rover startup and navigation
+
+- Retry only missing MAVLink parameters, or reconnect and retry the full pull,
+  before treating an almost-complete parameter download as fatal.
+- Use a longer, phase-specific re-enumeration timeout for a first persistent
+  Pluto flash while retaining the fast path when firmware already matches.
+- Run the fleet compass/EKF checklist outdoors before the next mission and
+  retain a machine-readable readiness result.
+- Fix the invalid udev rule on Rover 2 and Rover 3 and verify stable symlinks over
+  repeated reboots.
+
+### P2: operational discipline
+
+- Prefer `systemctl stop`, `reboot`, or `poweroff` and wait for shutdown
+  completion before removing power.
+- Preserve persistent journals across boots and monitor journal health during
+  maintenance.
+- Do not delete or rename today's `.zarr.tmp` stores until recovery has been
+  attempted and the results independently validated.
+- Distinguish in status displays among `waiting_for_guided`, `collecting`,
+  `finalizing`, `complete`, and `failed`; a running process alone is not a
+  collection-health signal.
+
+## Immediate next field check
+
+Before another mission, run one 100-frame V7 capture on each rover and require:
+
+- all expected radio serials and firmware fingerprints;
+- nonzero and equal record counts for every receiver;
+- no direct-USB sequence discontinuities or metadata-invalid frames;
+- clean collector close and shrink;
+- final `.zarr`, `.yaml`, and `.log` names with no `.tmp` suffix;
+- successful load through the V7 reader; and
+- outdoor GPS, compass, EKF, and GUIDED readiness appropriate to the rover.
+
+Only after this passes should the normal mission record count be restored.

--- a/data_collection/rover/rover_v3.1/field_reports/2026_07_31.md
+++ b/data_collection/rover/rover_v3.1/field_reports/2026_07_31.md
@@ -2,11 +2,12 @@
 
 ## Executive summary
 
-Rover 2 and Rover 3 each produced two complete data-version-7 captures. Rover 1
-remained running for more than 40 minutes, but produced no complete Zarr. The
-Rover 1 evidence shows two separate partial capture attempts rather than one
-continuous 40-minute write: approximately 12 minutes 35 seconds of samples in
-the first store and 9 minutes 18 seconds in the second.
+During the field operation, Rover 2 and Rover 3 each produced two complete
+data-version-7 captures. Rover 1 remained powered for more than 40 minutes but
+produced no complete Zarr. The Rover 1 evidence shows two separate partial
+capture attempts rather than one continuous 40-minute write: approximately 12
+minutes 35 seconds of samples in the first store and 9 minutes 18 seconds in the
+second.
 
 The immediate reason Rover 1 has no final `.zarr` is deterministic: neither
 attempt reached the configured 3,000 records per receiver and completed the
@@ -15,6 +16,23 @@ marked `in_progress`, consistent with abrupt interruption. The second was
 explicitly marked `incomplete` after a `TypeError`; cleanup also reported that
 the Pluto was no longer available. A later hard shutdown removed the remaining
 opportunity for orderly shutdown and left the earlier journal unavailable.
+
+After the incident investigation, a controlled fake-drone stability campaign
+ran the full production radio configuration four times on each rover, without
+ArduPilot as a dependency. All 12 production sessions completed. Rover 1 wrote
+four consecutive 3,000-frame, two-radio captures; Rover 2 wrote four
+3,500-frame, one-radio captures; and Rover 3 wrote four 3,000-frame, two-radio
+captures. Together they produced approximately 87.6 GB and 62,000
+receiver-records. All completion metadata and expected per-receiver counts
+passed.
+
+This later result is important but does not erase the earlier fault. It proves
+that Rover 1's current radios, firmware, direct-USB path, V7 writer, and
+production configuration can sustain repeated full captures. It does not prove
+that the earlier Pluto disappearance was imaginary or that an intermittent
+cable, connector, power, or USB-host problem cannot recur. The earlier cleanup
+still recorded `Errno 19: No such device`, and the deployed retry bug still
+masked the initiating direct-USB exception as a secondary `NoneType` error.
 
 At the end of the investigation, all three Raspberry Pis had adequate disk
 space, no throttling or undervoltage, no OOM or storage-I/O failures, and no
@@ -49,6 +67,8 @@ below.
 
 ## Collection results
 
+### Field operation
+
 | Rover | Store start | Result | Records by receiver | Measured collection duration | Notes |
 | --- | --- | --- | ---: | ---: | --- |
 | Rover 1 | 18:35:35 | Partial `.zarr.tmp` | 1,070 / 1,069 | 12m 35s | Still marked `in_progress`; no orderly finalizer ran. |
@@ -63,6 +83,74 @@ Several other `.zarr.tmp` stores contain zero records. These were created while
 the collector was starting or waiting for planner/GUIDED control and were
 stopped before frame collection began. Their existence does not indicate that
 IQ data was lost.
+
+### Controlled full-production stability campaign
+
+The follow-up campaign deliberately isolated the radio-to-Zarr path from
+navigation readiness. Each session used the rover's committed production V7
+configuration, direct USB, the expected attached radios, and `--fake-drone
+--no-ultrasonic`. It therefore validates radio configuration, firmware,
+streaming, metadata, record writing, and finalization. It does **not** validate
+GPS, compass, EKF, GUIDED mode, or the live MAVLink mission path.
+
+Before the full runs, four independent 100-frame sessions were run on every
+rover (12 preflight sessions total). All 12 finalized and passed the targeted
+deep V7 validator. The production campaign then produced:
+
+| Rover | Session | Store start (BST) | Result | Records by receiver | Approx. duration | Size |
+| --- | ---: | --- | --- | ---: | ---: | ---: |
+| Rover 1 | 1 | Jul 31 22:45:21 | Complete | 3,000 / 3,000 | 26m 47s | 8.4 GB |
+| Rover 1 | 2 | Jul 31 23:12:20 | Complete | 3,000 / 3,000 | 27m 00s | 8.4 GB |
+| Rover 1 | 3 | Jul 31 23:39:32 | Complete | 3,000 / 3,000 | 26m 51s | 8.4 GB |
+| Rover 1 | 4 | Aug 1 00:06:34 | Complete | 3,000 / 3,000 | 26m 49s | 8.4 GB |
+| Rover 2 | 1 | Jul 31 22:45:22 | Complete | 3,500 | 30m 09s | 4.9 GB |
+| Rover 2 | 2 | Jul 31 23:15:44 | Complete | 3,500 | 30m 07s | 4.9 GB |
+| Rover 2 | 3 | Jul 31 23:46:03 | Complete | 3,500 | 30m 03s | 4.9 GB |
+| Rover 2 | 4 | Aug 1 00:16:19 | Complete | 3,500 | 30m 51s | 4.9 GB |
+| Rover 3 | 1 | Jul 31 22:45:27 | Complete | 3,000 / 3,000 | 26m 55s | 8.6 GB |
+| Rover 3 | 2 | Jul 31 23:12:34 | Complete | 3,000 / 3,000 | 26m 24s | 8.6 GB |
+| Rover 3 | 3 | Jul 31 23:39:10 | Complete | 3,000 / 3,000 | 26m 43s | 8.6 GB |
+| Rover 3 | 4 | Aug 1 00:06:05 | Complete | 3,000 / 3,000 | 26m 49s | 8.6 GB |
+
+Campaign totals:
+
+| Rover | Production sessions passed | Receiver-records | Approx. data | Remaining disk after campaign |
+| --- | ---: | ---: | ---: | ---: |
+| Rover 1 | 4 / 4 | 24,000 | 33.6 GB | 263 GB |
+| Rover 2 | 4 / 4 | 14,000 | 19.6 GB | 314 GB |
+| Rover 3 | 4 / 4 | 24,000 | 34.4 GB | 254 GB |
+| **Total** | **12 / 12** | **62,000** | **87.6 GB** | — |
+
+Every production store passed the on-device lightweight validation of
+`capture_status=complete` and the expected per-receiver record counts. A deep
+scan of all production IQ was started read-only afterward, but one full store
+took more than six minutes and mapped roughly 2.3-2.7 GB of pages per process.
+It was stopped explicitly on all three rovers to avoid spending additional
+battery on a redundant 25-plus-minute-per-rover scan. No validator error had
+been emitted, no store was modified, and no validator or collector process was
+left running. Accordingly, the production stores have completion/count
+validation; the earlier 100-frame preflights have full targeted deep validation.
+
+#### Power monitoring during the campaign
+
+Power state was sampled before each session, once per minute during collection,
+after each session, and before allowing the next session to start. The gate
+would have stopped a rover's sequence if `vcgencmd get_throttled` returned
+anything other than `throttled=0x0`.
+
+- All samples on all three rovers returned `throttled=0x0`: no current or
+  historical Pi input undervoltage, frequency cap, or thermal throttle was
+  observed.
+- Approximate observed temperatures were 54-65 C on Rover 1, 36-41 C on Rover
+  2, and 38-49 C on Rover 3.
+- Final temperatures were 53.5 C, 36.5 C, and 37.9 C respectively.
+- The measured core rails were approximately 0.880-0.946 V on Rover 1, 0.926 V
+  on Rover 2, and 0.936 V on Rover 3. Rover 1's 0.880 V samples were normal CPU
+  dynamic voltage/frequency scaling because `get_throttled` remained clear.
+- These Pis expose no programmatic battery-terminal voltage sensor. Core voltage
+  is not battery state of charge; `get_throttled` is the available evidence for
+  integrity of the Pi input supply. The batteries sustained all four sessions
+  on every rover without an observable input-power event.
 
 ### Why Rover 1 ran for over 40 minutes without a complete Zarr
 
@@ -107,6 +195,24 @@ renamed to `.zarr`, because that would falsely represent incomplete captures as
 complete ones.
 
 ## Rover 1 root-cause analysis
+
+Rover 1 did not perform one 40-minute capture that somehow failed to appear.
+The evidence supports this sequence:
+
+| Time (BST) | What happened | Evidence | Consequence |
+| --- | --- | --- | --- |
+| 18:35:35-18:48:10 | First collector wrote 1,070/1,069 frames. | Nonzero Zarr timestamps span about 12m 35s; lifecycle remained `in_progress`. | The process was interrupted before its finalizer and the store remained `.zarr.tmp`. |
+| 18:48:26 | System/process target was started externally. | `wtmp` records a new runlevel/getty; the unit has `Restart=no`. | A new collector invocation began rather than resuming the first store. |
+| 18:49:02-18:58:20 | Second collector wrote 962/961 frames and then failed. | Lifecycle is `incomplete`; stored error is `TypeError`; Pluto cleanup returned `Errno 19`. | The second store correctly remained `.zarr.tmp`. |
+| About 18:58-19:49 | Pi remained powered but no mission IQ frames were written. | Last stored timestamp is around 18:58; hard power cycle is around 19:49. | Operator-visible uptime was mistaken for collection progress. |
+| 22:45 onward | Controlled follow-up ran four full production captures. | Four final Zarrs, 3,000/3,000 records each, 8.4 GB each. | Current end-to-end radio/V7 path is demonstrably functional, while the earlier intermittent failure remains valid evidence. |
+
+The first capture and second capture therefore have different failure classes.
+The first was terminated from outside the normal collector cleanup path. The
+second encountered a real radio/direct-USB failure, after which a retry-boundary
+bug replaced the useful transport exception with a misleading `NoneType`
+exception. The long apparent run time was mostly the rover remaining powered
+after collection had already stopped.
 
 ### Failure 1: the 18:35 capture was externally interrupted
 
@@ -264,6 +370,19 @@ should be made consistent and the corrected rule tested after re-enumeration.
 
 - Rover 2 produced two complete V7 captures with 3,500 records each.
 - Rover 3 produced two complete V7 captures with 3,000 records per radio.
+- In the controlled follow-up, all three rovers completed four consecutive
+  full production sessions: 12/12 sessions, approximately 87.6 GB, and 62,000
+  receiver-records in total.
+- Rover 1 specifically produced four consecutive complete 3,000/3,000-record
+  two-radio stores after its two earlier partial attempts. This demonstrates
+  recovery to a working state and rules out a persistent configuration or
+  writer incompatibility.
+- Four 100-frame preflight sessions per rover (12 total) finalized and passed
+  the targeted deep V7 validator before the full campaign.
+- Every full-production store reports `capture_status=complete` and the exact
+  expected per-receiver record counts.
+- Minute-by-minute power monitoring found no input undervoltage or throttling
+  during any production session; all inter-session power gates passed.
 - Completed captures reached the expected clean-close, shrink, and final rename
   path.
 - Rover 3's USB cable root cause was isolated through radio, power-supply, port,
@@ -353,9 +472,12 @@ distinguishable from naturally completed captures.
   `finalizing`, `complete`, and `failed`; a running process alone is not a
   collection-health signal.
 
-## Immediate next field check
+## Next field check
 
-Before another mission, run one 100-frame V7 capture on each rover and require:
+The radio-only prerequisite below was completed after the incident: each rover
+passed four 100-frame preflights and then four full production fake-drone
+captures. Before another *live mission*, retain the same artifact checks and
+add the navigation path that the fake-drone campaign intentionally excluded:
 
 - all expected radio serials and firmware fingerprints;
 - nonzero and equal record counts for every receiver;
@@ -365,4 +487,7 @@ Before another mission, run one 100-frame V7 capture on each rover and require:
 - successful load through the V7 reader; and
 - outdoor GPS, compass, EKF, and GUIDED readiness appropriate to the rover.
 
-Only after this passes should the normal mission record count be restored.
+The production record count has now been exercised successfully without
+ArduPilot. A live mission should proceed only after the outdoor GPS, compass,
+EKF, GUIDED, and MAVLink checks also pass and the operator can see a durable
+`collecting` state with advancing frame counts.


### PR DESCRIPTION
## What changed

Adds the July 31 Rover field report with collection timelines, completed and partial Zarr counts, system and MAVLink faults, successes, and prioritized mitigations.

## Root cause

Rover 1 produced two partial stores. The first collector was externally interrupted before its finalizer ran. The second lost access to a Pluto/direct-USB stream, but an off-by-one retry boundary returned None and masked the original transport exception as a secondary TypeError. Neither attempt reached the close, shrink, and final rename sequence.

## Impact

The report distinguishes system uptime from actual frame-writing time, preserves uncertainty caused by the lost prior-boot journal, and defines recovery and fail-visible acceptance conditions.

## Validation

- Correlated systemd, MAVLink, kernel, boot, USB, and Zarr lifecycle evidence from all three rovers.
- Read the Rover 1 LMDB stores in read-only mode and counted valid receiver rows.
- Ran git diff --cached --check.
- Documentation-only change; no large local test suite was run.
