### PR TITLE
ci: fix the last two test failures on main

### DIFF
--- a/spf/calibrations/dual_rx_gain_frequency/configs/all_gain_cross_2p4.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/all_gain_cross_2p4.yaml
@@ -21,7 +21,10 @@ pluto-firmware:
   image-sha256: 0a6a8939b31babed2ad7093d83941ebc809323d69804adcd8da5bcae0e48d3e9
   firmware-git-sha: 7b02276519a802aed83d47b6672c46e578ce4de0
   gadget-git-sha: a1e6417d07188bd72be70692e28c5d6ae9a5ec62
-  boot-mode: ram
+  # Match the rover production configs: the image is persisted in mtd3 and
+  # boot preparation only reflashes when the active image differs. Calibrate
+  # against the same firmware state the rovers actually fly.
+  boot-mode: qspi
 
 calibration:
   frequencies-hz: [2412000000, 2467000000]

--- a/spf/calibrations/dual_rx_gain_frequency/configs/coarse_5ghz.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/coarse_5ghz.yaml
@@ -9,7 +9,10 @@ pluto-firmware:
   image-sha256: 0a6a8939b31babed2ad7093d83941ebc809323d69804adcd8da5bcae0e48d3e9
   firmware-git-sha: 7b02276519a802aed83d47b6672c46e578ce4de0
   gadget-git-sha: a1e6417d07188bd72be70692e28c5d6ae9a5ec62
-  boot-mode: ram
+  # Match the rover production configs: the image is persisted in mtd3 and
+  # boot preparation only reflashes when the active image differs. Calibrate
+  # against the same firmware state the rovers actually fly.
+  boot-mode: qspi
 
 calibration:
   frequencies-hz:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/frequency_scout_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/frequency_scout_cross_band.yaml
@@ -13,7 +13,10 @@ pluto-firmware:
   image-sha256: 0a6a8939b31babed2ad7093d83941ebc809323d69804adcd8da5bcae0e48d3e9
   firmware-git-sha: 7b02276519a802aed83d47b6672c46e578ce4de0
   gadget-git-sha: a1e6417d07188bd72be70692e28c5d6ae9a5ec62
-  boot-mode: ram
+  # Match the rover production configs: the image is persisted in mtd3 and
+  # boot preparation only reflashes when the active image differs. Calibrate
+  # against the same firmware state the rovers actually fly.
+  boot-mode: qspi
 
 calibration:
   frequencies-hz:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/historical_exact_lo_cross_2p4.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/historical_exact_lo_cross_2p4.yaml
@@ -13,7 +13,10 @@ pluto-firmware:
   image-sha256: 0a6a8939b31babed2ad7093d83941ebc809323d69804adcd8da5bcae0e48d3e9
   firmware-git-sha: 7b02276519a802aed83d47b6672c46e578ce4de0
   gadget-git-sha: a1e6417d07188bd72be70692e28c5d6ae9a5ec62
-  boot-mode: ram
+  # Match the rover production configs: the image is persisted in mtd3 and
+  # boot preparation only reflashes when the active image differs. Calibrate
+  # against the same firmware state the rovers actually fly.
+  boot-mode: qspi
 
 calibration:
   frequencies-hz: [2411950000, 2467100000]

--- a/spf/calibrations/dual_rx_gain_frequency/configs/integer_gain_cross_2p4.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/integer_gain_cross_2p4.yaml
@@ -18,7 +18,10 @@ pluto-firmware:
   image-sha256: 0a6a8939b31babed2ad7093d83941ebc809323d69804adcd8da5bcae0e48d3e9
   firmware-git-sha: 7b02276519a802aed83d47b6672c46e578ce4de0
   gadget-git-sha: a1e6417d07188bd72be70692e28c5d6ae9a5ec62
-  boot-mode: ram
+  # Match the rover production configs: the image is persisted in mtd3 and
+  # boot preparation only reflashes when the active image differs. Calibrate
+  # against the same firmware state the rovers actually fly.
+  boot-mode: qspi
 
 calibration:
   frequencies-hz: [2412000000, 2467000000]

--- a/spf/calibrations/dual_rx_gain_frequency/configs/pilot_5ghz.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/pilot_5ghz.yaml
@@ -9,7 +9,10 @@ pluto-firmware:
   image-sha256: 0a6a8939b31babed2ad7093d83941ebc809323d69804adcd8da5bcae0e48d3e9
   firmware-git-sha: 7b02276519a802aed83d47b6672c46e578ce4de0
   gadget-git-sha: a1e6417d07188bd72be70692e28c5d6ae9a5ec62
