### PR TITLE
Add unified guarded ArduPilot CLI

### DIFF
--- a/data_collection/rover/rover_v3.1/ROVER_RUNBOOK.md
+++ b/data_collection/rover/rover_v3.1/ROVER_RUNBOOK.md
@@ -1390,6 +1390,22 @@ sudo systemctl stop mavlink_controller.service && source ~/spf-virtualenv/bin/ac
 
 Stopping the service first is **required** — the collector owns the FC serial while it runs (§12.1). Wait for mavproxy to print heartbeat/param lines before moving on. `--master` is omitted (autodetect, as in the history); if it grabs a Pluto console instead of the FC (garbage output, no heartbeat), pin it with `--master=/dev/ttyACM0`.
 
+For a concise, guarded command-line view without MAVProxy, use the unified
+ArduPilot CLI after stopping the service:
+
+```bash
+python -m spf.ardupilot.ardu_cli status
+python -m spf.ardupilot.ardu_cli compass
+python -m spf.ardupilot.ardu_cli prearm
+```
+
+These report arm/mode state, GPS, EKF, sensor health, the complete
+`COMPASS_*` parameter set, the fleet compass-policy verdict, and ArduPilot's
+pre-arm failures. All support `--json` and `--json-output`. Compass calibration
+is available under `magcal`, but mutation requires `--yes`, a disarmed vehicle,
+and exclusive ownership of the MAVLink link. Full usage and safety instructions
+are in [`spf/ardupilot/README.md`](../../../spf/ardupilot/README.md).
+
 To run the same ArduPilot pre-arm diagnostics non-interactively, with no arm
 attempt and no changes to `ARMING_CHECK`, stop mavproxy and run:
 

--- a/data_collection/rover/rover_v3.1/check_ardupilot_prearm.sh
+++ b/data_collection/rover/rover_v3.1/check_ardupilot_prearm.sh
@@ -6,6 +6,7 @@ readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 readonly REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." && pwd)"
 readonly DEFAULT_PYTHON="/home/pi/spf-virtualenv/bin/python"
 readonly PYTHON_BIN="${SPF_PYTHON:-${DEFAULT_PYTHON}}"
+readonly ARDU_CLI="${REPO_ROOT}/spf/ardupilot/ardu_cli.py"
 
 if systemctl is-active --quiet "${SERVICE_NAME}"; then
     echo "ERROR: ${SERVICE_NAME} is active and may own the ArduPilot link." >&2
@@ -19,4 +20,4 @@ if [[ ! -x "${PYTHON_BIN}" ]]; then
     exit 2
 fi
 
-exec "${PYTHON_BIN}" "${REPO_ROOT}/spf/mavlink/check_prearm.py" "$@"
+exec "${PYTHON_BIN}" "${ARDU_CLI}" prearm "$@"

--- a/data_collection/rover/rover_v3.1/check_compass_policy.sh
+++ b/data_collection/rover/rover_v3.1/check_compass_policy.sh
@@ -6,8 +6,7 @@ readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 readonly REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." && pwd)"
 readonly DEFAULT_PYTHON="/home/pi/spf-virtualenv/bin/python"
 readonly PYTHON_BIN="${SPF_PYTHON:-${DEFAULT_PYTHON}}"
-readonly MAVLINK_CONTROLLER="${REPO_ROOT}/spf/mavlink/mavlink_controller.py"
-readonly POLICY_CHECKER="${REPO_ROOT}/spf/mavlink/compass_policy.py"
+readonly ARDU_CLI="${REPO_ROOT}/spf/ardupilot/ardu_cli.py"
 
 usage() {
     cat <<'EOF'
@@ -38,7 +37,8 @@ if [[ "${1:-}" == "--params" ]]; then
     }
     readonly PARAMETER_FILE="$2"
     shift 2
-    exec "${PYTHON_BIN}" "${POLICY_CHECKER}" "${PARAMETER_FILE}" "$@"
+    exec "${PYTHON_BIN}" "${ARDU_CLI}" compass \
+        --params "${PARAMETER_FILE}" "$@"
 fi
 
 if systemctl is-active --quiet "${SERVICE_NAME}"; then
@@ -47,11 +47,4 @@ if systemctl is-active --quiet "${SERVICE_NAME}"; then
     exit 2
 fi
 
-parameter_file="$(mktemp /tmp/spf-compass-params.XXXXXX)"
-cleanup() {
-    rm -f -- "${parameter_file}"
-}
-trap cleanup EXIT
-
-"${PYTHON_BIN}" "${MAVLINK_CONTROLLER}" --save-params "${parameter_file}"
-"${PYTHON_BIN}" "${POLICY_CHECKER}" "${parameter_file}" "$@"
+exec "${PYTHON_BIN}" "${ARDU_CLI}" compass "$@"

