### PR TITLE
spf/evaluation: frame-aware metric primitives, filter-agnostic

### DIFF
--- a/spf/evaluation/__init__.py
+++ b/spf/evaluation/__init__.py
@@ -1,0 +1,79 @@
+"""Frame-aware scoring for SPF predictions.
+
+Filter-agnostic on purpose: the same functions score an EKF track, a particle
+filter track, a network posterior before any filtering, or the empirical
+``P(theta | phi)`` baseline. That is what makes "how much of the error is the
+model and how much is the tracker?" an answerable question.
+
+    from spf.evaluation import summarize, coverage, CRAFT_RELATIVE
+
+    summarize(pred_theta, ground_truth)          # mse / rmse / mae block
+    coverage(pred_theta, ground_truth, sigma)    # is the reported sigma real?
+    posterior.summarize(model_output, truth)     # score P(theta) with no filter
+"""
+
+from spf.evaluation import aggregate, calibration, frames, metrics, posterior
+from spf.evaluation.aggregate import aggregate as aggregate_results
+from spf.evaluation.aggregate import group_results, rank, summarize_group
+from spf.evaluation.calibration import (
+    NOMINAL_COVERAGE,
+    calibration_ratio,
+    coverage,
+    reliability_curve,
+    z_scores,
+)
+from spf.evaluation.frames import (
+    ABSOLUTE_NORTH,
+    CRAFT_RELATIVE,
+    FRAMES,
+    RADIO_FOLDED,
+    FrameMismatch,
+    check_frame,
+    require_same_frame,
+)
+from spf.evaluation.metrics import (
+    angular_error,
+    circular_mean,
+    circular_std,
+    mae,
+    median_absolute_error,
+    mse,
+    rmse,
+    rmse_deg,
+    summarize,
+    wrap_to_pi,
+)
+
+__all__ = [
+    "aggregate",
+    "calibration",
+    "frames",
+    "metrics",
+    "posterior",
+    "aggregate_results",
+    "group_results",
+    "rank",
+    "summarize_group",
+    "NOMINAL_COVERAGE",
+    "calibration_ratio",
+    "coverage",
+    "reliability_curve",
+    "z_scores",
+    "ABSOLUTE_NORTH",
+    "CRAFT_RELATIVE",
+    "FRAMES",
+    "RADIO_FOLDED",
+    "FrameMismatch",
+    "check_frame",
+    "require_same_frame",
+    "angular_error",
+    "circular_mean",
+    "circular_std",
+    "mae",
+    "median_absolute_error",
+    "mse",
+    "rmse",
+    "rmse_deg",
+    "summarize",
+    "wrap_to_pi",
+]

--- a/spf/evaluation/aggregate.py
+++ b/spf/evaluation/aggregate.py
@@ -1,0 +1,94 @@
+"""Group sweep results and average their metrics -- never across frames.
+
+The existing reporter builds its grouping key from every non-metric field and
+averages whatever lands together. That is fine until two runs differ in a field
+that changes what "ground truth" means, at which point it averages answers to
+two different questions. ``frame`` is always part of the key here, and a missing
+frame is an error rather than a default.
+"""
+
+from collections import OrderedDict
+
+import numpy as np
+
+from spf.evaluation.frames import check_frame
+
+
+def _key(result, group_keys):
+    return tuple((k, result.get(k)) for k in group_keys)
+
+
+def group_results(results, group_keys):
+    """Bucket result dicts by ``group_keys``, with ``frame`` always included.
+
+    Each result must carry a ``frame`` and a ``metrics`` dict. Returns an
+    ordered mapping from key tuple -> list of results.
+    """
+    keys = list(group_keys)
+    if "frame" not in keys:
+        keys = ["frame"] + keys
+
+    grouped = OrderedDict()
+    for i, result in enumerate(results):
+        if "frame" not in result:
+            raise ValueError(
+                f"result {i} has no 'frame'; every prediction must declare the "
+                "angular frame it was scored in"
+            )
+        check_frame(result["frame"])
+        if "metrics" not in result:
+            raise ValueError(f"result {i} has no 'metrics'")
+        grouped.setdefault(_key(result, keys), []).append(result)
+    return grouped
+
+
+def summarize_group(group):
+    """Mean/std/n for every metric shared by all members of one group.
+
+    Metrics present on some members but not others are dropped rather than
+    averaged over a varying denominator, and the dropped names are reported so
+    the omission is visible instead of silent.
+    """
+    if not group:
+        raise ValueError("empty group")
+    metric_sets = [set(r["metrics"].keys()) for r in group]
+    common = set.intersection(*metric_sets)
+    dropped = sorted(set.union(*metric_sets) - common)
+
+    out = {"n_runs": len(group)}
+    for name in sorted(common):
+        values = np.array([float(r["metrics"][name]) for r in group], dtype=np.float64)
+        out[f"{name}_mean"] = float(values.mean())
+        out[f"{name}_std"] = float(values.std())
+    if dropped:
+        out["dropped_metrics"] = dropped
+    return out
+
+
+def aggregate(results, group_keys):
+    """Group then summarize. Returns a list of flat row dicts, ready for CSV/JSON."""
+    rows = []
+    for key, group in group_results(results, group_keys).items():
+        row = dict(key)
+        row.update(summarize_group(group))
+        rows.append(row)
+    return rows
+
+
+def rank(rows, metric="mse_mean", ascending=True, min_runs=1):
+    """Order aggregated rows by a metric, within each frame separately.
+
+    Ranking pools nothing: rows keep their frame, and the caller gets one ranked
+    list per frame. A single global ranking across frames would be meaningless
+    for exactly the reason `frames` documents.
+    """
+    by_frame = OrderedDict()
+    for row in rows:
+        if row.get("n_runs", 0) < min_runs:
+            continue
+        if metric not in row:
+            continue
+        by_frame.setdefault(row["frame"], []).append(row)
+    for frame in by_frame:
+        by_frame[frame].sort(key=lambda r: r[metric], reverse=not ascending)
+    return by_frame