-  boot-mode: ram
+  # Match the rover production configs: the image is persisted in mtd3 and
+  # boot preparation only reflashes when the active image differs. Calibrate
+  # against the same firmware state the rovers actually fly.
+  boot-mode: qspi
 
 calibration:
   frequencies-hz:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/pilot_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/pilot_cross_band.yaml
@@ -12,7 +12,10 @@ pluto-firmware:
   image-sha256: 0a6a8939b31babed2ad7093d83941ebc809323d69804adcd8da5bcae0e48d3e9
   firmware-git-sha: 7b02276519a802aed83d47b6672c46e578ce4de0
   gadget-git-sha: a1e6417d07188bd72be70692e28c5d6ae9a5ec62
-  boot-mode: ram
+  # Match the rover production configs: the image is persisted in mtd3 and
+  # boot preparation only reflashes when the active image differs. Calibrate
+  # against the same firmware state the rovers actually fly.
+  boot-mode: qspi
 
 calibration:
   frequencies-hz:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/power_cycle_subsample.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/power_cycle_subsample.yaml
@@ -13,7 +13,10 @@ pluto-firmware:
   image-sha256: 0a6a8939b31babed2ad7093d83941ebc809323d69804adcd8da5bcae0e48d3e9
   firmware-git-sha: 7b02276519a802aed83d47b6672c46e578ce4de0
   gadget-git-sha: a1e6417d07188bd72be70692e28c5d6ae9a5ec62
-  boot-mode: ram
+  # Match the rover production configs: the image is persisted in mtd3 and
+  # boot preparation only reflashes when the active image differs. Calibrate
+  # against the same firmware state the rovers actually fly.
+  boot-mode: qspi
 
 calibration:
   frequencies-hz:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/spectroscopy_campaign_base.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/spectroscopy_campaign_base.yaml
@@ -9,7 +9,10 @@ pluto-firmware:
   image-sha256: 0a6a8939b31babed2ad7093d83941ebc809323d69804adcd8da5bcae0e48d3e9
   firmware-git-sha: 7b02276519a802aed83d47b6672c46e578ce4de0
   gadget-git-sha: a1e6417d07188bd72be70692e28c5d6ae9a5ec62
-  boot-mode: ram
+  # Match the rover production configs: the image is persisted in mtd3 and
+  # boot preparation only reflashes when the active image differs. Calibrate
+  # against the same firmware state the rovers actually fly.
+  boot-mode: qspi
 
 calibration:
   frequencies-hz: [5766000000]

--- a/spf/calibrations/dual_rx_gain_frequency/configs/survey_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/survey_cross_band.yaml
@@ -13,7 +13,10 @@ pluto-firmware:
   image-sha256: 0a6a8939b31babed2ad7093d83941ebc809323d69804adcd8da5bcae0e48d3e9
   firmware-git-sha: 7b02276519a802aed83d47b6672c46e578ce4de0
   gadget-git-sha: a1e6417d07188bd72be70692e28c5d6ae9a5ec62
-  boot-mode: ram
+  # Match the rover production configs: the image is persisted in mtd3 and
+  # boot preparation only reflashes when the active image differs. Calibrate
+  # against the same firmware state the rovers actually fly.
+  boot-mode: qspi
 
 calibration:
   frequencies-hz:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/wide_integer_gain_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/wide_integer_gain_cross_band.yaml
@@ -15,7 +15,10 @@ pluto-firmware:
   image-sha256: 0a6a8939b31babed2ad7093d83941ebc809323d69804adcd8da5bcae0e48d3e9
   firmware-git-sha: 7b02276519a802aed83d47b6672c46e578ce4de0
   gadget-git-sha: a1e6417d07188bd72be70692e28c5d6ae9a5ec62
-  boot-mode: ram
+  # Match the rover production configs: the image is persisted in mtd3 and
+  # boot preparation only reflashes when the active image differs. Calibrate
+  # against the same firmware state the rovers actually fly.
+  boot-mode: qspi
 
 calibration:
   frequencies-hz:

--- a/tests/test_direct_usb_compatibility.py
+++ b/tests/test_direct_usb_compatibility.py
@@ -22,7 +22,11 @@ class _OneFrameReceiver:
         self.calls += 1
         assert samples_per_channel == 8
         assert frame_count == 1
-        return SimpleNamespace(frames=(self.frame,))
+        return SimpleNamespace(
+            frames=(self.frame,),
+            recovered_after_transport_loss=False,
+            transport_loss_summary=None,
+        )
 
 
 def _metadata_v2():

