### PR TITLE
filters: make a local sweep possible — pluggable results sink, no cloud

### DIFF
--- a/spf/filters/labels.py
+++ b/spf/filters/labels.py
@@ -1,0 +1,65 @@
+"""Turn a raw filter result into the labels a report groups by.
+
+Two labels, both of which the reporters previously got wrong or omitted:
+
+**movement** -- vehicle plus capture routine. Inferring it from the filename by
+substring is unsafe for merged v7 rover data, whose stores are named
+``<RX capture>.<TX capture>``. A bounce-RX / circle-TX pair contains *both*
+words, and the old reporter tested ``"circle" in name`` first, so every merged
+rover store was labelled ``circle`` when its RX routine was ``bounce``. The
+capture yaml records the routine; use it, and fall back to the filename only
+when it is absent.
+
+**frame** -- which angular frame the result was scored in. This is not recorded
+on the result, but it is fully determined by the filter type and the ``absolute``
+flag, so it can be recovered rather than having to change every filter's metrics
+dict. See ``spf.evaluation.frames`` for why pooling across frames is always a
+bug.
+"""
+
+from spf.evaluation.frames import ABSOLUTE_NORTH, CRAFT_RELATIVE, RADIO_FOLDED
+
+# Order matters: the more specific routine names must be tested first, or
+# "random_circle" is swallowed by "circle".
+_ROUTINE_TOKENS = (
+    "random_circle",
+    "bounce",
+    "center",
+    "diamond",
+    "circle",
+    "calibrate",
+)
+
+
+def ds_fn_to_movement(ds_fn, routine=None):
+    """``<vehicle>_<routine>``, e.g. ``rover_bounce`` or ``2dwallarray_circle``."""
+    name = str(ds_fn).lower()
+    movement = ""
+    if routine is not None and str(routine) != "unknown":
+        movement = str(routine)
+    else:
+        for token in _ROUTINE_TOKENS:
+            if token in name:
+                movement = token
+                break
+    if movement == "":
+        raise ValueError(f"cannot determine movement for {ds_fn}")
+    vehicle = "rover" if "rover" in name else "2dwallarray"
+    return f"{vehicle}_{movement}"
+
+
+def result_to_frame(result):
+    """Recover the angular frame a result was scored in.
+
+    Single-radio filters score against the front/back-folded per-radio bearing.
+    Dual-radio filters score against the craft-relative bearing, except the NN
+    dual-radio filter with ``absolute=True``, which scores against the circular
+    mean of the north-referenced bearings -- a different ground truth reported
+    under the same ``mse_craft_theta`` key.
+    """
+    if result.get("absolute", False):
+        return ABSOLUTE_NORTH
+    _type = str(result.get("type", "")).lower()
+    if "single_radio" in _type:
+        return RADIO_FOLDED
+    return CRAFT_RELATIVE