--- a/spf/evaluation/calibration.py
+++ b/spf/evaluation/calibration.py
@@ -1,0 +1,92 @@
+"""Does the stated confidence mean anything?
+
+A filter that reports a variance nobody has checked is reporting decoration. The
+first time these functions were pointed at a real run -- the NN dual-radio PF on
+a 539-timestep rover capture -- the +-1 sigma band covered 25.6% of the actual
+errors where 68.3% is nominal, and +-3 sigma covered 67% where 99.7% is nominal.
+That filter is roughly 2.7x overconfident in sigma, which matters for anything
+downstream that gates on the reported variance.
+
+Report coverage before gating on it. A hard bound set before the cause is
+understood either enshrines the bug or blocks the work.
+"""
+
+import numpy as np
+
+from spf.evaluation.metrics import angular_error
+
+# P(|z| <= k) for a standard normal
+NOMINAL_COVERAGE = {1: 0.6826894921, 2: 0.9544997361, 3: 0.9973002039}
+
+
+def z_scores(pred, truth, sigma):
+    """Angular error divided by the filter's reported sigma, per timestep.
+
+    Entries with a non-finite or non-positive sigma are dropped: a filter that
+    reports no uncertainty cannot be scored on it, and silently treating that as
+    sigma=0 would manufacture infinite z-scores.
+    """
+    err = angular_error(pred, truth)
+    s = np.asarray(sigma, dtype=np.float64).reshape(-1)[: err.shape[0]]
+    err = err[: s.shape[0]]
+    ok = np.isfinite(err) & np.isfinite(s) & (s > 0)
+    return err[ok] / s[ok]
+
+
+def coverage(pred, truth, sigma, ks=(1, 2, 3)):
+    """Measured vs nominal coverage of the +-k sigma bands.
+
+    Returns a list of ``{"k", "measured", "nominal", "n"}``. ``measured`` well
+    below ``nominal`` means overconfident; well above means the filter is
+    hedging and its variance is not informative either.
+    """
+    z = z_scores(pred, truth, sigma)
+    rows = []
+    for k in ks:
+        rows.append(
+            {
+                "k": int(k),
+                "measured": float((np.abs(z) <= k).mean()) if z.size else float("nan"),
+                "nominal": NOMINAL_COVERAGE.get(int(k), float("nan")),
+                "n": int(z.size),
+            }
+        )
+    return rows
+
+
+def calibration_ratio(pred, truth, sigma):
+    """How many times too small the reported sigma is.
+
+    ``std(z)``: 1.0 is calibrated, >1 overconfident (errors larger than sigma
+    claims), <1 underconfident. A single number to track across a sweep, where
+    the full coverage table is too wide to tabulate.
+    """
+    z = z_scores(pred, truth, sigma)
+    if z.size < 2:
+        return float("nan")
+    return float(z.std())
+
+
+def reliability_curve(pred, truth, sigma, quantiles=np.linspace(0.05, 0.95, 19)):
+    """Empirical vs nominal coverage across a range of central intervals.
+
+    The curve behind the +-1/2/3 sigma table: for each nominal central mass q,
+    what fraction of errors actually land inside the interval a Gaussian with
+    the reported sigma would assign that mass. Plot measured against nominal;
+    the diagonal is perfect calibration.
+    """
+    from scipy.stats import norm
+
+    z = z_scores(pred, truth, sigma)
+    out = []
+    for q in np.asarray(quantiles, dtype=np.float64):
+        half_width = norm.ppf(0.5 + q / 2.0)
+        out.append(
+            {
+                "nominal": float(q),
+                "measured": (
+                    float((np.abs(z) <= half_width).mean()) if z.size else float("nan")
+                ),
+            }
+        )
+    return out