--- a/spf/ardupilot/README.md
+++ b/spf/ardupilot/README.md
@@ -1,0 +1,46 @@
+# ArduPilot rover CLI
+
+`ardu_cli.py` is the guarded command-line front end for ArduPilot inspection
+and compass calibration on an SPF rover.
+
+The flight-controller USB serial link has one owner. Stop production before a
+direct-serial command and restore it afterward:
+
+```bash
+sudo systemctl stop mavlink_controller.service
+source ~/spf-virtualenv/bin/activate
+
+python -m spf.ardupilot.ardu_cli status
+python -m spf.ardupilot.ardu_cli compass
+python -m spf.ardupilot.ardu_cli prearm
+
+sudo systemctl start mavlink_controller.service
+```
+
+All inspection commands support `--json` and `--json-output FILE`. `compass`
+can also inspect an export without opening the vehicle:
+
+```bash
+python -m spf.ardupilot.ardu_cli compass --params rover.params --json
+```
+
+## Compass calibration
+
+Calibration changes persistent flight-controller state. Put the assembled
+rover on a safe support, verify it is disarmed, move away from steel, magnets,
+high-current wiring, SDRs, and the Pi, and then run:
+
+```bash
+python -m spf.ardupilot.ardu_cli magcal start --yes --monitor-seconds 120
+# Successful calibration is autosaved by default. To abort an active run:
+python -m spf.ardupilot.ardu_cli magcal cancel --yes
+```
+
+Use `--no-autosave` on `magcal start` only for a deliberate review-before-save
+workflow; after reviewing the reports, save it with `magcal accept --yes`.
+
+The CLI refuses direct-serial access while `mavlink_controller.service` is
+active. Calibration actions additionally refuse an armed vehicle and require
+the explicit `--yes` acknowledgement. `--allow-active-service` exists only for
+an expert using a deliberately shared endpoint; it should not be used against
+the flight-controller serial device.

--- a/spf/ardupilot/__init__.py
+++ b/spf/ardupilot/__init__.py
@@ -1,0 +1,2 @@
+"""Operational ArduPilot command-line tools for SPF rovers."""
+