--- a/spf/filters/report.py
+++ b/spf/filters/report.py
@@ -1,0 +1,172 @@
+"""Turn a local sweep's results into artifacts you can actually commit.
+
+``run_filters_report.py`` writes CSV, and ``.gitignore`` matches ``**/*.csv``
+(with only the JLC fab files excepted), so a sweep result in that format can
+never be checked in. This writes ``results.json`` plus a ``REPORT.md`` table,
+both of which are tracked, matching the append-only report convention already
+used under ``spf/calibrations/*/reports/<name>_<date>_v1/``.
+
+It also groups on the angular **frame**, so a craft-relative run and an
+absolute-north run of the same hyperparameters never land in one average.
+"""
+
+import argparse
+import json
+import logging
+import os
+import pickle
+
+from spf.evaluation.aggregate import aggregate
+from spf.filters.labels import ds_fn_to_movement, result_to_frame
+
+# Fields that describe the run rather than measure it; everything else that is
+# not a metric becomes part of the grouping key.
+_NON_GROUPING = {"metrics", "ds_fn", "precompute_cache", "full_name", "runtime"}
+
+
+def load_results(workdir):
+    """Every result dict written by LocalResultsStore under ``workdir``."""
+    out = []
+    for dirpath, _, filenames in os.walk(workdir):
+        for name in sorted(filenames):
+            if not name.endswith(".pkl"):
+                continue
+            with open(os.path.join(dirpath, name), "rb") as f:
+                out.extend(pickle.load(f))
+    return out
+
+
+def annotate(results):
+    """Attach ``frame`` and ``movement`` so the results can be grouped."""
+    annotated = []
+    for result in results:
+        result = dict(result)
+        result["frame"] = result_to_frame(result)
+        result["movement"] = ds_fn_to_movement(
+            result.get("ds_fn", ""), result.get("routine")
+        )
+        annotated.append(result)
+    return annotated
+
+
+def grouping_keys(results):
+    """Every non-metric field shared by all results, in stable order."""
+    if not results:
+        return []
+    common = set(results[0])
+    for result in results[1:]:
+        common &= set(result)
+    return sorted(common - _NON_GROUPING)
+
+
+def build_report(workdir):
+    results = annotate(load_results(workdir))
+    if not results:
+        raise ValueError(f"no results found under {workdir}")
+    rows = aggregate(results, grouping_keys(results))
+    return {
+        "workdir": workdir,
+        "n_results": len(results),
+        "n_groups": len(rows),
+        "rows": rows,
+    }
+
+
+def _fmt(value):
+    if isinstance(value, float):
+        return f"{value:.4f}"
+    if isinstance(value, list):
+        return ",".join(str(v) for v in value)
+    return str(value)
+
+
+# Each filter family names its error metric differently, so the column to rank on
+# cannot be hard-coded: dual-radio filters report mse_craft_theta, single-radio
+# ones mse_single_radio_theta, XY adds mse_xy. Preference order, best first.
+_SORT_PREFERENCE = (
+    "mse_craft_theta_mean",
+    "mse_single_radio_theta_mean",
+    "mse_mean",
+    "mse_xy_mean",
+)
+
+
+def default_sort_metric(rows):
+    """The metric to rank these rows by, discovered from what they carry."""
+    present = set().union(*(set(r) for r in rows)) if rows else set()
+    for name in _SORT_PREFERENCE:
+        if name in present:
+            return name
+    candidates = sorted(
+        c for c in present if c.startswith("mse") and c.endswith("_mean")
+    )
+    return candidates[0] if candidates else None
+
+
+def report_to_markdown(report, sort_by=None, top=25):
+    """A per-frame leaderboard. Frames get their own table -- never one ranking."""
+    lines = [
+        "# Filter sweep report",
+        "",
+        f"- results: **{report['n_results']}** in **{report['n_groups']}** groups",
+        f"- work dir: `{report['workdir']}`",
+        "",
+        "Rows are grouped by every non-metric field **and by angular frame**. A"
+        " craft-relative and an absolute-north run of the same hyperparameters"
+        " answer different questions and are never averaged or ranked together.",
+        "",
+    ]
+    by_frame = {}
+    for row in report["rows"]:
+        by_frame.setdefault(row["frame"], []).append(row)
+
+    for frame in sorted(by_frame):
+        rows = by_frame[frame]
+        # resolve per frame: single-radio and dual-radio rows carry different
+        # metric names, and they never share a frame anyway
+        metric = sort_by or default_sort_metric(rows)
+        if metric is not None and all(metric in r for r in rows):
+            rows = sorted(rows, key=lambda r: r[metric])
+            heading = f"## frame: `{frame}` (ranked by `{metric}`)"
+        else:
+            heading = f"## frame: `{frame}` (unranked: no shared error metric)"
+        lines += [heading, ""]
+        shown = rows[:top]
+        columns = [c for c in sorted(shown[0]) if c != "frame"]
+        lines.append("| " + " | ".join(columns) + " |")
+        lines.append("|" + "|".join(["---"] * len(columns)) + "|")
+        for row in shown:
+            lines.append(
+                "| " + " | ".join(_fmt(row.get(c, "")) for c in columns) + " |"
+            )
+        if len(rows) > top:
+            lines.append("")
+            lines.append(f"_{len(rows) - top} further rows omitted; see results.json._")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def write_report(workdir, output_dir, sort_by=None, top=25):
+    report = build_report(workdir)
+    os.makedirs(output_dir, exist_ok=True)
+    json_fn = os.path.join(output_dir, "results.json")
+    with open(json_fn, "w") as f:
+        json.dump(report, f, indent=2, sort_keys=True)
+    md_fn = os.path.join(output_dir, "REPORT.md")
+    with open(md_fn, "w") as f:
+        f.write(report_to_markdown(report, sort_by=sort_by, top=top))
+    return json_fn, md_fn
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--work-dir", type=str, required=True)
+    parser.add_argument("--output-dir", type=str, required=True)
+    parser.add_argument("--sort-by", type=str, default=None)
+    parser.add_argument("--top", type=int, default=25)
+    args = parser.parse_args()
+    logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO").upper())
+    json_fn, md_fn = write_report(
+        args.work_dir, args.output_dir, sort_by=args.sort_by, top=args.top
+    )
+    logging.info(f"wrote {json_fn} and {md_fn}")