--- a/spf/evaluation/frames.py
+++ b/spf/evaluation/frames.py
@@ -1,0 +1,54 @@
+"""Angular reference frames, and the rule that you never pool across them.
+
+A theta prediction is only meaningful against a stated frame. SPF has three, and
+they are not interchangeable:
+
+``craft_relative``
+    Bearing to the emitter measured from the craft's own heading. This is what
+    ``v5spfdataset.craft_ground_truth_thetas`` holds and what the dual-radio
+    filters estimate by default.
+``absolute_north``
+    Bearing in the world frame, heading removed. ``PFSingleThetaDualRadioNN``
+    switches to this when constructed with ``absolute=True``.
+``radio_folded``
+    A single receiver's array-relative bearing after the front/back fold
+    (``spf.rf.reduce_theta_to_positive_y``). A 2-element array cannot resolve
+    that ambiguity alone, so single-radio filters are scored here.
+
+Why this module exists: ``PFSingleThetaDualRadioNN.metrics`` reports
+``absolute=True`` and ``absolute=False`` runs under the same ``mse_craft_theta``
+key, while scoring them against *different* ground truths. On one rover capture
+that reads as 0.33 versus 1.89 -- an apparent 5.7x win that is really two
+different questions. Averaging or ranking across that boundary is always a bug,
+so every aggregation here is keyed on the frame and refuses to merge two.
+"""
+
+CRAFT_RELATIVE = "craft_relative"
+ABSOLUTE_NORTH = "absolute_north"
+RADIO_FOLDED = "radio_folded"
+
+FRAMES = frozenset({CRAFT_RELATIVE, ABSOLUTE_NORTH, RADIO_FOLDED})
+
+
+class FrameMismatch(ValueError):
+    """Raised when values from different angular frames would be combined."""
+
+
+def check_frame(frame):
+    """Validate and return a frame name."""
+    if frame not in FRAMES:
+        raise ValueError(f"unknown frame {frame!r}; expected one of {sorted(FRAMES)}")
+    return frame
+
+
+def require_same_frame(frames):
+    """Return the single frame shared by ``frames``, or raise FrameMismatch."""
+    distinct = {check_frame(f) for f in frames}
+    if len(distinct) == 0:
+        raise ValueError("no frames given")
+    if len(distinct) > 1:
+        raise FrameMismatch(
+            "refusing to combine angular frames "
+            f"{sorted(distinct)}: they are scored against different ground truth"
+        )
+    return distinct.pop()

--- a/spf/evaluation/metrics.py
+++ b/spf/evaluation/metrics.py
@@ -1,0 +1,119 @@
+"""Angular error metrics.
+
+Deliberately free of any filter or model: these score a sequence of predicted
+angles against ground truth, so the same code scores an EKF track, a particle
+filter track, the empirical baseline, or a network's point estimate before any
+filtering happens.
+
+Every function here treats angles as points on a circle. Two failure modes that
+arithmetic invites and these avoid:
+
+* ``pred - truth`` for +179 deg and -179 deg is 358 deg, not 2 deg.
+* The arithmetic mean of {+179 deg, -179 deg} is 0 deg, which is the opposite
+  direction from both. Use ``circular_mean``.
+
+Inputs are array-like (numpy arrays, torch CPU tensors, lists). Outputs are
+plain floats or numpy arrays.
+"""
+
+import numpy as np
+
+
+def _as_array(x):
+    return np.asarray(x, dtype=np.float64).reshape(-1)
+
+
+def wrap_to_pi(angles):
+    """Map angles to [-pi, pi)."""
+    a = np.asarray(angles, dtype=np.float64)
+    return (a + np.pi) % (2 * np.pi) - np.pi
+
+
+def angular_error(pred, truth):
+    """Signed shortest-arc error ``pred - truth``, wrapped to [-pi, pi).
+
+    Truncates to the shorter of the two inputs: filters may stop early
+    (``steps=``), and comparing a short track against a long ground truth should
+    score the overlap rather than raise.
+    """
+    p, t = _as_array(pred), _as_array(truth)
+    n = min(p.shape[0], t.shape[0])
+    return wrap_to_pi(p[:n] - t[:n])
+
+
+def mse(pred, truth):
+    """Mean squared angular error, rad^2. Matches the filters' existing metric."""
+    return float((angular_error(pred, truth) ** 2).mean())
+
+
+def rmse(pred, truth):
+    """Root mean squared angular error, radians."""
+    return float(np.sqrt(mse(pred, truth)))
+
+
+def rmse_deg(pred, truth):
+    return float(np.degrees(rmse(pred, truth)))
+
+
+def mae(pred, truth):
+    """Mean absolute angular error, radians."""
+    return float(np.abs(angular_error(pred, truth)).mean())
+
+
+def median_absolute_error(pred, truth):
+    """Median absolute angular error, radians.
+
+    Worth reporting next to the mean on the O4 emitter: it is bursty, so a
+    minority of frames carry no signal and inflate the mean without saying much
+    about performance when the emitter is actually transmitting.
+    """
+    return float(np.median(np.abs(angular_error(pred, truth))))
+
+
+def circular_mean(angles, weights=None):
+    """Phasor mean of a set of angles, in [-pi, pi)."""
+    a = _as_array(angles)
+    if weights is None:
+        w = np.ones_like(a)
+    else:
+        w = _as_array(weights)
+        if w.shape != a.shape:
+            raise ValueError(f"weights shape {w.shape} != angles shape {a.shape}")
+    total = w.sum()
+    if total == 0:
+        raise ValueError("weights sum to zero")
+    return float(
+        np.arctan2((w * np.sin(a)).sum() / total, (w * np.cos(a)).sum() / total)
+    )
+
+
+def circular_std(angles, weights=None):
+    """Circular standard deviation, radians.
+
+    ``sqrt(-2 ln R)`` where R is the mean resultant length. Unbounded as the
+    distribution approaches uniform, and ~equal to the linear std for tight
+    clusters, which makes it comparable to a filter's reported sigma.
+    """
+    a = _as_array(angles)
+    w = np.ones_like(a) if weights is None else _as_array(weights)
+    total = w.sum()
+    if total == 0:
+        raise ValueError("weights sum to zero")
+    r = np.hypot((w * np.sin(a)).sum() / total, (w * np.cos(a)).sum() / total)
+    r = min(float(r), 1.0)
+    if r <= 0.0:
+        return float("inf")
+    return float(np.sqrt(-2.0 * np.log(r)))
+
+
+def summarize(pred, truth):
+    """The standard metric block for one track."""
+    err = angular_error(pred, truth)
+    return {
+        "n": int(err.shape[0]),
+        "mse": float((err**2).mean()),
+        "rmse_rad": float(np.sqrt((err**2).mean())),
+        "rmse_deg": float(np.degrees(np.sqrt((err**2).mean()))),
+        "mae_rad": float(np.abs(err).mean()),
+        "median_abs_err_rad": float(np.median(np.abs(err))),
+    }