--- a/tests/test_dual_rx_gain_frequency_automation.py
+++ b/tests/test_dual_rx_gain_frequency_automation.py
@@ -79,7 +79,7 @@ def test_automate_prepares_probes_captures_validates_and_resumes(tmp_path, monke
     assert result["radio_serials"] == list(serials)
     plan = json.loads((output / "automation_plan.json").read_text())
     assert plan["radio_serials"] == list(serials)
-    assert plan["firmware"]["boot-mode"] == "ram"
+    assert plan["firmware"]["boot-mode"] == "qspi"
     for serial in serials:
         assert json.loads((output / serial / "probe.json").read_text())["status"] == (
             "pass"


### PR DESCRIPTION
The last 5 failures blocking a green run. Both clusters are the same shape: a dependent that wasn't updated when the thing it depends on changed. **Neither is a production defect.**

Baseline for this branch is run [30731192070](https://github.com/misko/spf/actions/runs/30731192070) — `5 failed, 770 passed, 6 skipped, 2 xfailed`.

## 1. Stale test double — 3 failures in `tests/test_direct_usb_compatibility.py`

```
AttributeError: 'types.SimpleNamespace' object has no attribute 'recovered_after_transport_loss'
  at spf/sdrpluto/sdr_controller.py:870
```

`5821e90` added `recovered_after_transport_loss` and `transport_loss_summary` to the `DirectUsbCapture` dataclass, plus a consumer that reads the first at the top of `_capture_direct_frame`:

```python
capture = self.direct_rx.capture(...)
if capture.recovered_after_transport_loss:      # new
    raise DirectUsbStreamDiscontinuityError(...)
```

The file's `_OneFrameReceiver` double still returned `SimpleNamespace(frames=(self.frame,))`. Every test that goes through the capture path raised. The fourth test in the file passes precisely because it never calls `rx()` — the failure set exactly tracks "does this test reach line 870".

**Fix:** give the double the real dataclass's own defaults, so it describes the case these tests mean — a clean capture with no transport loss.

`tests/test_interrupted_capture_harness.py:37` has a similar stub, but it drives `harness._capture_from_fresh_probe_session`, which never reads these fields. Checked; unaffected.

## 2. Config drift — 2 failures in `tests/test_dual_rx_gain_frequency_automation.py`

```
ValueError: calibration and preparation configs pin different Pluto firmware
  at spf/calibrations/dual_rx_gain_frequency/automation.py:97
```

`run_automated_calibration` refuses to start if the calibration config and the rover preparation config pin different firmware — a good interlock, so you can't calibrate against firmware A and fly firmware B. It compares seven fields with `!=`.

`d1fded6` moved `rover{1,2,3}_production_v7.yaml` to persistent QSPI flash and left the calibration configs on RAM side-load. Field-by-field, the two blocks are:

| | calibration | rover |
|---|---|---|
| release-tag, asset-name, image-url, image-sha256, firmware-git-sha, gadget-git-sha | *identical* | *identical* |
| **boot-mode** | **`ram`** | **`qspi`** |

Same `image-sha256` — byte-identical firmware. The interlock was firing on the delivery mechanism.

**Fix:** point the calibration configs at the boot mode the rovers actually fly.

This is **declarative only**. The calibration document's `boot-mode` is not read by anything except this comparison — the sole `boot-mode` reference under `spf/calibrations/` is `automation.py:76`, which reads the *rover* plan — and `_prepare_radios` drives the real flashing from the rover config via `SPF_CAPTURE_CONFIG`. No firmware handling changes.

**All eleven** calibration configs carrying a `pluto-firmware` block are updated, not just the one the test loads. Every one pinned `ram` and would have tripped the same interlock against any rover production config; fixing one would have left ten identical landmines. (`spectroscopy_campaign.yaml` has no firmware block and is untouched.)

The recorded-provenance assertion in the automation test moves with it, since `automation_plan.json` now records `qspi`.

## Verification

Against the CI interpreter (python 3.10.15, pytest 8.3.3, same self-hosted host):

| check | before | after |
|---|---|---|
| the two affected files | 5 failed, 5 passed | **10 passed** |
| `-k "firmware or pluto or capture_profile or manifest or calibration"` | — | 98 passed |
| every calibration config vs every rover production config | 11 mismatches | **0 mismatches** |
| all calibration YAML parses | ok | ok |
| `flake8 --select=E9,F63,F7,F82,F811` | 0 | 0 |

**The interlock still works.** `test_automate_refuses_firmware_mismatch_before_preparation` mutates `image-sha256` to `"d" * 64` and still gets its `ValueError` — a different image is still a different image.

## Note on the pattern

Four separate CI breakages now trace to `5821e90` and `d1fded6` — both production hardening that didn't update its dependents, both landing on an unprotected `main` with no passing-CI gate. Worth considering branch protection; the individual bugs are cheap, the pattern isn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)