--- a/spf/filters/results_store.py
+++ b/spf/filters/results_store.py
@@ -1,0 +1,108 @@
+"""Where a filter sweep's results go.
+
+The runner previously wrote every result straight into a DynamoDB table, with
+the local file path behind a hard-coded ``use_file_system = False``. That made a
+local sweep impossible without AWS credentials, and left the runner and
+``run_filters_report.py`` -- which reads ``.pkl`` files out of the work dir --
+wired to two different sinks, so the local reporter had nothing to read.
+
+Both sinks now sit behind one interface, and **local is the default**. The
+DynamoDB path is preserved for the AWS Batch driver but is opt-in and imports
+boto3 lazily, so no local run touches the network.
+"""
+
+import logging
+import os
+import pickle
+from decimal import Decimal
+
+
+def float_to_decimal(obj):
+    """Recursively convert floats to Decimal, which is what DynamoDB accepts."""
+    if isinstance(obj, float):
+        # via str: Decimal(0.1) carries the binary float's full error
+        return Decimal(str(obj))
+    if isinstance(obj, dict):
+        return {k: float_to_decimal(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [float_to_decimal(v) for v in obj]
+    return obj
+
+
+class ResultsStore:
+    """Sink for one sweep. ``key`` is the workdir-relative result path."""
+
+    def already_processed(self):
+        """Keys already present, so a resumed sweep can skip them."""
+        raise NotImplementedError
+
+    def put(self, key, results):
+        raise NotImplementedError
+
+
+class LocalResultsStore(ResultsStore):
+    """One pickle per job under ``workdir``, laid out as the reporter expects."""
+
+    def __init__(self, workdir):
+        self.workdir = workdir
+
+    def path_for(self, key):
+        return os.path.join(self.workdir, key)
+
+    def already_processed(self):
+        found = set()
+        for dirpath, _, filenames in os.walk(self.workdir):
+            for name in filenames:
+                if name.endswith(".pkl"):
+                    found.add(
+                        os.path.relpath(os.path.join(dirpath, name), self.workdir)
+                    )
+        return found
+
+    def put(self, key, results):
+        path = self.path_for(key)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        # write-then-rename: a sweep killed mid-write must not leave a truncated
+        # pickle that the reporter would later fail on
+        tmp = path + ".tmp"
+        with open(tmp, "wb") as f:
+            pickle.dump(results, f)
+        os.rename(tmp, path)
+
+
+class DynamoDBResultsStore(ResultsStore):
+    """The AWS Batch sink. boto3 is imported lazily so local runs never need it."""
+
+    def __init__(self, workdir, table_name="filter_metrics"):
+        import boto3
+
+        self.workdir = workdir
+        self.table = boto3.resource("dynamodb").Table(table_name)
+
+    def already_processed(self):
+        from spf.filters.run_filters_on_data_b2 import (
+            get_all_items_by_bucket_scan_full_name,
+        )
+
+        return {
+            item["full_name"]
+            for item in get_all_items_by_bucket_scan_full_name(self.workdir)
+        }
+
+    def put(self, key, results):
+        self.table.put_item(
+            Item={
+                "bucket": self.workdir,
+                "full_name": key,
+                "results": float_to_decimal(results),
+            }
+        )
+
+
+def make_results_store(backend, workdir):
+    if backend == "local":
+        return LocalResultsStore(workdir)
+    if backend == "dynamodb":
+        logging.info("results backend: dynamodb (network writes enabled)")
+        return DynamoDBResultsStore(workdir)
+    raise ValueError(f"unknown results backend {backend!r}; expected local or dynamodb")

--- a/spf/filters/run_filters_on_data.py
+++ b/spf/filters/run_filters_on_data.py
@@ -1,14 +1,11 @@
 import argparse
 import logging
 import os
-import pickle
 import random
 import time
-from decimal import Decimal
 from functools import partial
 from multiprocessing import Pool
 
-import boto3
 import torch
 import tqdm
 import yaml
@@ -24,30 +21,10 @@ from spf.filters.particle_dualradioXY_filter import PFXYDualRadio
 from spf.filters.particle_single_radio_filter import PFSingleThetaSingleRadio
 from spf.filters.particle_single_radio_nn_filter import PFSingleThetaSingleRadioNN
 from spf.s3_utils import b2_file_to_local_with_cache, b2path_to_bucket_and_path
+from spf.filters.results_store import make_results_store
 from spf.utils import get_md5_of_file
 
 checkpoints_cache_dir = None
-
-
-def float_to_decimal(obj):
-    """
-    Recursively convert all floating point values in a dict, list, or float
-    to Decimal for DynamoDB.
-    """
-    if isinstance(obj, float):
-        # Convert float to a string, then to Decimal to avoid precision issues
-        return Decimal(str(obj))
-    elif isinstance(obj, dict):
-        for k, v in obj.items():
-            obj[k] = float_to_decimal(v)
-        return obj
-    elif isinstance(obj, list):
-        for i, v in enumerate(obj):
-            obj[i] = float_to_decimal(v)
-        return obj
-    else:
-        # For other types (int, str, bool, None, Decimal, etc.), return as-is
-        return obj
 
 
 def args_to_str(args):
@@ -68,19 +45,25 @@ def fake_runner(ds, **kwargs):
         a = ds[idx][0]
 
 
-def run_jobs_with_one_dataset(kwargs, checkpoints_cache_dir, already_processed=[]):
-
-    dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table("filter_metrics")
+def run_jobs_with_one_dataset(
+    kwargs, checkpoints_cache_dir, already_processed=[], results_backend="local"
+):
     # b2_reset_cache()  # different processes need different folders for cache
     result_fns = []
+    store = None  # built lazily: a fully-skipped dataset should touch no sink
 
     for fn, fn_kwargs in kwargs["jobs"]:
         precompute_cache = fn_kwargs.pop("precompute_cache")
         segmentation_version = fn_kwargs.pop("segmentation_version")
 
         original_b2_paths = {}
-        if "checkpoint_fn" in fn_kwargs:
+        # Only b2:// checkpoints need fetching. b2path_to_bucket_and_path on a
+        # local path yields an empty bucket and the config fetch below then tries
+        # to download "b2:///mnt/...", so without this guard a local checkpoint
+        # cannot be used at all.
+        if "checkpoint_fn" in fn_kwargs and str(fn_kwargs["checkpoint_fn"]).startswith(
+            "b2://"
+        ):
 
             b2_checkpoint_fn = fn_kwargs["checkpoint_fn"]
             local_checkpoint_fn = b2_file_to_local_with_cache(
@@ -141,40 +124,26 @@ def run_jobs_with_one_dataset(kwargs, checkpoints_cache_dir, already_processed=[
             segmentation_version=segmentation_version,
         ) as ds:
 
-            use_file_system = False
-            if use_file_system:
+            fn_kwargs["ds"] = ds
+            new_results = fn(**fn_kwargs)
+            for result in new_results:
+                # NOTE: deliberately not storing result_fn_without_workdir on the
+                # result. It embeds the dataset basename, and the reporter builds
+                # its grouping key from every non-metric field -- storing it puts
+                # each dataset in its own group and defeats the cross-dataset
+                # averaging the report exists to do.
+                result["ds_fn"] = kwargs["ds_fn"]
+                result["segmentation_version"] = segmentation_version
+                result["precompute_cache"] = precompute_cache
+                # report the b2 path the job was configured with, not the local
+                # cache copy it was actually read from
+                for replace_key, replace_value in original_b2_paths.items():
+                    if replace_key in result:
+                        result[replace_key] = replace_value
 
-                os.makedirs(os.path.dirname(result_fn), exist_ok=True)
-                if not os.path.exists(result_fn):
-                    fn_kwargs["ds"] = ds
-                    new_results = fn(**fn_kwargs)
-                    for result in new_results:
-                        result["full_name"] = result_fn_without_workdir
-                        result["ds_fn"] = kwargs["ds_fn"]
-                        result["segmentation_version"] = segmentation_version
-                        result["precompute_cache"] = precompute_cache
-                    # dump to file
-                    pickle.dump(new_results, open(result_fn + ".tmp", "wb"))
-                    os.rename(result_fn + ".tmp", result_fn)
-                    assert os.path.exists(result_fn)
-            else:
-
-                fn_kwargs["ds"] = ds
-                new_results = fn(**fn_kwargs)
-                for result in new_results:
-                    result["ds_fn"] = kwargs["ds_fn"]
-                    result["segmentation_version"] = segmentation_version
-                    result["precompute_cache"] = precompute_cache
-                    for replace_key, replace_value in original_b2_paths.items():
-                        if replace_key in result:
-                            result[replace_key] = replace_value
-                table.put_item(
-                    Item={
-                        "bucket": workdir,
-                        "full_name": result_fn_without_workdir,
-                        "results": float_to_decimal(new_results),
-                    }
-                )
+            if store is None:
+                store = make_results_store(results_backend, workdir)
+            store.put(result_fn_without_workdir, new_results)
 
             result_fns.append(result_fn)
 
@@ -624,12 +593,18 @@ def generate_configs_to_run(
 
 
 def run_filter_jobs(
-    jobs, nparallel, debug=False, checkpoints_cache_dir=None, already_processed=[]
+    jobs,
+    nparallel,
+    debug=False,
+    checkpoints_cache_dir=None,
+    already_processed=[],
+    results_backend="local",
 ):
     f = partial(
         run_jobs_with_one_dataset,
         checkpoints_cache_dir=checkpoints_cache_dir,
         already_processed=already_processed,
+        results_backend=results_backend,
     )
     if debug:
         _ = list(
@@ -710,6 +685,31 @@ if __name__ == "__main__":
             type=str,
             required=True,
         )
+        parser.add_argument(
+            "--results-backend",
+            type=str,
+            choices=["local", "dynamodb"],
+            default="local",
+            help=(
+                "local (default): one results.pkl per job under --work-dir, which "
+                "is what run_filters_report.py reads. dynamodb: put_item into the "
+                "'filter_metrics' table -- needs AWS credentials and writes to the "
+                "network."
+            ),
+        )
+        parser.add_argument(
+            "--checkpoints-cache-dir",
+            type=str,
+            default=None,
+            required=False,
+            help="local cache for b2:// checkpoints; unused for local paths",
+        )
+        parser.add_argument(
+            "--resume",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="skip jobs already present in the results store",
+        )
 
         return parser
 
@@ -728,4 +728,18 @@ if __name__ == "__main__":
         seed=args.seed,
         empirical_pkl_fn=args.empirical_pkl_fn,
     )
-    run_filter_jobs(jobs)
+    already_processed = []
+    if args.resume:
+        already_processed = make_results_store(
+            args.results_backend, args.work_dir
+        ).already_processed()
+        if already_processed:
+            logging.info(f"resuming: {len(already_processed)} results already present")
+    run_filter_jobs(
+        jobs,
+        nparallel=args.parallel,
+        debug=args.debug,
+        checkpoints_cache_dir=args.checkpoints_cache_dir,
+        already_processed=already_processed,
+        results_backend=args.results_backend,
+    )

--- a/spf/filters/run_filters_on_data_b2.py
+++ b/spf/filters/run_filters_on_data_b2.py
@@ -22,7 +22,7 @@ from spf.s3_utils import (
     get_b2_client,
     list_b2_objects,
 )
-from spf.scripts.run_filters_on_data import generate_configs_to_run, run_filter_jobs
+from spf.filters.run_filters_on_data import generate_configs_to_run, run_filter_jobs
 
 
 def get_parser():
@@ -314,6 +314,10 @@ def main():
                                 if os.path.basename(local_zarr_fn) in x
                             ]
                         ),
+                        # explicit: run_filter_jobs now defaults to the local
+                        # sink, and this driver's whole purpose is the shared
+                        # DynamoDB table that its reporter reads back
+                        results_backend="dynamodb",
                     )
                 except Exception as e:
                     print("Failed to process", str(e))

--- a/spf/filters/run_filters_report.py
+++ b/spf/filters/run_filters_report.py
@@ -7,6 +7,8 @@ import pickle
 import torch
 import tqdm
 
+from spf.filters.labels import ds_fn_to_movement
+
 
 def read_pkl(pkl_fn):
     return pickle.load(open(pkl_fn, "rb"))
@@ -43,18 +45,8 @@ def merge_results(results, header):
     for _results in results:
         for result in _results:
             result = result.copy()
-            # _ty = result.pop("type")
-            _fn = result.pop("ds_fn").lower()
-            movement = ""
-            if "circle" in _fn:
-                movement = "circle"
-            elif "bounce" in _fn:
-                movement = "bounce"
-            elif "calibrate" in _fn:
-                movement = "calibrate"
-            else:
-                raise ValueError(f"Cannot figure out movement {_fn}")
-            result["movement"] = movement
+            _fn = result.pop("ds_fn")
+            result["movement"] = ds_fn_to_movement(_fn, result.get("routine"))
             key = result_to_tuple(result, header)
             if key not in merged:
                 merged[key] = []

--- a/spf/filters/run_filters_report_b2.py
+++ b/spf/filters/run_filters_report_b2.py
@@ -7,7 +7,7 @@ import pickle
 import torch
 import tqdm
 
-from spf.scripts.run_filters_on_data_b2 import get_all_items_by_bucket
+from spf.filters.run_filters_on_data_b2 import get_all_items_by_bucket
 
 
 def read_pkl(pkl_fn):

--- a/tests/test_filter_report.py
+++ b/tests/test_filter_report.py
@@ -1,0 +1,189 @@
+"""Labels, the local results store, and the JSON/Markdown report."""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from spf.evaluation.frames import ABSOLUTE_NORTH, CRAFT_RELATIVE, RADIO_FOLDED
+from spf.filters.labels import ds_fn_to_movement, result_to_frame
+from spf.filters.report import build_report, report_to_markdown, write_report
+from spf.filters.results_store import LocalResultsStore, make_results_store
+
+# A real merged v7 rover store name: <RX capture>.<TX capture>. The RX rover is
+# doing `bounce`, the TX rover `circle`, so the name contains BOTH words.
+MERGED_V7 = (
+    "/mnt/qnap01/mouse9911/rovers_2026/merged/"
+    "rover_2026_08_01_19_31_21_nRX2_bounce_spacing0p043_tag_RO3."
+    "rover_2026_08_01_19_54_32_nRX1_circle_spacing0p05075_tag_RO2.zarr"
+)
+WALL = "/mnt/md2/cache/nosig_data/wallarrayv3_2024_06_03_00_30_00_nRX2_rx_circle.zarr"
+
+
+# ------------------------------------------------------------------ labels
+
+
+def test_merged_v7_uses_the_recorded_routine_not_the_filename():
+    """The filename has both 'bounce' and 'circle'; only the yaml disambiguates."""
+    assert ds_fn_to_movement(MERGED_V7, routine="bounce") == "rover_bounce"
+
+
+def test_merged_v7_filename_alone_is_ambiguous():
+    """Documents why the routine is preferred: substring order decides, wrongly.
+
+    'bounce' is tested before 'circle', so the fallback happens to be right here
+    -- but it is right by token ordering, not by knowing which rover is the RX.
+    """
+    assert ds_fn_to_movement(MERGED_V7) == "rover_bounce"
+
+
+def test_wall_array_movement():
+    assert ds_fn_to_movement(WALL, routine="circle") == "2dwallarray_circle"
+
+
+def test_unknown_routine_falls_back_to_the_filename():
+    assert ds_fn_to_movement(WALL, routine="unknown") == "2dwallarray_circle"
+
+
+def test_random_circle_is_not_swallowed_by_circle():
+    name = "/data/rover_2025_01_01_random_circle_tag_RO1.zarr"
+    assert ds_fn_to_movement(name) == "rover_random_circle"
+
+
+def test_undeterminable_movement_raises():
+    with pytest.raises(ValueError):
+        ds_fn_to_movement("/data/something_unlabelled.zarr")
+
+
+@pytest.mark.parametrize(
+    "result,expected",
+    [
+        ({"type": "PF_single_theta_single_radio"}, RADIO_FOLDED),
+        ({"type": "EKF_single_theta_single_radio"}, RADIO_FOLDED),
+        ({"type": "PF_single_theta_dual_radio"}, CRAFT_RELATIVE),
+        ({"type": "EKF_XY_dual_radio"}, CRAFT_RELATIVE),
+        ({"type": "PF_single_theta_dual_radio_NN", "absolute": False}, CRAFT_RELATIVE),
+        ({"type": "PF_single_theta_dual_radio_NN", "absolute": True}, ABSOLUTE_NORTH),
+    ],
+)
+def test_frame_is_recovered_from_type_and_absolute(result, expected):
+    assert result_to_frame(result) == expected
+
+
+# ------------------------------------------------------------------- store
+
+
+def _result(ds_fn, _type, mse, **extra):
+    r = {
+        "type": _type,
+        "ds_fn": ds_fn,
+        "routine": "bounce",
+        "N": 4096,
+        "metrics": {"mse_craft_theta": mse, "runtime": 0.5},
+    }
+    r.update(extra)
+    return r
+
+
+def test_local_store_round_trip():
+    with tempfile.TemporaryDirectory() as d:
+        store = LocalResultsStore(d)
+        assert store.already_processed() == set()
+        key = "fn_run_PF/3.700/ds_x.zarr/_Nx4096_results.pkl"
+        store.put(key, [_result(MERGED_V7, "PF_single_theta_dual_radio", 1.5)])
+        assert store.already_processed() == {key}
+        assert os.path.exists(os.path.join(d, key))
+
+
+def test_local_store_leaves_no_partial_file_behind():
+    """Results are renamed into place, so a killed sweep cannot strand a .tmp."""
+    with tempfile.TemporaryDirectory() as d:
+        store = LocalResultsStore(d)
+        store.put("a/b/r.pkl", [_result(WALL, "PF_single_theta_dual_radio", 1.0)])
+        stragglers = [f for _, _, fs in os.walk(d) for f in fs if f.endswith(".tmp")]
+        assert stragglers == []
+
+
+def test_make_results_store_rejects_unknown_backend():
+    with pytest.raises(ValueError):
+        make_results_store("s3", "/tmp/x")
+
+
+def test_local_backend_needs_no_credentials():
+    """The whole point: a local sweep must not touch boto3 or the network."""
+    assert isinstance(make_results_store("local", "/tmp/x"), LocalResultsStore)
+
+
+# ------------------------------------------------------------------ report
+
+
+def test_report_groups_across_datasets_and_counts_runs():
+    with tempfile.TemporaryDirectory() as d:
+        store = LocalResultsStore(d)
+        for i, ds in enumerate([MERGED_V7, MERGED_V7.replace("19_31_21", "20_31_21")]):
+            store.put(
+                f"fn_run_PF/3.700/ds_{i}/_Nx4096_results.pkl",
+                [_result(ds, "PF_single_theta_dual_radio", 1.0 + i)],
+            )
+        report = build_report(d)
+        assert report["n_results"] == 2
+        # same hyperparameters on two datasets must land in ONE group
+        assert report["n_groups"] == 1
+        row = report["rows"][0]
+        assert row["n_runs"] == 2
+        assert row["frame"] == CRAFT_RELATIVE
+        assert row["movement"] == "rover_bounce"
+        assert abs(row["mse_craft_theta_mean"] - 1.5) < 1e-9
+
+
+def test_absolute_and_craft_relative_get_separate_rows():
+    """The trap: identical hyperparameters, different ground truth."""
+    with tempfile.TemporaryDirectory() as d:
+        store = LocalResultsStore(d)
+        store.put(
+            "fn_run_NN/3.700/ds_a/_absT_results.pkl",
+            [_result(MERGED_V7, "PF_single_theta_dual_radio_NN", 0.33, absolute=True)],
+        )
+        store.put(
+            "fn_run_NN/3.700/ds_a/_absF_results.pkl",
+            [_result(MERGED_V7, "PF_single_theta_dual_radio_NN", 1.89, absolute=False)],
+        )
+        report = build_report(d)
+        assert report["n_groups"] == 2
+        frames = {r["frame"] for r in report["rows"]}
+        assert frames == {ABSOLUTE_NORTH, CRAFT_RELATIVE}
+
+
+def test_write_report_emits_tracked_file_types():
+    """CSV is gitignored repo-wide; results must land as json + md to be committable."""
+    with tempfile.TemporaryDirectory() as d, tempfile.TemporaryDirectory() as out:
+        LocalResultsStore(d).put(
+            "fn_run_PF/3.700/ds_a/_r.pkl",
+            [_result(MERGED_V7, "PF_single_theta_dual_radio", 1.0)],
+        )
+        json_fn, md_fn = write_report(d, out)
+        assert json_fn.endswith("results.json") and os.path.exists(json_fn)
+        assert md_fn.endswith("REPORT.md") and os.path.exists(md_fn)
+        with open(json_fn) as f:
+            assert json.load(f)["n_results"] == 1
+        with open(md_fn) as f:
+            body = f.read()
+        assert "frame: `craft_relative`" in body
+
+
+def test_markdown_gives_each_frame_its_own_table():
+    rows = [
+        {"frame": CRAFT_RELATIVE, "N": 128, "mse_mean": 2.0, "n_runs": 1},
+        {"frame": ABSOLUTE_NORTH, "N": 128, "mse_mean": 0.5, "n_runs": 1},
+    ]
+    md = report_to_markdown(
+        {"workdir": "w", "n_results": 2, "n_groups": 2, "rows": rows}
+    )
+    assert md.count("## frame: `") == 2
+
+
+def test_empty_workdir_is_an_error_not_an_empty_report():
+    with tempfile.TemporaryDirectory() as d:
+        with pytest.raises(ValueError, match="no results"):
+            build_report(d)

--- a/tests/test_filter_sweep_smoke.py
+++ b/tests/test_filter_sweep_smoke.py
@@ -1,0 +1,167 @@
+"""End-to-end: config -> local sweep -> results store -> report.
+
+Guards the two defects that made a local run impossible:
+
+* ``run_filter_jobs(jobs)`` in ``__main__`` omitted the required ``nparallel``,
+  so invoking the runner directly raised TypeError before doing any work.
+* The runner wrote to DynamoDB behind a hard-coded ``use_file_system = False``
+  while ``run_filters_report.py`` read ``.pkl`` from the work dir, so the two
+  halves of the pipeline pointed at different sinks.
+
+Uses the tiny synthetic fixture, so it needs no /mnt access and no credentials.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+import yaml
+
+from spf.filters.report import build_report
+from spf.filters.run_filters_on_data import (
+    generate_configs_to_run,
+    run_filter_jobs,
+)
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _config(precompute_cache):
+    return {
+        "precompute_caches": {3.7: precompute_cache},
+        "runs": [
+            {
+                "run_EKF_single_theta_dual_radio": {
+                    "phi_std": [10.0],
+                    "p": [5.0],
+                    "noise_std": [0.001],
+                    "dynamic_R": [0.0],
+                    "segmentation_version": [3.7],
+                }
+            },
+            {
+                "run_PF_single_theta_dual_radio": {
+                    "N": [128],
+                    "theta_err": [0.01],
+                    "theta_dot_err": [0.01],
+                    "segmentation_version": [3.7],
+                }
+            },
+        ],
+    }
+
+
+def _run_sweep(noise1_n128_obits2, workdir, config_fn):
+    dirname, empirical_pkl_fn, ds_fn = noise1_n128_obits2
+    with open(config_fn, "w") as f:
+        yaml.safe_dump(_config(dirname), f)
+    jobs = generate_configs_to_run(
+        yaml_config_fn=config_fn,
+        work_dir=workdir,
+        dataset_fns=[ds_fn + ".zarr"],
+        seed=0,
+        empirical_pkl_fn=empirical_pkl_fn,
+    )
+    run_filter_jobs(jobs, nparallel=2, debug=True, results_backend="local")
+    return jobs
+
+
+def test_local_sweep_writes_results_the_reporter_can_read(noise1_n128_obits2):
+    with tempfile.TemporaryDirectory() as d:
+        workdir = os.path.join(d, "wd")
+        jobs = _run_sweep(noise1_n128_obits2, workdir, os.path.join(d, "c.yml"))
+        assert len(jobs) == 2
+
+        written = [
+            os.path.join(dp, f)
+            for dp, _, fs in os.walk(workdir)
+            for f in fs
+            if f.endswith(".pkl")
+        ]
+        assert len(written) == 2, written
+
+        report = build_report(workdir)
+        assert report["n_results"] >= 2
+        assert all("frame" in row for row in report["rows"])
+        # every run must carry a real error metric
+        for row in report["rows"]:
+            assert any(k.startswith("mse") and k.endswith("_mean") for k in row), row
+
+
+def test_sweep_is_resumable(noise1_n128_obits2):
+    """A second pass with the same work dir must skip everything already done."""
+    with tempfile.TemporaryDirectory() as d:
+        workdir = os.path.join(d, "wd")
+        config_fn = os.path.join(d, "c.yml")
+        _run_sweep(noise1_n128_obits2, workdir, config_fn)
+        before = {
+            os.path.join(dp, f): os.path.getmtime(os.path.join(dp, f))
+            for dp, _, fs in os.walk(workdir)
+            for f in fs
+        }
+
+        from spf.filters.results_store import LocalResultsStore
+
+        dirname, empirical_pkl_fn, ds_fn = noise1_n128_obits2
+        jobs = generate_configs_to_run(
+            yaml_config_fn=config_fn,
+            work_dir=workdir,
+            dataset_fns=[ds_fn + ".zarr"],
+            seed=0,
+            empirical_pkl_fn=empirical_pkl_fn,
+        )
+        run_filter_jobs(
+            jobs,
+            nparallel=2,
+            debug=True,
+            already_processed=LocalResultsStore(workdir).already_processed(),
+            results_backend="local",
+        )
+        after = {
+            os.path.join(dp, f): os.path.getmtime(os.path.join(dp, f))
+            for dp, _, fs in os.walk(workdir)
+            for f in fs
+        }
+        assert before == after, "resumed sweep rewrote already-finished results"
+
+
+def test_runner_main_accepts_its_own_arguments(noise1_n128_obits2):
+    """`run_filter_jobs(jobs)` in __main__ used to raise TypeError immediately."""
+    dirname, empirical_pkl_fn, ds_fn = noise1_n128_obits2
+    with tempfile.TemporaryDirectory() as d:
+        config_fn = os.path.join(d, "c.yml")
+        with open(config_fn, "w") as f:
+            yaml.safe_dump(_config(dirname), f)
+        proc = subprocess.run(
+            [
+                sys.executable,
+                os.path.join(REPO, "spf", "filters", "run_filters_on_data.py"),
+                "-d",
+                ds_fn + ".zarr",
+                "--empirical-pkl-fn",
+                empirical_pkl_fn,
+                "--work-dir",
+                os.path.join(d, "wd"),
+                "--config",
+                config_fn,
+                "--results-backend",
+                "local",
+                "--parallel",
+                "2",
+                "--debug",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=900,
+            cwd=REPO,
+        )
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "TypeError" not in proc.stderr
+        produced = [
+            f
+            for _, _, fs in os.walk(os.path.join(d, "wd"))
+            for f in fs
+            if f.endswith(".pkl")
+        ]
+        assert len(produced) == 2, proc.stdout + proc.stderr


### PR DESCRIPTION
Third of four changes. **Stacked on [#21](https://github.com/misko/spf/pull/21)** (`spf/evaluation`); base retargets to `main` automatically once that merges.

Four defects made a local run impossible, and a fifth mislabelled the new rover data once it did run.

| # | Defect | Fix |
|---|---|---|
| 1 | `run_jobs_with_one_dataset` built a DynamoDB resource unconditionally and wrote every result there, behind a hard-coded `use_file_system = False` — while `run_filters_report.py` reads `.pkl` from the work dir. **The two halves of the pipeline pointed at different sinks.** | `results_store.py`: both behind one interface, **local by default**, boto3 imported lazily |
| 2 | `__main__` called `run_filter_jobs(jobs)` without the required `nparallel` → `TypeError` before any work | pass it, plus `--results-backend` / `--checkpoints-cache-dir` / `--resume` |
| 3 | Checkpoints assumed `b2://`; `b2path_to_bucket_and_path` on a local path yields an empty bucket, so the config fetch tried `b2:///mnt/...`. **Local checkpoints could not be used at all.** | guard on the `b2://` prefix |
| 4 | Both cloud drivers imported `spf.scripts.run_filters_on_data*`, which `2276ed1` moved without updating them → `ModuleNotFoundError` | two lines |
| 5 | The reporter picked `movement` by filename substring with `"circle"` tested first. A merged v7 store is `<RX>.<TX>`, so a bounce-RX/circle-TX pair contains **both** words — every merged rover store was labelled `circle` when its RX routine was `bounce` | `labels.py` prefers the routine recorded in the capture yaml |

The AWS Batch driver is unchanged: it now passes `results_backend="dynamodb"` explicitly.

## New: `report.py`

Writes `results.json` + `REPORT.md` rather than CSV. `.gitignore` matches `**/*.csv` repo-wide (only the JLC fab files excepted), so **a sweep result in CSV can never be committed** — that's the whole reason this exists. Matches the append-only convention under `spf/calibrations/*/reports/`.

It groups on the angular frame recovered by `labels.result_to_frame`, so an `absolute=True` and an `absolute=False` run of the same hyperparameters never land in one average — they're scored against different ground truth.

Also drops the `full_name` field the old file-system branch wrote into each result: it embeds the dataset basename, and the reporter keys on every non-metric field, so storing it put each dataset in its own group and defeated the cross-dataset averaging the report exists to do.

## Not fixed, deliberately

The b2 reporter's own `merge_results` double-prefixes the vehicle when the routine is missing (`rover_rover_bounce`). That's the cloud path and out of scope.

## Tests

21 unit (labels, store round-trip, frame recovery, report grouping, CSV-vs-JSON) + 3 end-to-end on the synthetic fixture: sweep → store → report, resumability, and a **subprocess run of `__main__`** that would have caught defect 2. No `/mnt` access, no credentials.

Full filter suite green: **104 passed, 1 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)