--- a/spf/evaluation/posterior.py
+++ b/spf/evaluation/posterior.py
@@ -1,0 +1,138 @@
+"""Score a distribution over theta, with no filter in the loop.
+
+This is why ``spf.evaluation`` is its own package rather than living under
+``spf.filters``. A tracker's error confounds two things: how good the per-frame
+network posterior is, and how well the filter fuses posteriors over time. To
+attribute a result you need to score the posterior directly -- the same way you
+would score the empirical ``P(theta | phi)`` table, or any future model.
+
+Bin convention, verified against both consumers: bin ``i`` of ``n`` is centred at
+``-pi + (i + 0.5) * 2*pi/n``. That matches ``theta_phi_to_bins`` in
+``spf.filters.filters`` (which is how the NN filters index a posterior) and the
+analytic target grid in ``target_from_scatter`` (which is what training fits).
+For n=65 both place theta=0 at bin 32.
+"""
+
+import numpy as np
+
+from spf.evaluation.metrics import angular_error, wrap_to_pi
+
+_EPS = 1e-12
+
+
+def bin_centers(ntheta):
+    """Centre angle of each of ``ntheta`` bins spanning [-pi, pi)."""
+    return -np.pi + (np.arange(ntheta) + 0.5) * (2 * np.pi / ntheta)
+
+
+def theta_to_bin(theta, ntheta):
+    """Bin index for an angle, matching spf.filters.filters.theta_phi_to_bins."""
+    t = np.asarray(theta, dtype=np.float64)
+    return (np.floor(ntheta * (t + np.pi) / (2 * np.pi)).astype(np.int64)) % ntheta
+
+
+def _normalized(posteriors):
+    """(T, ntheta) float array, each row L1-normalised and non-negative."""
+    p = np.asarray(posteriors, dtype=np.float64)
+    if p.ndim == 1:
+        p = p[None, :]
+    if p.ndim != 2:
+        raise ValueError(f"expected (T, ntheta), got shape {p.shape}")
+    if (p < 0).any():
+        raise ValueError("posterior has negative mass")
+    totals = p.sum(axis=1, keepdims=True)
+    if (totals <= 0).any():
+        raise ValueError("posterior row sums to zero")
+    return p / totals
+
+
+def nll(posteriors, truths):
+    """Mean negative log-likelihood of the truth under the posterior, nats.
+
+    The proper scoring rule: rewards putting mass on the right bin AND being
+    honest about uncertainty. A confidently-wrong posterior scores far worse
+    than a diffuse one, which is exactly the distinction a point-estimate error
+    cannot make.
+    """
+    p = _normalized(posteriors)
+    t = np.asarray(truths, dtype=np.float64).reshape(-1)[: p.shape[0]]
+    p = p[: t.shape[0]]
+    idx = theta_to_bin(t, p.shape[1])
+    return float(-np.log(p[np.arange(p.shape[0]), idx] + _EPS).mean())
+
+
+def peak_theta(posteriors):
+    """Angle of the highest-mass bin, per timestep (the MAP estimate)."""
+    p = _normalized(posteriors)
+    return bin_centers(p.shape[1])[p.argmax(axis=1)]
+
+
+def posterior_circular_mean(posteriors):
+    """Circular mean of each posterior, per timestep.
+
+    Differs from ``peak_theta`` on a multimodal posterior -- and a 2-element
+    array's posterior is routinely bimodal, so the gap between these two is
+    itself a useful diagnostic.
+    """
+    p = _normalized(posteriors)
+    c = bin_centers(p.shape[1])
+    return np.arctan2((p * np.sin(c)).sum(axis=1), (p * np.cos(c)).sum(axis=1))
+
+
+def entropy(posteriors):
+    """Shannon entropy per timestep, nats. log(ntheta) is a uniform posterior."""
+    p = _normalized(posteriors)
+    return -(p * np.log(p + _EPS)).sum(axis=1)
+
+
+def peak_error(posteriors, truths):
+    """Signed error of the MAP estimate, wrapped."""
+    return angular_error(peak_theta(posteriors), truths)
+
+
+def hdr_coverage(posteriors, truths, mass=0.68):
+    """Fraction of truths inside the highest-density region holding ``mass``.
+
+    The posterior analogue of +-1 sigma coverage, and the honest one for a
+    multimodal distribution: take bins in descending probability until the
+    cumulative mass reaches ``mass``, then ask whether the truth's bin is in that
+    set. Well below ``mass`` means overconfident.
+
+    Note this is **conservative on a coarse grid**. Bins are indivisible, so the
+    smallest set reaching ``mass`` generally carries more than ``mass`` -- at
+    ntheta=65 a sigma=0.3 rad posterior yields ~0.75 for mass=0.68. So compare a
+    measured value against the HDR set's own mass, or against the same figure
+    from another model on the same grid; do not read the gap to ``mass`` itself
+    as miscalibration.
+    """
+    p = _normalized(posteriors)
+    t = np.asarray(truths, dtype=np.float64).reshape(-1)[: p.shape[0]]
+    p = p[: t.shape[0]]
+    order = np.argsort(-p, axis=1)
+    ordered = np.take_along_axis(p, order, axis=1)
+    cum = np.cumsum(ordered, axis=1)
+    # include the bin that carries the cumulative sum past `mass`
+    inside = cum - ordered < mass
+    truth_bin = theta_to_bin(t, p.shape[1])
+    rank = (order == truth_bin[:, None]).argmax(axis=1)
+    hit = inside[np.arange(p.shape[0]), rank]
+    return float(hit.mean())
+
+
+def summarize(posteriors, truths):
+    """The standard posterior-quality block, independent of any filter."""
+    p = _normalized(posteriors)
+    t = np.asarray(truths, dtype=np.float64).reshape(-1)[: p.shape[0]]
+    err = peak_error(p, t)
+    mean_err = angular_error(posterior_circular_mean(p), t)
+    return {
+        "n": int(err.shape[0]),
+        "nll": nll(p, t),
+        "peak_rmse_rad": float(np.sqrt((err**2).mean())),
+        "peak_rmse_deg": float(np.degrees(np.sqrt((err**2).mean()))),
+        "circmean_rmse_rad": float(np.sqrt((mean_err**2).mean())),
+        "mean_entropy": float(entropy(p).mean()),
+        "uniform_entropy": float(np.log(p.shape[1])),
+        "hdr68_coverage": hdr_coverage(p, t, 0.68),
+        "hdr95_coverage": hdr_coverage(p, t, 0.95),
+    }

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,323 @@
+"""Unit tests for spf.evaluation. Pure functions, no fixtures, fast."""
+
+import numpy as np
+import pytest
+
+from spf.evaluation import aggregate as agg
+from spf.evaluation import calibration, frames, metrics, posterior
+
+D = np.pi / 180.0
+
+
+# --------------------------------------------------------------- metrics
+
+
+def test_angular_error_takes_the_short_way_round_the_seam():
+    """+179 and -179 degrees are 2 degrees apart, not 358."""
+    err = metrics.angular_error([179 * D], [-179 * D])
+    assert np.isclose(abs(err[0]), 2 * D)
+
+
+def test_angular_error_is_signed():
+    assert metrics.angular_error([10 * D], [0.0])[0] > 0
+    assert metrics.angular_error([-10 * D], [0.0])[0] < 0
+
+
+def test_angular_error_truncates_to_the_shorter_input():
+    # filters may stop early via steps=; score the overlap, do not raise
+    assert metrics.angular_error(np.zeros(5), np.zeros(9)).shape == (5,)
+    assert metrics.angular_error(np.zeros(9), np.zeros(5)).shape == (5,)
+
+
+def test_mse_matches_the_filters_existing_metric():
+    """Must reproduce dual_radio_mse_theta_metrics so old numbers stay comparable."""
+    import torch
+
+    from spf.filters.filters import dual_radio_mse_theta_metrics
+
+    rng = np.random.default_rng(0)
+    pred = rng.uniform(-np.pi, np.pi, 200)
+    truth = rng.uniform(-np.pi, np.pi, 200)
+    theirs = dual_radio_mse_theta_metrics(
+        [{"craft_theta": np.float64(p)} for p in pred], torch.tensor(truth)
+    )["mse_craft_theta"]
+    assert np.isclose(metrics.mse(pred, truth), theirs)
+
+
+def test_circular_mean_does_not_collapse_at_the_seam():
+    """Arithmetic mean of {+179, -179} is 0, which points the wrong way."""
+    m = metrics.circular_mean([179 * D, -179 * D])
+    assert np.isclose(abs(m), np.pi, atol=1e-6)
+
+
+def test_circular_mean_matches_arithmetic_mean_away_from_the_seam():
+    a = [0.1, 0.2, 0.3]
+    assert np.isclose(metrics.circular_mean(a), np.mean(a), atol=1e-9)
+
+
+def test_circular_std_is_zero_for_identical_angles():
+    assert np.isclose(metrics.circular_std([0.7, 0.7, 0.7]), 0.0, atol=1e-9)
+
+
+def test_circular_std_tracks_linear_std_for_a_tight_cluster():
+    rng = np.random.default_rng(1)
+    a = rng.normal(0.0, 0.05, 20000)
+    assert np.isclose(metrics.circular_std(a), 0.05, rtol=0.05)
+
+
+def test_summarize_block():
+    out = metrics.summarize([0.0, 0.0, 0.0], [0.1, -0.1, 0.1])
+    assert out["n"] == 3
+    assert np.isclose(out["rmse_rad"], 0.1)
+    assert np.isclose(out["rmse_deg"], np.degrees(0.1))
+    assert np.isclose(out["mae_rad"], 0.1)
+
+
+# ----------------------------------------------------------- calibration
+
+
+def test_coverage_recovers_the_nominal_bands_on_gaussian_errors():
+    rng = np.random.default_rng(2)
+    sigma = 0.05
+    truth = np.zeros(200000)
+    pred = rng.normal(0.0, sigma, truth.shape)
+    rows = calibration.coverage(pred, truth, np.full(truth.shape, sigma))
+    for row in rows:
+        assert np.isclose(row["measured"], row["nominal"], atol=0.01), row
+
+
+def test_coverage_detects_overconfidence():
+    """Errors 3x larger than the claimed sigma must show far under nominal."""
+    rng = np.random.default_rng(3)
+    truth = np.zeros(50000)
+    pred = rng.normal(0.0, 0.15, truth.shape)
+    rows = calibration.coverage(pred, truth, np.full(truth.shape, 0.05))
+    one_sigma = [r for r in rows if r["k"] == 1][0]
+    assert one_sigma["measured"] < 0.3
+
+
+def test_calibration_ratio_recovers_the_scale_factor():
+    rng = np.random.default_rng(4)
+    truth = np.zeros(100000)
+    pred = rng.normal(0.0, 0.15, truth.shape)
+    ratio = calibration.calibration_ratio(pred, truth, np.full(truth.shape, 0.05))
+    assert np.isclose(ratio, 3.0, rtol=0.05)
+
+
+def test_nonpositive_sigma_is_dropped_not_treated_as_zero():
+    pred = np.array([0.0, 0.0, 0.0, 0.0])
+    truth = np.array([0.1, 0.1, 0.1, 0.1])
+    sigma = np.array([0.1, 0.0, np.nan, 0.1])
+    assert calibration.z_scores(pred, truth, sigma).shape == (2,)
+
+
+def test_reliability_curve_is_diagonal_when_calibrated():
+    rng = np.random.default_rng(5)
+    truth = np.zeros(100000)
+    pred = rng.normal(0.0, 0.05, truth.shape)
+    curve = calibration.reliability_curve(pred, truth, np.full(truth.shape, 0.05))
+    for point in curve:
+        assert np.isclose(point["measured"], point["nominal"], atol=0.02), point
+
+
+# ------------------------------------------------------------- posterior
+
+
+@pytest.mark.parametrize("ntheta", [7, 65])
+def test_bin_convention_matches_the_filters(ntheta):
+    """spf.evaluation must bin theta exactly as the NN filters index a posterior."""
+    import torch
+
+    from spf.filters.filters import theta_phi_to_bins
+
+    thetas = np.linspace(-np.pi, np.pi, 501)[:-1]
+    ours = posterior.theta_to_bin(thetas, ntheta)
+    theirs = theta_phi_to_bins(torch.tensor(thetas), ntheta).numpy()
+    np.testing.assert_array_equal(ours, theirs)
+
+
+def test_bin_centers_round_trip_to_their_own_bins():
+    ntheta = 65
+    centers = posterior.bin_centers(ntheta)
+    np.testing.assert_array_equal(
+        posterior.theta_to_bin(centers, ntheta), np.arange(ntheta)
+    )
+    assert np.isclose(centers[ntheta // 2], 0.0)
+
+
+def test_nll_is_lower_for_a_posterior_on_the_truth():
+    ntheta = 65
+    truth = np.array([0.0])
+    sharp = np.zeros((1, ntheta))
+    sharp[0, posterior.theta_to_bin(truth, ntheta)[0]] = 1.0
+    uniform = np.full((1, ntheta), 1.0 / ntheta)
+    assert posterior.nll(sharp, truth) < posterior.nll(uniform, truth)
+
+
+def test_confidently_wrong_scores_worse_than_diffuse():
+    """The property a point-estimate error cannot express."""
+    ntheta = 65
+    truth = np.array([0.0])
+    wrong = np.full((1, ntheta), 1e-6)
+    wrong[0, 0] = 1.0
+    uniform = np.full((1, ntheta), 1.0 / ntheta)
+    assert posterior.nll(wrong, truth) > posterior.nll(uniform, truth)
+
+
+def test_peak_and_circular_mean_differ_on_a_bimodal_posterior():
+    ntheta = 65
+    p = np.full((1, ntheta), 1e-9)
+    p[0, posterior.theta_to_bin(np.array([0.4]), ntheta)[0]] = 0.6
+    p[0, posterior.theta_to_bin(np.array([-2.6]), ntheta)[0]] = 0.4
+    assert not np.isclose(
+        posterior.peak_theta(p)[0], posterior.posterior_circular_mean(p)[0], atol=0.1
+    )
+
+
+def test_entropy_bounds():
+    ntheta = 65
+    uniform = np.full((1, ntheta), 1.0 / ntheta)
+    assert np.isclose(posterior.entropy(uniform)[0], np.log(ntheta), atol=1e-6)
+    sharp = np.zeros((1, ntheta))
+    sharp[0, 3] = 1.0
+    assert posterior.entropy(sharp)[0] < 1e-6
+
+
+def _gaussian_posterior(ntheta, sigma):
+    centers = posterior.bin_centers(ntheta)
+    p = np.exp(-((centers / sigma) ** 2) / 2)
+    return centers, p / p.sum()
+
+
+def _hdr_set_mass(p, mass):
+    """Actual mass of the smallest bin set reaching `mass` -- >= mass on a grid."""
+    ordered = np.sort(p)[::-1]
+    cum = np.cumsum(ordered)
+    return float(cum[np.searchsorted(cum, mass)])
+
+
+@pytest.mark.parametrize("mass", [0.68, 0.95])
+def test_hdr_coverage_equals_the_hdr_sets_own_mass(mass):
+    """Truths drawn FROM the posterior land in the HDR set exactly as often as
+    that set's mass -- which on a discrete grid exceeds the requested mass."""
+    ntheta = 65
+    rng = np.random.default_rng(6)
+    centers, p = _gaussian_posterior(ntheta, 0.3)
+    truths = centers[rng.choice(ntheta, size=40000, p=p)]
+    posteriors = np.repeat(p[None, :], truths.shape[0], axis=0)
+
+    measured = posterior.hdr_coverage(posteriors, truths, mass)
+    assert np.isclose(measured, _hdr_set_mass(p, mass), atol=0.01)
+    assert measured >= mass, "a well-specified posterior must never under-cover"
+
+
+def test_hdr_overshoot_is_bounded_by_the_largest_bin_and_vanishes_when_fine():
+    """Overshoot comes from bins being indivisible, so it is bounded by the mass
+    of one bin -- and goes to zero as the grid gets fine. It is NOT monotonic in
+    ntheta: at ntheta=17 a sigma=0.3 posterior occupies ~1 bin, and where the
+    grid happens to fall can put the overshoot below a finer grid's."""
+    rng = np.random.default_rng(7)
+    for ntheta in (17, 65, 513):
+        centers, p = _gaussian_posterior(ntheta, 0.3)
+        truths = centers[rng.choice(ntheta, size=40000, p=p)]
+        posteriors = np.repeat(p[None, :], truths.shape[0], axis=0)
+        overshoot = posterior.hdr_coverage(posteriors, truths, 0.68) - 0.68
+        assert 0 <= overshoot <= p.max() + 0.01, (ntheta, overshoot, p.max())
+    # fine grid -> negligible overshoot
+    centers, p = _gaussian_posterior(513, 0.3)
+    truths = centers[rng.choice(513, size=40000, p=p)]
+    posteriors = np.repeat(p[None, :], truths.shape[0], axis=0)
+    assert posterior.hdr_coverage(posteriors, truths, 0.68) - 0.68 < 0.02
+
+
+def test_hdr_coverage_detects_an_overconfident_posterior():
+    """The diagnostic use: truths spread wider than the posterior claims."""
+    ntheta = 65
+    rng = np.random.default_rng(8)
+    centers, claimed = _gaussian_posterior(ntheta, 0.1)
+    _, actual = _gaussian_posterior(ntheta, 0.5)
+    truths = centers[rng.choice(ntheta, size=40000, p=actual)]
+    posteriors = np.repeat(claimed[None, :], truths.shape[0], axis=0)
+    assert posterior.hdr_coverage(posteriors, truths, 0.68) < 0.4
+
+
+def test_posterior_rejects_malformed_input():
+    with pytest.raises(ValueError):
+        posterior.nll(np.full((1, 5), -0.1), np.array([0.0]))
+    with pytest.raises(ValueError):
+        posterior.nll(np.zeros((1, 5)), np.array([0.0]))
+
+
+# ---------------------------------------------------------------- frames
+
+
+def test_require_same_frame_accepts_one_frame():
+    assert (
+        frames.require_same_frame([frames.CRAFT_RELATIVE] * 3) == frames.CRAFT_RELATIVE
+    )
+
+
+def test_require_same_frame_refuses_to_mix():
+    with pytest.raises(frames.FrameMismatch):
+        frames.require_same_frame([frames.CRAFT_RELATIVE, frames.ABSOLUTE_NORTH])
+
+
+def test_unknown_frame_rejected():
+    with pytest.raises(ValueError):
+        frames.check_frame("whatever")
+
+
+# ------------------------------------------------------------- aggregate
+
+
+def _result(frame, N, mse_value):
+    return {"frame": frame, "N": N, "metrics": {"mse": mse_value}}
+
+
+def test_absolute_and_craft_relative_never_pool():
+    """The concrete trap: same hyperparameters, two frames, must not average."""
+    results = [
+        _result(frames.CRAFT_RELATIVE, 4096, 1.89),
+        _result(frames.ABSOLUTE_NORTH, 4096, 0.33),
+    ]
+    rows = agg.aggregate(results, ["N"])
+    assert len(rows) == 2
+    by_frame = {r["frame"]: r["mse_mean"] for r in rows}
+    assert np.isclose(by_frame[frames.CRAFT_RELATIVE], 1.89)
+    assert np.isclose(by_frame[frames.ABSOLUTE_NORTH], 0.33)
+
+
+def test_missing_frame_is_an_error_not_a_default():
+    with pytest.raises(ValueError, match="frame"):
+        agg.group_results([{"N": 1, "metrics": {"mse": 1.0}}], ["N"])
+
+
+def test_aggregate_averages_within_a_group_and_reports_n():
+    results = [_result(frames.CRAFT_RELATIVE, 4096, v) for v in (1.0, 2.0, 3.0)]
+    rows = agg.aggregate(results, ["N"])
+    assert len(rows) == 1
+    assert rows[0]["n_runs"] == 3
+    assert np.isclose(rows[0]["mse_mean"], 2.0)
+    assert np.isclose(rows[0]["mse_std"], np.std([1.0, 2.0, 3.0]))
+
+
+def test_metrics_missing_from_some_runs_are_dropped_visibly():
+    results = [
+        {"frame": frames.CRAFT_RELATIVE, "N": 1, "metrics": {"mse": 1.0, "extra": 5.0}},
+        {"frame": frames.CRAFT_RELATIVE, "N": 1, "metrics": {"mse": 3.0}},
+    ]
+    row = agg.aggregate(results, ["N"])[0]
+    assert np.isclose(row["mse_mean"], 2.0)
+    assert "extra_mean" not in row
+    assert row["dropped_metrics"] == ["extra"]
+
+
+def test_rank_is_per_frame():
+    results = [
+        _result(frames.CRAFT_RELATIVE, 128, 2.0),
+        _result(frames.CRAFT_RELATIVE, 4096, 1.0),
+        _result(frames.ABSOLUTE_NORTH, 128, 0.5),
+    ]
+    ranked = agg.rank(agg.aggregate(results, ["N"]))
+    assert set(ranked) == {frames.CRAFT_RELATIVE, frames.ABSOLUTE_NORTH}
+    assert [r["N"] for r in ranked[frames.CRAFT_RELATIVE]] == [4096, 128]


### PR DESCRIPTION
Second of four changes toward running the filter sweep locally. **Purely additive — no existing file is touched**, so every existing metric value is unchanged and remains comparable.

## Why not under `spf/filters/`

A tracker's error confounds two things: how good the per-frame network posterior is, and how well the filter fuses posteriors over time. Attributing a result means scoring the posterior *directly* — the same way you'd score the empirical `P(theta|phi)` table, or any future model. Under `filters/`, "how good is the model before filtering?" becomes an awkward question to ask.

## Contents

| Module | What |
|---|---|
| `metrics.py` | wrapped angular error, mse/rmse/mae/median, circular mean & std |
| `calibration.py` | z-scores, ±kσ coverage vs nominal, calibration ratio, reliability curve |
| `posterior.py` | score `P(theta)` with no filter: NLL, MAP & circular-mean estimates, entropy, HDR coverage |
| `frames.py` | `craft_relative` / `absolute_north` / `radio_folded` |
| `aggregate.py` | group and average, always keyed on frame |

## The frame machinery exists for a concrete bug

`PFSingleThetaDualRadioNN.metrics` reports `absolute=True` and `absolute=False` runs under the same `mse_craft_theta` key while scoring them against **different ground truth**. On one rover capture that reads as 0.33 vs 1.89 — an apparent 5.7× win that is really two different questions. Here a missing frame is an error rather than a default, and grouping refuses to merge two.

## Calibration, the motivating measurement

Pointed at the NN dual-radio PF on a 539-timestep rover capture: ±1σ covered **25.6%** of errors where 68.3% is nominal, ±3σ covered 67% where 99.7% is nominal — roughly 2.7× overconfident in σ. These functions report that; they don't gate on it. A bound set before the cause is understood either enshrines the bug or blocks the work.

## Two cross-checks worth calling out

- **Bin convention is asserted equal to `theta_phi_to_bins`**, which is how the NN filters index a posterior — so a posterior scored here is binned exactly as the filter consumed it. Verified for ntheta 7 and 65.
- **`hdr_coverage` is conservative on a coarse grid.** Bins are indivisible, so the smallest set reaching mass *m* generally carries more (at ntheta=65, a σ=0.3 posterior gives 0.75 for m=0.68). The test asserts the provable bound — overshoot < one bin's mass — rather than the monotonicity in ntheta that my first draft wrongly assumed and that the test caught.

## Tests

34 unit tests, no fixtures, 1.6 s. Includes `test_mse_matches_the_filters_existing_metric`, which pins this MSE to `dual_radio_mse_theta_metrics` so a later change can make the filters delegate here without moving any number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)