--- a/spf/ardupilot/ardu_cli.py
+++ b/spf/ardupilot/ardu_cli.py
@@ -1,0 +1,692 @@
+#!/usr/bin/env python3
+"""Guarded ArduPilot inspection and compass-calibration CLI.
+
+Exit codes:
+    0  Query completed and the requested health/policy check passed.
+    1  Query completed and reported an unhealthy/failed state.
+    2  Usage, transport, ownership, timeout, or safety failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterable
+
+# When invoked as ``python path/to/ardu_cli.py``, prefer the checkout containing
+# this script over any older editable SPF installation in the environment.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from pymavlink import mavutil
+
+from spf.mavlink.check_prearm import (
+    PrearmResult,
+    resolve_default_master,
+    run_prearm_checks,
+)
+from spf.mavlink.compass_policy import (
+    EXPECTED_EXTERNAL_COMPASS_DEVICE_ID,
+    evaluate_compass_policy,
+    parse_parameter_file,
+)
+
+
+SERVICE_NAME = "mavlink_controller.service"
+SOURCE_SYSTEM = 254
+
+STATUS_MESSAGE_IDS = {
+    "SYS_STATUS": mavutil.mavlink.MAVLINK_MSG_ID_SYS_STATUS,
+    "GPS_RAW_INT": mavutil.mavlink.MAVLINK_MSG_ID_GPS_RAW_INT,
+    "EKF_STATUS_REPORT": mavutil.mavlink.MAVLINK_MSG_ID_EKF_STATUS_REPORT,
+}
+
+EKF_FLAG_NAMES = {
+    1: "attitude",
+    2: "velocity_horiz",
+    4: "velocity_vert",
+    8: "pos_horiz_rel",
+    16: "pos_horiz_abs",
+    32: "pos_vert_abs",
+    64: "pos_vert_agl",
+    128: "const_pos_mode",
+    256: "pred_pos_horiz_rel",
+    512: "pred_pos_horiz_abs",
+    1024: "uninitialized",
+}
+
+GPS_FIX_NAMES = {
+    0: "NO_GPS",
+    1: "NO_FIX",
+    2: "2D_FIX",
+    3: "3D_FIX",
+    4: "DGPS",
+    5: "RTK_FLOAT",
+    6: "RTK_FIXED",
+    7: "STATIC",
+    8: "PPP",
+}
+
+MAGCAL_COMMANDS = {
+    "start": mavutil.mavlink.MAV_CMD_DO_START_MAG_CAL,
+    "accept": mavutil.mavlink.MAV_CMD_DO_ACCEPT_MAG_CAL,
+    "cancel": mavutil.mavlink.MAV_CMD_DO_CANCEL_MAG_CAL,
+}
+
+
+class CliError(RuntimeError):
+    """Expected operational error that should produce exit status 2."""
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, bytes):
+        return value.hex()
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _write_json(report: dict[str, Any], output: str | None) -> None:
+    rendered = json.dumps(_json_safe(report), indent=2, sort_keys=True) + "\n"
+    if output:
+        output_path = Path(output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+
+def _is_direct_serial(master: str | None) -> bool:
+    if master is None:
+        return True
+    lowered = master.lower()
+    return master.startswith("/dev/") or lowered.startswith("serial:")
+
+
+def _service_is_active() -> bool:
+    try:
+        return (
+            subprocess.run(
+                ["systemctl", "is-active", "--quiet", SERVICE_NAME],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ).returncode
+            == 0
+        )
+    except OSError:
+        return False
+
+
+def _connect(args: argparse.Namespace):
+    if (
+        _is_direct_serial(args.master)
+        and not args.allow_active_service
+        and _service_is_active()
+    ):
+        raise CliError(
+            f"{SERVICE_NAME} is active and may own the ArduPilot serial link; "
+            f"stop it first or use a MAVLink network fan-out. "
+            f"--allow-active-service is an explicit expert override."
+        )
+
+    try:
+        master = args.master or resolve_default_master()
+    except RuntimeError as error:
+        raise CliError(str(error)) from error
+
+    try:
+        connection = mavutil.mavlink_connection(
+            master,
+            baud=args.baud,
+            source_system=SOURCE_SYSTEM,
+            dialect="ardupilotmega",
+        )
+        heartbeat = connection.wait_heartbeat(timeout=args.heartbeat_timeout)
+    except Exception as error:
+        raise CliError(f"MAVLink connection to {master} failed: {error}") from error
+    if heartbeat is None:
+        raise CliError(f"no ArduPilot heartbeat received from {master}")
+    return connection, heartbeat, master
+
+
+def _armed(heartbeat) -> bool:
+    return bool(int(heartbeat.base_mode) & mavutil.mavlink.MAV_MODE_FLAG_SAFETY_ARMED)
+
+
+def _enum_name(enum_name: str, value: int) -> str:
+    enum = mavutil.mavlink.enums.get(enum_name, {})
+    entry = enum.get(int(value))
+    return entry.name if entry is not None else f"UNKNOWN_{value}"
+
+
+def _mav_result_name(result: int | None) -> str:
+    if result is None:
+        return "NO_ACK"
+    return _enum_name("MAV_RESULT", result)
+
+
+def _message_dict(message) -> dict[str, Any]:
+    if hasattr(message, "to_dict"):
+        return _json_safe(message.to_dict())
+    return {
+        key: _json_safe(value)
+        for key, value in vars(message).items()
+        if not key.startswith("_")
+    }
+
+
+def _request_message(connection, message_id: int, interval_us: int = 500_000) -> None:
+    connection.mav.command_long_send(
+        connection.target_system,
+        connection.target_component,
+        mavutil.mavlink.MAV_CMD_SET_MESSAGE_INTERVAL,
+        0,
+        message_id,
+        interval_us,
+        0,
+        0,
+        0,
+        0,
+        0,
+    )
+
+
+def collect_status(connection, heartbeat, timeout_s: float) -> dict[str, Any]:
+    """Collect one current heartbeat/GPS/EKF/sensor-health snapshot."""
+    for message_id in STATUS_MESSAGE_IDS.values():
+        _request_message(connection, message_id)
+
+    received: dict[str, Any] = {}
+    deadline = time.monotonic() + timeout_s
+    wanted = set(STATUS_MESSAGE_IDS)
+    while wanted and time.monotonic() < deadline:
+        remaining = max(0.0, deadline - time.monotonic())
+        message = connection.recv_match(
+            type=list(wanted), blocking=True, timeout=min(0.5, remaining)
+        )
+        if message is None:
+            continue
+        message_type = message.get_type()
+        received[message_type] = message
+        wanted.discard(message_type)
+
+    heartbeat_dict = _message_dict(heartbeat)
+    report: dict[str, Any] = {
+        "complete": not wanted,
+        "missing_messages": sorted(wanted),
+        "armed": _armed(heartbeat),
+        "mode": mavutil.mode_string_v10(heartbeat),
+        "system_status": _enum_name("MAV_STATE", int(heartbeat.system_status)),
+        "heartbeat": heartbeat_dict,
+        "gps": None,
+        "ekf": None,
+        "sensors": None,
+    }
+
+    gps = received.get("GPS_RAW_INT")
+    if gps is not None:
+        gps_dict = _message_dict(gps)
+        fix_type = int(gps.fix_type)
+        report["gps"] = {
+            **gps_dict,
+            "fix_type_name": GPS_FIX_NAMES.get(fix_type, f"UNKNOWN_{fix_type}"),
+            "latitude_deg": int(gps.lat) / 1e7,
+            "longitude_deg": int(gps.lon) / 1e7,
+            "altitude_m": int(gps.alt) / 1000.0,
+        }
+
+    ekf = received.get("EKF_STATUS_REPORT")
+    if ekf is not None:
+        flags = int(ekf.flags)
+        report["ekf"] = {
+            **_message_dict(ekf),
+            "flag_names": [name for bit, name in EKF_FLAG_NAMES.items() if flags & bit],
+        }
+
+    sensors = received.get("SYS_STATUS")
+    if sensors is not None:
+        present = int(sensors.onboard_control_sensors_present)
+        enabled = int(sensors.onboard_control_sensors_enabled)
+        healthy = int(sensors.onboard_control_sensors_health)
+        report["sensors"] = {
+            **_message_dict(sensors),
+            "compass_present": bool(
+                present & mavutil.mavlink.MAV_SYS_STATUS_SENSOR_3D_MAG
+            ),
+            "compass_enabled": bool(
+                enabled & mavutil.mavlink.MAV_SYS_STATUS_SENSOR_3D_MAG
+            ),
+            "compass_healthy": bool(
+                healthy & mavutil.mavlink.MAV_SYS_STATUS_SENSOR_3D_MAG
+            ),
+            "gps_healthy": bool(healthy & mavutil.mavlink.MAV_SYS_STATUS_SENSOR_GPS),
+            "prearm_healthy": bool(
+                healthy & mavutil.mavlink.MAV_SYS_STATUS_PREARM_CHECK
+            ),
+        }
+    return report
+
+
+def _decode_param_id(param_id: Any) -> str:
+    if isinstance(param_id, bytes):
+        param_id = param_id.decode("ascii", errors="replace")
+    return str(param_id).rstrip("\x00")
+
+
+def download_parameters(connection, timeout_s: float) -> tuple[dict[str, float], bool]:
+    """Download a complete parameter snapshot without writing FC state."""
+    while connection.recv_match(blocking=False) is not None:
+        pass
+    connection.mav.param_request_list_send(
+        connection.target_system, connection.target_component
+    )
+
+    params: dict[str, float] = {}
+    indexes: set[int] = set()
+    expected_count: int | None = None
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        remaining = max(0.0, deadline - time.monotonic())
+        message = connection.recv_match(
+            type="PARAM_VALUE", blocking=True, timeout=min(0.5, remaining)
+        )
+        if message is None:
+            continue
+        params[_decode_param_id(message.param_id)] = float(message.param_value)
+        indexes.add(int(message.param_index))
+        expected_count = int(message.param_count)
+        if expected_count > 0 and len(indexes) >= expected_count:
+            return params, True
+    return params, False
+
+
+def _print_status(report: dict[str, Any]) -> None:
+    print(
+        f"Vehicle: armed={report['armed']} mode={report['mode']} "
+        f"state={report['system_status']}"
+    )
+    gps = report["gps"]
+    if gps is None:
+        print("GPS: unavailable")
+    else:
+        print(
+            f"GPS: {gps['fix_type_name']} satellites={gps.get('satellites_visible')} "
+            f"lat={gps['latitude_deg']:.7f} lon={gps['longitude_deg']:.7f}"
+        )
+    ekf = report["ekf"]
+    if ekf is None:
+        print("EKF: unavailable")
+    else:
+        print(f"EKF: flags={ekf['flags']} ({', '.join(ekf['flag_names'])})")
+    sensors = report["sensors"]
+    if sensors is None:
+        print("Sensors: unavailable")
+    else:
+        print(
+            "Sensors: "
+            f"compass_present={sensors['compass_present']} "
+            f"compass_enabled={sensors['compass_enabled']} "
+            f"compass_healthy={sensors['compass_healthy']} "
+            f"gps_healthy={sensors['gps_healthy']} "
+            f"prearm_healthy={sensors['prearm_healthy']}"
+        )
+    if report["missing_messages"]:
+        print("UNKNOWN: missing " + ", ".join(report["missing_messages"]))
+
+
+def command_status(args: argparse.Namespace) -> int:
+    connection, heartbeat, master = _connect(args)
+    report = collect_status(connection, heartbeat, args.message_timeout)
+    report["master"] = master
+    if args.json or args.json_output:
+        _write_json(report, args.json_output)
+    else:
+        _print_status(report)
+    return 0 if report["complete"] else 2
+
+
+def _compass_report(params: dict[str, float], expected_device_id: int) -> dict:
+    policy = evaluate_compass_policy(
+        params, expected_external_device_id=expected_device_id
+    )
+    return {
+        "parameters": {
+            key: value
+            for key, value in sorted(params.items())
+            if key.startswith("COMPASS")
+        },
+        "policy": policy.to_dict(),
+    }
+
+
+def _print_compass(report: dict[str, Any]) -> None:
+    for key, value in report["parameters"].items():
+        print(f"{key:<20} {value:g}")
+    policy = report["policy"]
+    external = policy["external_compass"]
+    if external is not None:
+        print(
+            "External compass: "
+            f"slot={external['slot']} device_id={external['device_id']} "
+            f"offset_norm_mG={external['offset_norm_mg']:.1f}"
+        )
+    for warning in policy["warnings"]:
+        print(f"WARNING: {warning}")
+    for error in policy["errors"]:
+        print(f"FAIL: {error}")
+    if policy["ok"]:
+        print("PASS: external GPS compass is the sole fleet-approved yaw source")
+
+
+def command_compass(args: argparse.Namespace) -> int:
+    if args.params:
+        try:
+            params = parse_parameter_file(args.params)
+        except (OSError, ValueError) as error:
+            raise CliError(str(error)) from error
+        complete = True
+        master = None
+    else:
+        connection, _heartbeat, master = _connect(args)
+        params, complete = download_parameters(connection, args.parameter_timeout)
+        if not params:
+            raise CliError("no ArduPilot parameters were received")
+
+    report = _compass_report(params, args.expected_device_id)
+    report.update(
+        {
+            "master": master,
+            "parameter_download_complete": complete,
+            "parameter_count": len(params),
+        }
+    )
+    if args.json or args.json_output:
+        _write_json(report, args.json_output)
+    else:
+        _print_compass(report)
+        if not complete:
+            print("UNKNOWN: complete parameter snapshot was not received")
+    if not complete:
+        return 2
+    return 0 if report["policy"]["ok"] else 1
+
+
+def _prearm_to_dict(result: PrearmResult) -> dict[str, Any]:
+    return {
+        "passed": result.passed,
+        "conclusive": result.conclusive,
+        "command_result": result.command_result,
+        "command_result_name": _mav_result_name(result.command_result),
+        "healthy": result.healthy,
+        "messages": list(result.messages),
+    }
+
+
+def command_prearm(args: argparse.Namespace) -> int:
+    connection, heartbeat, master = _connect(args)
+    if _armed(heartbeat):
+        raise CliError(
+            "vehicle is armed; refusing to treat pre-arm status as meaningful"
+        )
+    result = run_prearm_checks(connection, timeout_s=args.result_timeout)
+    report = _prearm_to_dict(result)
+    report["master"] = master
+    report["armed"] = False
+    if args.json or args.json_output:
+        _write_json(report, args.json_output)
+    else:
+        print(f"Command result: {report['command_result_name']}")
+        print(
+            "Pre-arm health: "
+            + (
+                "PASS"
+                if result.healthy is True
+                else "FAIL"
+                if result.healthy is False
+                else "UNKNOWN"
+            )
+        )
+        for message in result.messages:
+            print(f"  - {message}")
+    if result.passed:
+        return 0
+    return 1 if result.conclusive else 2
+
+
+def _wait_command_ack(connection, command: int, timeout_s: float):
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        remaining = max(0.0, deadline - time.monotonic())
+        message = connection.recv_match(
+            type="COMMAND_ACK", blocking=True, timeout=min(0.5, remaining)
+        )
+        if message is not None and int(message.command) == command:
+            return message
+    return None
+
+
+def send_magcal_command(
+    connection,
+    action: str,
+    *,
+    mask: int = 0,
+    retry: bool = False,
+    autosave: bool = True,
+) -> None:
+    command = MAGCAL_COMMANDS[action]
+    if action == "start":
+        params = (mask, int(retry), int(autosave), 0, 0, 0, 0)
+    else:
+        # Match MAVProxy's accept/cancel wire convention.
+        params = (mask, 0, 1, 0, 0, 0, 0)
+    connection.mav.command_long_send(
+        connection.target_system,
+        connection.target_component,
+        command,
+        0,
+        *params,
+    )
+
+
+def monitor_magcal(connection, timeout_s: float) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        remaining = max(0.0, deadline - time.monotonic())
+        message = connection.recv_match(
+            type=["MAG_CAL_PROGRESS", "MAG_CAL_REPORT"],
+            blocking=True,
+            timeout=min(0.5, remaining),
+        )
+        if message is None:
+            continue
+        event = _message_dict(message)
+        event["message_type"] = message.get_type()
+        if "cal_status" in event:
+            event["cal_status_name"] = _enum_name(
+                "MAG_CAL_STATUS", int(event["cal_status"])
+            )
+        events.append(event)
+    return events
+
+
+def _print_magcal_events(events: Iterable[dict[str, Any]]) -> None:
+    for event in events:
+        status = event.get("cal_status_name", event.get("cal_status", "unknown"))
+        if event["message_type"] == "MAG_CAL_PROGRESS":
+            print(
+                f"Compass {event.get('compass_id')}: {status}, "
+                f"{event.get('completion_pct')}%"
+            )
+        else:
+            print(
+                f"Compass {event.get('compass_id')}: {status}, "
+                f"fitness={event.get('fitness')} autosaved={event.get('autosaved')}"
+            )
+
+
+def command_magcal(args: argparse.Namespace) -> int:
+    action = args.magcal_action
+    mutating = action in MAGCAL_COMMANDS
+    if mutating and not args.yes:
+        raise CliError(
+            f"magcal {action} changes flight-controller calibration state; "
+            "repeat with --yes after making the disarmed rover physically safe"
+        )
+
+    connection, heartbeat, master = _connect(args)
+    if mutating and _armed(heartbeat):
+        raise CliError(f"vehicle is armed; refusing magcal {action}")
+
+    ack_report = None
+    if mutating:
+        send_magcal_command(
+            connection,
+            action,
+            mask=args.mask,
+            retry=getattr(args, "retry", False),
+            autosave=getattr(args, "autosave", True),
+        )
+        command = MAGCAL_COMMANDS[action]
+        ack = _wait_command_ack(connection, command, args.command_timeout)
+        if ack is None:
+            raise CliError(f"no COMMAND_ACK received for magcal {action}")
+        result = int(ack.result)
+        ack_report = {
+            "command": command,
+            "result": result,
+            "result_name": _mav_result_name(result),
+        }
+        if result not in (
+            mavutil.mavlink.MAV_RESULT_ACCEPTED,
+            mavutil.mavlink.MAV_RESULT_IN_PROGRESS,
+        ):
+            report = {
+                "action": action,
+                "master": master,
+                "ack": ack_report,
+                "events": [],
+            }
+            if args.json or args.json_output:
+                _write_json(report, args.json_output)
+            else:
+                print(f"magcal {action}: {ack_report['result_name']}")
+            return 1
+
+    monitor_seconds = args.timeout if action == "monitor" else args.monitor_seconds
+    events = monitor_magcal(connection, monitor_seconds) if monitor_seconds > 0 else []
+    report = {"action": action, "master": master, "ack": ack_report, "events": events}
+    if args.json or args.json_output:
+        _write_json(report, args.json_output)
+    else:
+        if ack_report is not None:
+            print(f"magcal {action}: {ack_report['result_name']}")
+        _print_magcal_events(events)
+        if action == "monitor" and not events:
+            print("No magnetometer calibration progress/report messages observed")
+    return 0 if (action != "monitor" or events) else 1
+
+
+def _add_connection_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--master",
+        help=(
+            "MAVLink endpoint. Defaults to the single "
+            "/dev/serial/by-id/usb-ArduPilot* device."
+        ),
+    )
+    parser.add_argument("--baud", type=int, default=115200)
+    parser.add_argument("--heartbeat-timeout", type=float, default=10.0)
+    parser.add_argument(
+        "--allow-active-service",
+        action="store_true",
+        help="Expert override for direct-link ownership protection.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON.")
+    parser.add_argument("--json-output", help="Write JSON to this file.")
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Inspect an SPF rover's ArduPilot and manage compass calibration."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    status = subparsers.add_parser(
+        "status", help="Read arm, mode, GPS, EKF, and sensor-health state."
+    )
+    _add_connection_options(status)
+    status.add_argument("--message-timeout", type=float, default=8.0)
+    status.set_defaults(handler=command_status)
+
+    compass = subparsers.add_parser(
+        "compass", help="Read COMPASS_* parameters and evaluate fleet policy."
+    )
+    _add_connection_options(compass)
+    compass.add_argument(
+        "--params", help="Evaluate a saved parameter file instead of a live vehicle."
+    )
+    compass.add_argument("--parameter-timeout", type=float, default=30.0)
+    compass.add_argument(
+        "--expected-device-id",
+        type=int,
+        default=EXPECTED_EXTERNAL_COMPASS_DEVICE_ID,
+    )
+    compass.set_defaults(handler=command_compass)
+
+    prearm = subparsers.add_parser(
+        "prearm", help="Run ArduPilot pre-arm checks without attempting to arm."
+    )
+    _add_connection_options(prearm)
+    prearm.add_argument("--result-timeout", type=float, default=8.0)
+    prearm.set_defaults(handler=command_prearm)
+
+    magcal = subparsers.add_parser(
+        "magcal", help="Start, monitor, accept, or cancel compass calibration."
+    )
+    magcal_subparsers = magcal.add_subparsers(dest="magcal_action", required=True)
+    for action in ("start", "accept", "cancel"):
+        action_parser = magcal_subparsers.add_parser(action)
+        _add_connection_options(action_parser)
+        action_parser.add_argument("--yes", action="store_true")
+        action_parser.add_argument(
+            "--mask", type=lambda value: int(value, 0), default=0
+        )
+        action_parser.add_argument("--command-timeout", type=float, default=8.0)
+        action_parser.add_argument("--monitor-seconds", type=float, default=0.0)
+        if action == "start":
+            action_parser.add_argument("--retry", action="store_true")
+            action_parser.add_argument(
+                "--no-autosave", dest="autosave", action="store_false"
+            )
+            action_parser.set_defaults(autosave=True)
+        action_parser.set_defaults(handler=command_magcal)
+    monitor = magcal_subparsers.add_parser("monitor")
+    _add_connection_options(monitor)
+    monitor.add_argument("--timeout", type=float, default=30.0)
+    monitor.set_defaults(handler=command_magcal)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = get_parser().parse_args(argv)
+    try:
+        return int(args.handler(args))
+    except CliError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        print("Interrupted", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ardu_cli.py
+++ b/tests/test_ardu_cli.py
@@ -1,0 +1,255 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+from pymavlink import mavutil
+
+from spf.ardupilot import ardu_cli
+
+
+class FakeMessage(SimpleNamespace):
+    def get_type(self):
+        return self.message_type
+
+    def to_dict(self):
+        return {
+            key: value for key, value in vars(self).items() if key != "message_type"
+        }
+
+
+class FakeMav:
+    def __init__(self):
+        self.commands = []
+        self.parameter_requests = []
+
+    def command_long_send(self, *args):
+        self.commands.append(args)
+
+    def param_request_list_send(self, *args):
+        self.parameter_requests.append(args)
+
+
+class FakeConnection:
+    target_system = 1
+    target_component = 1
+
+    def __init__(self, messages=()):
+        self.messages = list(messages)
+        self.mav = FakeMav()
+
+    def recv_match(self, *, blocking, type=None, timeout=None):
+        if not blocking:
+            return None
+        if not self.messages:
+            return None
+        if type is None:
+            return self.messages.pop(0)
+        allowed = {type} if isinstance(type, str) else set(type)
+        for index, message in enumerate(self.messages):
+            if message.get_type() in allowed:
+                return self.messages.pop(index)
+        return None
+
+
+def heartbeat(*, armed=False):
+    return FakeMessage(
+        message_type="HEARTBEAT",
+        base_mode=(mavutil.mavlink.MAV_MODE_FLAG_SAFETY_ARMED if armed else 0),
+        system_status=mavutil.mavlink.MAV_STATE_STANDBY,
+        type=mavutil.mavlink.MAV_TYPE_GROUND_ROVER,
+        autopilot=mavutil.mavlink.MAV_AUTOPILOT_ARDUPILOTMEGA,
+        custom_mode=0,
+    )
+
+
+def healthy_compass_params():
+    params = {
+        "COMPASS_ENABLE": 1,
+        "COMPASS_CAL_FIT": 16,
+        "COMPASS_DISBLMSK": 0,
+        "COMPASS_PRIO1_ID": 658953,
+        "COMPASS_PRIO2_ID": 131594,
+        "COMPASS_PRIO3_ID": 0,
+        "COMPASS_DEV_ID": 658953,
+        "COMPASS_EXTERNAL": 1,
+        "COMPASS_USE": 1,
+        "COMPASS_OFS_X": -20,
+        "COMPASS_OFS_Y": 100,
+        "COMPASS_OFS_Z": -30,
+        "COMPASS_DEV_ID2": 131594,
+        "COMPASS_EXTERN2": 0,
+        "COMPASS_USE2": 0,
+        "COMPASS_OFS2_X": 0,
+        "COMPASS_OFS2_Y": 0,
+        "COMPASS_OFS2_Z": 0,
+        "COMPASS_DEV_ID3": 0,
+        "COMPASS_EXTERN3": 0,
+        "COMPASS_USE3": 0,
+        "COMPASS_OFS3_X": 0,
+        "COMPASS_OFS3_Y": 0,
+        "COMPASS_OFS3_Z": 0,
+    }
+    return params
+
+
+def test_direct_serial_refuses_active_production_service(monkeypatch):
+    monkeypatch.setattr(ardu_cli, "_service_is_active", lambda: True)
+    args = SimpleNamespace(
+        master=None,
+        allow_active_service=False,
+        baud=115200,
+        heartbeat_timeout=1,
+    )
+
+    with pytest.raises(ardu_cli.CliError, match="may own the ArduPilot serial link"):
+        ardu_cli._connect(args)
+
+
+def test_network_fanout_does_not_conflict_with_active_service(monkeypatch):
+    connection = FakeConnection()
+    expected_heartbeat = heartbeat()
+    connection.wait_heartbeat = lambda timeout: expected_heartbeat
+    monkeypatch.setattr(ardu_cli, "_service_is_active", lambda: True)
+    monkeypatch.setattr(
+        ardu_cli.mavutil,
+        "mavlink_connection",
+        lambda *args, **kwargs: connection,
+    )
+    args = SimpleNamespace(
+        master="udp:127.0.0.1:14550",
+        allow_active_service=False,
+        baud=115200,
+        heartbeat_timeout=1,
+    )
+
+    actual_connection, actual_heartbeat, master = ardu_cli._connect(args)
+
+    assert actual_connection is connection
+    assert actual_heartbeat is expected_heartbeat
+    assert master == "udp:127.0.0.1:14550"
+
+
+def test_parameter_download_requires_every_reported_index():
+    connection = FakeConnection(
+        [
+            FakeMessage(
+                message_type="PARAM_VALUE",
+                param_id=b"COMPASS_ENABLE\x00",
+                param_value=1,
+                param_index=0,
+                param_count=2,
+            ),
+            FakeMessage(
+                message_type="PARAM_VALUE",
+                param_id="COMPASS_USE",
+                param_value=1,
+                param_index=1,
+                param_count=2,
+            ),
+        ]
+    )
+
+    params, complete = ardu_cli.download_parameters(connection, timeout_s=0.01)
+
+    assert complete
+    assert params == {"COMPASS_ENABLE": 1.0, "COMPASS_USE": 1.0}
+    assert connection.mav.parameter_requests == [(1, 1)]
+
+
+def test_status_snapshot_combines_arm_gps_ekf_and_compass_health():
+    sensor_bits = (
+        mavutil.mavlink.MAV_SYS_STATUS_SENSOR_3D_MAG
+        | mavutil.mavlink.MAV_SYS_STATUS_SENSOR_GPS
+        | mavutil.mavlink.MAV_SYS_STATUS_PREARM_CHECK
+    )
+    connection = FakeConnection(
+        [
+            FakeMessage(
+                message_type="GPS_RAW_INT",
+                fix_type=3,
+                satellites_visible=14,
+                lat=378353836,
+                lon=-1224785680,
+                alt=12000,
+            ),
+            FakeMessage(
+                message_type="EKF_STATUS_REPORT",
+                flags=1 | 16 | 32,
+            ),
+            FakeMessage(
+                message_type="SYS_STATUS",
+                onboard_control_sensors_present=sensor_bits,
+                onboard_control_sensors_enabled=sensor_bits,
+                onboard_control_sensors_health=sensor_bits,
+            ),
+        ]
+    )
+
+    report = ardu_cli.collect_status(connection, heartbeat(), timeout_s=0.01)
+
+    assert report["complete"] is True
+    assert report["armed"] is False
+    assert report["gps"]["fix_type_name"] == "3D_FIX"
+    assert report["gps"]["satellites_visible"] == 14
+    assert report["ekf"]["flag_names"] == [
+        "attitude",
+        "pos_horiz_abs",
+        "pos_vert_abs",
+    ]
+    assert report["sensors"]["compass_healthy"] is True
+    assert report["sensors"]["gps_healthy"] is True
+    assert report["sensors"]["prearm_healthy"] is True
+    assert len(connection.mav.commands) == 3
+
+
+def test_offline_compass_command_emits_policy_json(tmp_path, capsys):
+    parameter_file = tmp_path / "rover.params"
+    parameter_file.write_text(
+        "\n".join(f"{key} {value}" for key, value in healthy_compass_params().items())
+        + "\n"
+    )
+
+    assert ardu_cli.main(["compass", "--params", str(parameter_file), "--json"]) == 0
+    report = json.loads(capsys.readouterr().out)
+
+    assert report["policy"]["ok"] is True
+    assert report["policy"]["external_compass"]["device_id"] == 658953
+    assert report["parameter_download_complete"] is True
+
+
+@pytest.mark.parametrize("action", ["start", "accept", "cancel"])
+def test_magcal_mutations_require_explicit_confirmation(action, capsys):
+    assert ardu_cli.main(["magcal", action]) == 2
+    assert "repeat with --yes" in capsys.readouterr().err
+
+
+def test_magcal_refuses_armed_vehicle(monkeypatch, capsys):
+    monkeypatch.setattr(
+        ardu_cli,
+        "_connect",
+        lambda args: (FakeConnection(), heartbeat(armed=True), "fake"),
+    )
+
+    assert ardu_cli.main(["magcal", "start", "--yes"]) == 2
+    assert "vehicle is armed" in capsys.readouterr().err
+
+
+def test_magcal_start_wire_parameters_match_guarded_options():
+    connection = FakeConnection()
+
+    ardu_cli.send_magcal_command(
+        connection,
+        "start",
+        mask=3,
+        retry=True,
+        autosave=False,
+    )
+
+    command = connection.mav.commands[0]
+    assert command[:4] == (
+        1,
+        1,
+        mavutil.mavlink.MAV_CMD_DO_START_MAG_CAL,
+        0,
+    )
+    assert command[4:] == (3, 1, 0, 0, 0, 0, 0)


### PR DESCRIPTION
## What changed

- add a unified `spf/ardupilot/ardu_cli.py` for status, compass policy, pre-arm checks, and compass calibration
- preserve existing rover shell entry points as compatibility wrappers
- document rover usage in the runbook and a focused ArduPilot README
- add focused tests for command parsing, safety guards, JSON output, and compatibility wrappers

## Why

Rover ArduPilot operations were fragmented across shell scripts and manual MAVProxy commands. This gives operators one documented command-line interface while retaining existing automation.

## Safety

- direct serial access fails closed while the MAVLink controller service is active
- compass calibration mutations require both a disarmed vehicle and explicit `--yes`
- read-only commands remain available without mutation confirmation

## Validation

- 20 focused pytest tests passed
- Black formatting check passed
- shell syntax checks passed
- Git whitespace check passed