### PR TITLE
filters: unified visualiser, local sweep configs, and the E-INF1 design

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -32,6 +32,7 @@ append-only convention.
 | [e_gsp7_conditioned_comb](e_gsp7_conditioned_comb/experiment_readme.md) | Does a 10-LO comb *chosen by conditioning* calibrate, where E-CAL3's uniform 10-LO comb failed at 11.61°? | ✅ run 2026-08-07 — yes, but only if the delays are ALSO frozen: chosen-10 frozen 4.95° vs the E-CAL3 comb's 23.50°, same session, same coverage |
 | [e_lnk1_transport_sample_rate](e_lnk1_transport_sample_rate/experiment_readme.md) | How do direct-USB, libiio/USB, IIO-over-RNDIS and IIO-over-Ethernet compare across the sample-rate range on `.18` — in throughput, integrity, metadata and measured phase? | ✅ throughput run 2026-08-07 — Ethernet holds up **exactly** as well as USB and no better: both wall at ~23 MB/s (2.9 MS/s), so the limit is the radio, not the link. Ethernet's apparent 28% lead at production buffer size is a buffer-tuning artifact. Phase/CPU metrics not yet run |
 | [e_gsp2_pad_sweep](e_gsp2_pad_sweep/experiment_readme.md) | Is the frequency ripple actually a harness reflection? | needs parts |
+| [e_inf1_filter_sweep](e_inf1_filter_sweep/experiment_readme.md) | How do the current models plus the EKF/PF trackers perform on the 2026 rover corpus versus the frozen val set, and does the reported confidence mean anything? | designed 2026-08-08, tooling landed, not yet run; blocked on the d/λ = 0.904 empirical-table gap |
 
 Designs and decision rules for the wider programme are in
 [`docs/future_experiments.md`](../docs/future_experiments.md).

--- a/experiments/e_inf1_filter_sweep/RESULTS.md
+++ b/experiments/e_inf1_filter_sweep/RESULTS.md
@@ -1,0 +1,40 @@
+# E-INF1 — results
+
+**Status: NOT RUN.** Design and decision rules are pre-registered in
+[`experiment_readme.md`](experiment_readme.md); this file exists so the
+hypotheses cannot be edited after seeing the data.
+
+| Hypothesis | Prediction | Outcome |
+|---|---|---|
+| H1 | NN dual-radio PF beats empirical on the rover corpus | _pending_ |
+| H2 | best rover MSE ≥ 2× best frozen-val MSE | _pending_ |
+| H3 | median `std(z)` > 1.5 on every corpus (filters overconfident) | _pending_ |
+| H4 | MSE worse at d/λ = 0.904 than at 0.673 | _pending_ |
+
+## Blocking item
+
+3 of the 48 merged rover stores are RO4 at **d/λ = 0.90397**, which has no entry
+in `empirical_dists/full.pkl`. `get_empirical_dist` is an exact-key lookup, so
+every empirical (non-NN) filter raises `KeyError` on those. Resolve before stage
+2 — either run `create_empirical_p_dist.py` for that spacing, or restrict the
+empirical families to the 0.673 and 0.827 stores and say so here.
+
+## Pilot observations (single dataset, 2026-08-07)
+
+Not results — these motivated the experiment and are recorded so the stage-2
+numbers can be sanity-checked against something.
+
+On `rover_2026_08_01_19_31_21…RO3` (539 timesteps, d/λ = 0.827), one seed each:
+
+| filter | MSE (rad²) | frame |
+|---|---|---|
+| PF dual, NN, `absolute=True` | 0.32–0.76 across 8 seeds | absolute_north |
+| PF dual, NN, `absolute=False` | 1.86 | craft_relative |
+| PF dual, empirical | 1.63–2.44 across 8 seeds | craft_relative |
+| PF single, empirical (r0/r1) | 0.32 / 0.58 | radio_folded |
+| EKF dual | 2.57 | craft_relative |
+
+±1σ coverage for the NN dual PF was **25.6%** against 68.3% nominal.
+
+⚠️ The two NN rows are **not** comparable — different ground truth. And the
+per-seed spread (42% empirical, 106% NN) is why stage 2 runs 5 seeds.

--- a/experiments/e_inf1_filter_sweep/experiment_readme.md
+++ b/experiments/e_inf1_filter_sweep/experiment_readme.md
@@ -1,0 +1,137 @@
+# E-INF1 — how do our best models track, locally, across three corpora?
+
+**Status:** designed 2026-08-08, not yet run. Tooling landed in changes 1–4
+(`spf/filters/resample.py`, `spf/evaluation/`, `spf/filters/report.py`,
+`spf/filters/plot_filter_run.py`, `spf/filters/configs/`).
+**Results:** [`RESULTS.md`](RESULTS.md) _(written when it runs)_
+**Est. compute:** ~8 h wall on the 24-core box. **No cloud.**
+
+This is a computational experiment, so the `experiments/README.md` "hardware
+setup" section does not apply — there is no bench, no radio, no schematic. The
+inputs are recorded datasets and trained checkpoints, all read-only.
+
+---
+
+## 1. Purpose
+
+We have never measured how the current models plus the EKF/PF trackers perform
+on the **2026 rover corpus**, and the historical numbers we do have came from a
+sweep that was (a) run on cloud infrastructure we are no longer using and (b)
+built on a particle filter whose results were not reproducible.
+
+Three things are unknown:
+
+1. **Which filter family and hyperparameters actually win**, per corpus, now
+   that runs are seeded and repeatable.
+2. **How far the 2026 rover data is out of distribution.** Its arrays run at
+   d/λ = 0.673 / 0.827 / 0.904 — all past the λ/2 unambiguous limit, so the
+   arrays are spatially aliased. The models take d/λ as an input, but whether
+   they extrapolate there is untested.
+3. **Whether the reported confidence means anything.** A single pilot run put
+   ±1σ coverage at 25.6% against 68.3% nominal. If that holds across the sweep,
+   nothing downstream can gate on filter variance.
+
+## 2. Hypotheses (pre-registered)
+
+- **H1 — NN beats empirical on rover.** The NN dual-radio PF has lower craft-relative
+  MSE than the empirical dual-radio PF on the rover corpus, because the empirical
+  `P(θ|φ)` table was built from wall-array data at different spacings.
+- **H2 — the rover corpus is materially harder.** Best-config craft-relative MSE
+  on rover is at least 2× the best on the frozen val set.
+- **H3 — filters are overconfident everywhere, not just in the pilot.** Median
+  `std(z)` across the best 10 configs is > 1.5 on every corpus.
+- **H4 — the aliased spacings are the problem.** Within the rover corpus, MSE is
+  worse at d/λ = 0.904 than at 0.673, for the same filter and hyperparameters.
+
+## 3. Approach
+
+Four stages. Each is a gate: do not start the next until the previous passes.
+
+| Stage | What | Cost |
+|---|---|---|
+| 0 | segment the rover corpus at v3.7 (`segment_zarr.py`, **unchanged**) | ~2 h GPU, ~1.3 GB |
+| 1 | build inference caches on **GPU** (`create_inference_cache.py --device cuda`) | rover 160 s; val 2.1 h |
+| 2 | coarse grid (348 configs) on a **stratified 16-dataset sample** per corpus, **5 seeds** | ~1.3 h wall per corpus |
+| 3 | top ~4 configs per family on the **full** corpora, 1 seed | ~1 h val, ~15 min rover |
+
+Stage 2 uses seeds because a 16-dataset average only cuts the 42–106% per-dataset
+PF spread by √16 = 4×. Stage 3 does not, because 565 datasets cut it by √565 ≈ 24×,
+leaving ~1.7% residual — below any effect worth acting on.
+
+**Stratification for the sample:** by (routine × d/λ × capture day) for rover, and
+by (vehicle × routine × band × d/λ) for the frozen val set. The sample list is
+written to the report directory so the stage-2 result is reproducible.
+
+### Controls
+
+- **Seeded runs.** Since change 1, `seed` fully determines a PF run; the sweep
+  records it.
+- **Frames never pooled.** `absolute=True` and `absolute=False` are scored against
+  different ground truth and are kept in separate frames end to end.
+- **Posterior scored separately from the tracker.** `spf/evaluation/posterior.py`
+  scores the network's `P(θ)` with no filter, so H1/H2 can be attributed to the
+  model or to the tracker rather than confounded.
+- **The frozen val set is untouched.** It is read-only; no new val view is created.
+
+## 4. Software setup
+
+```bash
+# stage 0 -- segmentation code is NOT modified; it is used as-is
+python spf/scripts/segment_zarr.py -i <merged>.zarr \
+    -c /mnt/qnap01/mouse9911/rovers_2026/precompute --gpu --workers 2
+
+# stage 1 -- GPU, batch >= 64. CPU at batch 16 is 42x slower (13 vs 543 sess/s)
+python spf/scripts/create_inference_cache.py --device cuda --parallel 2 \
+    --config-fn <ckpt>/config.yml --checkpoint-fn <ckpt>/best.pth \
+    --inference-cache /mnt/qnap01/.../inference_cache \
+    --precompute-cache <precompute> --segmentation-version 3.7 -d <datasets>
+
+# stage 2/3 -- 24 workers, not 30: throughput peaks at 24 and regresses at 30
+python spf/filters/run_filters_on_data.py -d <datasets> \
+    --empirical-pkl-fn empirical_dists/full.pkl \
+    --work-dir /mnt/qnap01/.../filter_runs/<stage> \
+    --config spf/filters/configs/<corpus>_coarse.yaml \
+    --results-backend local --parallel 24
+
+python spf/filters/report.py --work-dir <workdir> \
+    --output-dir spf/filters/reports/e_inf1_<corpus>_<date>_v1
+```
+
+Model: `/mnt/md0/checkpoints/jun26_2026/paired_3p7_thin_noblade/best.pth`
+(the newest paired checkpoint, 2026-07-04). Environment:
+`~/virtual-envs/spf/bin/python3`.
+
+## 5. Outputs and acceptance gates
+
+| Artifact | Location | Gate |
+|---|---|---|
+| rover precompute | `rovers_2026/precompute/` | all 48 stores segment without error |
+| inference caches | `rovers_2026/inference_cache/` | one `.npz` per dataset per model |
+| stage-2 reports | `spf/filters/reports/e_inf1_<corpus>_coarse_<date>_v1/` | every config has `n_runs = 5` |
+| stage-3 reports | `spf/filters/reports/e_inf1_<corpus>_full_<date>_v1/` | `n_runs` equals the corpus size |
+| per-dataset figures | qnap01 (gitignored) | ≥1 figure per corpus visually checked per CLAUDE.md |
+| `RESULTS.md` | this directory | states H1–H4 outcomes with numbers |
+
+## 6. Decision rules (pre-registered)
+
+- **H1** — if NN craft-relative MSE is not below empirical on rover, the NN
+  advantage does not survive the domain shift and retraining with 2026 rover data
+  becomes the priority over further filter tuning.
+- **H2** — if rover MSE is within 2× of val, the 2026 corpus is usable as-is for
+  evaluation. If it is far worse, diagnose with the posterior scores first
+  (stage 3 emits them): a bad posterior means the model, a good posterior with a
+  bad track means the tracker.
+- **H3** — if `std(z) > 1.5` holds, **no downstream component may gate on filter
+  variance** until the cause is found, and that becomes its own work item.
+- **H4** — if d/λ = 0.904 is materially worse, the RO4 rovers need re-spacing
+  before further capture, and the 3 affected stores are excluded from training.
+
+## 7. Risks
+
+| Risk | Catch |
+|---|---|
+| 3 RO4 stores at d/λ = 0.904 have no empirical-table entry → `KeyError` in every empirical filter | known; either run `create_empirical_p_dist.py` for that spacing or restrict the empirical families. **Resolve before stage 2.** |
+| The O4 emitter is bursty (60–70% NaN is healthy) so mean-over-all-frames metrics measure the silence | report `median_abs_err` alongside the mean; both are in `metrics.summarize` |
+| Stage 2 sample is unrepresentative | stratify, and record the sample list in the report |
+| Another session is using the box | timings are not a gate here; only stage-2/3 wall clock is affected |
+| Filenames are unreliable for ordering/attribution (19 captures carry a restored-clock timestamp) | group by `routine` and `gps_timestamp`, never by filename — `spf/filters/labels.py` already prefers the recorded routine |

--- a/spf/filters/configs/README.md
+++ b/spf/filters/configs/README.md
@@ -1,0 +1,34 @@
+# Filter sweep configs
+
+Grids for `spf/filters/run_filters_on_data.py`. All paths are **local** — no
+`b2://`, no DynamoDB.
+
+## One config per corpus, and why
+
+`precompute_caches` is a single global `segmentation_version -> path` map, so a
+config can only ever describe **one** corpus. The rover-2026 precompute lives on
+qnap01; the historical wall/rover corpus lives on md2. Hence `rover2026_*.yaml`
+and `historical_*.yaml` rather than one file with both.
+
+## The two stages
+
+| File | Datasets | Configs | Purpose |
+|---|---|---|---|
+| `*_smoke.yaml` | 1 | ~8 | prove the harness runs against a corpus before spending hours |
+| `*_coarse.yaml` | ~16 stratified | ~500 | find the region of good hyperparameters, **5 seeds each** |
+
+The shipped `spf/model_training_and_inference/models/ekf_and_pf_config.yml`
+expands to **5,926 jobs per dataset**. At the measured 4.155 cpu-s per filter
+timestep and a parallel ceiling of 8.8x on this box, that is ~12 h for the rover
+corpus but **22 days** for the frozen val set and **87 days** for train. It was
+designed for AWS Batch. Locally the grid has to be cut, which is what these
+configs do.
+
+## Seeds
+
+Particle filters are stochastic. Since `spf/filters/resample.py` they are
+reproducible from `seed`, but different seeds still give different answers — the
+per-dataset spread was measured at 42% (empirical dual-radio) and 106% (NN
+dual-radio) of mean MSE. Averaging over a 16-dataset sample cuts that by only
+sqrt(16) = 4x, so the coarse stage runs **5 seeds per config**. On a full corpus
+(565 datasets, sqrt = 24x) one seed is enough.

--- a/spf/filters/configs/historical_coarse.yaml
+++ b/spf/filters/configs/historical_coarse.yaml
@@ -1,0 +1,69 @@
+# Historical corpus (frozen val / train) -- coarse hyperparameter grid.
+#
+# Same grid as rover2026_coarse.yaml against the md2 precompute. Run it on a
+# STRATIFIED SAMPLE of ~16 datasets from the frozen val list, never the whole
+# corpus: at a measured 4.155 cpu-s per filter timestep and ~4.14M timesteps in
+# the frozen val set, even this reduced grid over all 565 datasets is days.
+#
+# The precompute cache on md2 is READ-ONLY -- it holds 4.3 TB of unregenerable
+# 3.4/3.5/3.6 caches. New outputs (work dirs, inference caches) go to qnap01.
+#
+# The frozen val list is /mnt/md2/splits/apr17_val_nosig_noroverbounce.txt
+# (565 datasets, 556 with 3.7 precompute).
+precompute_caches:
+  3.7: "/mnt/md2/cache/precompute_cache_3p7"
+
+runs:
+  # --- EKF: cheap (0.02-0.04 s/run), so it can afford a wider grid
+  - run_EKF_single_theta_dual_radio:
+      phi_std: [20.0, 10.0, 5.0, 2.5, 1.0]
+      p: [5.0, 1.0, 0.1]
+      noise_std: [0.01, 0.001, 0.0001, 0.00001]
+      dynamic_R: [0.0]
+      segmentation_version: [3.7]
+  - run_EKF_single_theta_dual_radio:
+      phi_std: [0.0]
+      p: [5.0, 1.0, 0.1]
+      noise_std: [0.01, 0.001, 0.0001, 0.00001]
+      dynamic_R: [1.0, 0.1]
+      segmentation_version: [3.7]
+  - run_EKF_single_theta_single_radio:
+      phi_std: [20.0, 10.0, 5.0, 1.0]
+      p: [5.0, 1.0]
+      noise_std: [0.01, 0.001, 0.0001]
+      dynamic_R: [0.0]
+      segmentation_version: [3.7]
+
+  # --- PF: ~0.7 ms per timestep per run at N=8192 and linear in N, so the grid
+  # is deliberately coarse in N. Log-spaced errs: the shipped grid's 12x13 mesh
+  # resolves far finer than the seed-to-seed spread justifies.
+  - run_PF_single_theta_dual_radio:
+      N: [128 * 8, 128 * 32, 128 * 128]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.005, 0.02, 0.1]
+      segmentation_version: [3.7]
+  - run_PF_single_theta_single_radio:
+      N: [128 * 8, 128 * 32]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.01, 0.1]
+      segmentation_version: [3.7]
+
+  # --- NN PF: the family with the most to gain, and the noisiest (106%
+  # seed-to-seed spread), so keep the grid tight and lean on repeats instead.
+  - run_PF_single_theta_dual_radio_NN:
+      checkpoint_fn_and_segmentation_version:
+        - checkpoint_fn: "/mnt/md0/checkpoints/jun26_2026/paired_3p7_thin_noblade/best.pth"
+          segmentation_version: 3.7
+      inference_cache: ["/mnt/qnap01/mouse9911/inference_cache_3p7"]
+      N: [128 * 8, 128 * 32, 128 * 128]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.005, 0.02, 0.1]
+      absolute: [True, False]
+  - run_PF_single_theta_single_radio_NN:
+      checkpoint_fn_and_segmentation_version:
+        - checkpoint_fn: "/mnt/md0/checkpoints/jun26_2026/paired_3p7_thin_noblade/best.pth"
+          segmentation_version: 3.7
+      inference_cache: ["/mnt/qnap01/mouse9911/inference_cache_3p7"]
+      N: [128 * 8, 128 * 32]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.01, 0.1]

--- a/spf/filters/configs/rover2026_coarse.yaml
+++ b/spf/filters/configs/rover2026_coarse.yaml
@@ -1,0 +1,74 @@
+# Rover 2026 merged v7 -- coarse hyperparameter grid for the tuning stage.
+#
+# ~500 jobs per dataset against the shipped grid's 5,926. Run it on a STRATIFIED
+# SAMPLE of ~16 stores (by routine x d/lambda x day), not the whole corpus: the
+# point of this stage is to find the region of good hyperparameters, and the
+# winners then get evaluated on everything.
+#
+#   python spf/filters/run_filters_on_data.py \
+#     -d $(cat sample16.txt) \
+#     --empirical-pkl-fn empirical_dists/full.pkl \
+#     --work-dir /mnt/qnap01/mouse9911/rovers_2026/filter_runs/coarse \
+#     --config spf/filters/configs/rover2026_coarse.yaml \
+#     --results-backend local --parallel 24
+#
+# Parallelism: 24, not the old default of 30. Measured throughput on this box
+# peaks at 24 workers (8.8x) and REGRESSES at 30 (7.9x) as work spills onto
+# E-cores -- total CPU for the same work rises from 51.7 s to 139 s.
+precompute_caches:
+  3.7: "/mnt/qnap01/mouse9911/rovers_2026/precompute"
+
+runs:
+  # --- EKF: cheap (0.02-0.04 s/run), so it can afford a wider grid
+  - run_EKF_single_theta_dual_radio:
+      phi_std: [20.0, 10.0, 5.0, 2.5, 1.0]
+      p: [5.0, 1.0, 0.1]
+      noise_std: [0.01, 0.001, 0.0001, 0.00001]
+      dynamic_R: [0.0]
+      segmentation_version: [3.7]
+  - run_EKF_single_theta_dual_radio:
+      phi_std: [0.0]
+      p: [5.0, 1.0, 0.1]
+      noise_std: [0.01, 0.001, 0.0001, 0.00001]
+      dynamic_R: [1.0, 0.1]
+      segmentation_version: [3.7]
+  - run_EKF_single_theta_single_radio:
+      phi_std: [20.0, 10.0, 5.0, 1.0]
+      p: [5.0, 1.0]
+      noise_std: [0.01, 0.001, 0.0001]
+      dynamic_R: [0.0]
+      segmentation_version: [3.7]
+
+  # --- PF: ~0.7 ms per timestep per run at N=8192 and linear in N, so the grid
+  # is deliberately coarse in N. Log-spaced errs: the shipped grid's 12x13 mesh
+  # resolves far finer than the seed-to-seed spread justifies.
+  - run_PF_single_theta_dual_radio:
+      N: [128 * 8, 128 * 32, 128 * 128]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.005, 0.02, 0.1]
+      segmentation_version: [3.7]
+  - run_PF_single_theta_single_radio:
+      N: [128 * 8, 128 * 32]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.01, 0.1]
+      segmentation_version: [3.7]
+
+  # --- NN PF: the family with the most to gain, and the noisiest (106%
+  # seed-to-seed spread), so keep the grid tight and lean on repeats instead.
+  - run_PF_single_theta_dual_radio_NN:
+      checkpoint_fn_and_segmentation_version:
+        - checkpoint_fn: "/mnt/md0/checkpoints/jun26_2026/paired_3p7_thin_noblade/best.pth"
+          segmentation_version: 3.7
+      inference_cache: ["/mnt/qnap01/mouse9911/rovers_2026/inference_cache"]
+      N: [128 * 8, 128 * 32, 128 * 128]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.005, 0.02, 0.1]
+      absolute: [True, False]
+  - run_PF_single_theta_single_radio_NN:
+      checkpoint_fn_and_segmentation_version:
+        - checkpoint_fn: "/mnt/md0/checkpoints/jun26_2026/paired_3p7_thin_noblade/best.pth"
+          segmentation_version: 3.7
+      inference_cache: ["/mnt/qnap01/mouse9911/rovers_2026/inference_cache"]
+      N: [128 * 8, 128 * 32]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.01, 0.1]

--- a/spf/filters/configs/rover2026_smoke.yaml
+++ b/spf/filters/configs/rover2026_smoke.yaml
@@ -1,0 +1,68 @@
+# Rover 2026 merged v7 -- one setting per filter family, ~8 jobs per dataset.
+#
+# Purpose: prove the harness runs end to end against this corpus before spending
+# hours on the coarse grid. Run it on a single dataset first.
+#
+#   python spf/filters/run_filters_on_data.py \
+#     -d /mnt/qnap01/mouse9911/rovers_2026/merged/<one>.zarr \
+#     --empirical-pkl-fn empirical_dists/full.pkl \
+#     --work-dir /mnt/qnap01/mouse9911/rovers_2026/filter_runs/smoke \
+#     --config spf/filters/configs/rover2026_smoke.yaml \
+#     --results-backend local --parallel 24
+#
+# NOTE 3 of the 48 merged stores are RO4 at d/lambda = 0.90397, which has no
+# entry in empirical_dists/full.pkl. get_empirical_dist does an exact key
+# lookup, so every empirical (non-NN) filter raises KeyError on those. Either
+# run create_empirical_p_dist.py to add the spacing, or restrict the empirical
+# families to the 0.673 and 0.827 stores.
+precompute_caches:
+  3.7: "/mnt/qnap01/mouse9911/rovers_2026/precompute"
+
+runs:
+  - run_EKF_single_theta_single_radio:
+      phi_std: [10.0]
+      p: [5.0]
+      noise_std: [0.001]
+      dynamic_R: [0.0]
+      segmentation_version: [3.7]
+  - run_EKF_single_theta_dual_radio:
+      phi_std: [10.0]
+      p: [5.0]
+      noise_std: [0.001]
+      dynamic_R: [0.0]
+      segmentation_version: [3.7]
+  - run_PF_single_theta_single_radio:
+      N: [128 * 32]
+      theta_err: [0.01]
+      theta_dot_err: [0.01]
+      segmentation_version: [3.7]
+  - run_PF_single_theta_dual_radio:
+      N: [128 * 32]
+      theta_err: [0.01]
+      theta_dot_err: [0.01]
+      segmentation_version: [3.7]
+  - run_PF_xy_dual_radio:
+      N: [128 * 8]
+      pos_err: [15]
+      vel_err: [0.5]
+      segmentation_version: [3.7]
+  - run_PF_single_theta_single_radio_NN:
+      checkpoint_fn_and_segmentation_version:
+        - checkpoint_fn: "/mnt/md0/checkpoints/jun26_2026/paired_3p7_thin_noblade/best.pth"
+          segmentation_version: 3.7
+      inference_cache: ["/mnt/qnap01/mouse9911/rovers_2026/inference_cache"]
+      N: [128 * 32]
+      theta_err: [0.01]
+      theta_dot_err: [0.01]
+  - run_PF_single_theta_dual_radio_NN:
+      checkpoint_fn_and_segmentation_version:
+        - checkpoint_fn: "/mnt/md0/checkpoints/jun26_2026/paired_3p7_thin_noblade/best.pth"
+          segmentation_version: 3.7
+      inference_cache: ["/mnt/qnap01/mouse9911/rovers_2026/inference_cache"]
+      N: [128 * 32]
+      theta_err: [0.01]
+      theta_dot_err: [0.01]
+      # absolute=True scores against a DIFFERENT ground truth (north-referenced
+      # rather than craft-relative). The report keeps them in separate frames;
+      # never read the two side by side as a like-for-like comparison.
+      absolute: [True, False]

--- a/spf/filters/plot_filter_run.py
+++ b/spf/filters/plot_filter_run.py
@@ -1,0 +1,426 @@
+"""Visualise one filter run: observations, prediction, confidence, calibration.
+
+The per-filter ``plot_*`` helpers scattered through ``spf/filters/*.py`` each
+build their own filter with hard-coded hyperparameters and each draw a different
+set of panels, so two filters cannot be put side by side. This runs a filter
+under the hyperparameters you actually swept and draws the same panels for every
+family, scoring through ``spf.evaluation`` so the numbers match the report.
+
+Panels:
+
+1. measured phi vs ground-truth phi per radio, with dropped (NaN) frames marked
+2. the theta track with a +-1 sigma band, against ground truth
+3. absolute error over time and the running RMSE
+4. calibration -- z-score histogram against a unit normal, plus measured
+   +-1/2/3 sigma coverage against nominal
+5. for NN filters, the model posterior over theta as a heat map, with ground
+   truth and the filter track drawn on top
+
+Panel 4 is the point. A filter reporting a variance nobody has checked is
+reporting decoration: pointed at the NN dual-radio PF on a rover capture, the
++-1 sigma band covered 25.6% of errors where 68.3% is nominal.
+
+Example::
+
+    python spf/filters/plot_filter_run.py \\
+        --dataset /mnt/qnap01/mouse9911/rovers_2026/merged/<prefix>.zarr \\
+        --precompute-cache /mnt/qnap01/mouse9911/rovers_2026/precompute \\
+        --empirical-pkl-fn empirical_dists/full.pkl \\
+        --segmentation-version 3.7 \\
+        --filter pf_dual_nn --params '{"N": 4096, "theta_err": 0.01}' \\
+        --checkpoint-fn <ckpt>/best.pth --inference-cache <cache> \\
+        --output-dir /tmp/filter_plots
+"""
+
+import argparse
+import json
+import logging
+import os
+
+import numpy as np
+import torch
+
+from spf.dataset.spf_dataset import v5spfdataset
+from spf.dataset.spf_nn_dataset_wrapper import v5spfdataset_nn_wrapper
+from spf.evaluation import calibration, metrics
+from spf.evaluation.frames import ABSOLUTE_NORTH, CRAFT_RELATIVE, RADIO_FOLDED
+from spf.filters.ekf_dualradio_filter import SPFPairedKalmanFilter
+from spf.filters.ekf_single_radio_filter import SPFKalmanFilter
+from spf.filters.particle_dual_radio_nn_filter import PFSingleThetaDualRadioNN
+from spf.filters.particle_dualradio_filter import PFSingleThetaDualRadio
+from spf.filters.particle_single_radio_filter import PFSingleThetaSingleRadio
+from spf.filters.particle_single_radio_nn_filter import PFSingleThetaSingleRadioNN
+from spf.rf import reduce_theta_to_positive_y
+
+FILTERS = [
+    "ekf_single",
+    "ekf_dual",
+    "pf_single",
+    "pf_dual",
+    "pf_single_nn",
+    "pf_dual_nn",
+]
+
+# The filters never read these; loading them costs minutes of IO per dataset.
+FILTER_SKIP_FIELDS = set(
+    [
+        "windowed_beamformer",
+        "weighted_beamformer",
+        "all_windows_stats",
+        "downsampled_segmentation_mask",
+        "signal_matrix",
+        "simple_segmentations",
+    ]
+)
+
+
+def open_dataset(
+    prefix, precompute_cache, empirical_pkl_fn, segmentation_version, nthetas=65
+):
+    return v5spfdataset(
+        prefix=str(prefix).replace(".zarr", ""),
+        nthetas=nthetas,
+        ignore_qc=True,
+        precompute_cache=precompute_cache,
+        paired=True,
+        snapshots_per_session=1,
+        readahead=False,
+        skip_fields=FILTER_SKIP_FIELDS,
+        empirical_data_fn=empirical_pkl_fn,
+        segmentation_version=segmentation_version,
+        segment_if_not_exist=False,
+        gpu=False,
+    )
+
+
+def _scalars(values):
+    return np.asarray([float(np.asarray(v).reshape(-1)[0]) for v in values])
+
+
+def _nn_posterior(nn_ds, key, rx_idx):
+    """(timesteps, ntheta) model posterior, or None when running realtime."""
+    cached = getattr(nn_ds, "cached_model_inference", None)
+    if cached is None or key not in cached:
+        return None
+    return np.asarray(cached[key])[:, rx_idx, 0, :]
+
+
+def run_filter(ds, filter_name, params, checkpoint_fn=None, inference_cache=None):
+    """Run one filter; return (theta, sigma, ground_truth, extras).
+
+    All three arrays are in the SAME angular frame, named in ``extras["frame"]``.
+    """
+    params = dict(params)
+    rx_idx = int(params.pop("rx_idx", 0))
+    seed = int(params.pop("seed", 0))
+    extras = {"rx_idx": rx_idx, "seed": seed}
+
+    pf_kwargs = None
+    if filter_name.startswith("pf_"):
+        pf_kwargs = dict(
+            mean=torch.tensor([[0.0, 0.0]]),
+            std=torch.tensor([[20.0, 0.1]]),
+            noise_std=torch.tensor(
+                [[params.pop("theta_err", 0.01), params.pop("theta_dot_err", 0.001)]]
+            ),
+            N=int(params.pop("N", 128 * 32)),
+            return_particles=False,
+            seed=seed,
+        )
+
+    if filter_name == "pf_single":
+        pf = PFSingleThetaSingleRadio(ds=ds, rx_idx=rx_idx)
+        traj = pf.trajectory(**pf_kwargs)
+        theta, sigma = _scalars([x["theta"] for x in traj]), np.sqrt(
+            _scalars([x["P_theta"] for x in traj])
+        )
+        gt = reduce_theta_to_positive_y(ds.ground_truth_thetas[rx_idx]).numpy()
+        extras["frame"] = RADIO_FOLDED
+    elif filter_name == "pf_single_nn":
+        pf = PFSingleThetaSingleRadioNN(
+            ds,
+            rx_idx,
+            checkpoint_fn,
+            f"{os.path.dirname(checkpoint_fn)}/config.yml",
+            inference_cache=inference_cache,
+            device="cpu",
+        )
+        traj = pf.trajectory(**pf_kwargs)
+        theta, sigma = _scalars([x["theta"] for x in traj]), np.sqrt(
+            _scalars([x["P_theta"] for x in traj])
+        )
+        gt = reduce_theta_to_positive_y(ds.ground_truth_thetas[rx_idx]).numpy()
+        extras["frame"] = RADIO_FOLDED
+        extras["posterior"] = _nn_posterior(pf.ds, "single", rx_idx)
+    elif filter_name == "pf_dual":
+        pf = PFSingleThetaDualRadio(ds=ds)
+        traj = pf.trajectory(**pf_kwargs)
+        theta, sigma = _scalars([x["craft_theta"] for x in traj]), np.sqrt(
+            _scalars([x["P_theta"] for x in traj])
+        )
+        gt = ds.craft_ground_truth_thetas.numpy()
+        extras["frame"] = CRAFT_RELATIVE
+    elif filter_name == "pf_dual_nn":
+        absolute = bool(params.pop("absolute", False))
+        nn_ds = v5spfdataset_nn_wrapper(
+            ds,
+            f"{os.path.dirname(checkpoint_fn)}/config.yml",
+            checkpoint_fn,
+            inference_cache,
+            device="cpu",
+            absolute=absolute,
+        )
+        pf = PFSingleThetaDualRadioNN(nn_ds=nn_ds)
+        traj = pf.trajectory(**pf_kwargs)
+        theta, sigma = _scalars([x["craft_theta"] for x in traj]), np.sqrt(
+            _scalars([x["P_theta"] for x in traj])
+        )
+        if absolute:
+            # matches PFSingleThetaDualRadioNN.metrics: circular mean over radios
+            gt = torch.atan2(
+                torch.sin(ds.absolute_thetas).mean(axis=0),
+                torch.cos(ds.absolute_thetas).mean(axis=0),
+            ).numpy()
+            extras["frame"] = ABSOLUTE_NORTH
+        else:
+            gt = ds.craft_ground_truth_thetas.numpy()
+            extras["frame"] = CRAFT_RELATIVE
+        extras["posterior"] = _nn_posterior(nn_ds, "paired", 0)
+    elif filter_name == "ekf_dual":
+        ekf = SPFPairedKalmanFilter(
+            ds=ds,
+            phi_std=params.pop("phi_std", 10.0),
+            p=params.pop("p", 5.0),
+            dynamic_R=params.pop("dynamic_R", 0.0),
+        )
+        # debug=True is what populates P_theta; without it the EKF reports no sigma
+        traj = ekf.trajectory(
+            dt=1.0, noise_std=params.pop("noise_std", 0.001), debug=True
+        )
+        theta, sigma = _scalars([x["craft_theta"] for x in traj]), np.sqrt(
+            _scalars([x["P_theta"] for x in traj])
+        )
+        gt = ds.craft_ground_truth_thetas.numpy()
+        extras["frame"] = CRAFT_RELATIVE
+    elif filter_name == "ekf_single":
+        ekf = SPFKalmanFilter(
+            ds=ds,
+            rx_idx=rx_idx,
+            phi_std=params.pop("phi_std", 10.0),
+            p=params.pop("p", 5.0),
+            dynamic_R=params.pop("dynamic_R", 0.0),
+        )
+        traj = ekf.trajectory(
+            dt=1.0, noise_std=params.pop("noise_std", 0.001), debug=True
+        )
+        theta, sigma = _scalars([x["theta"] for x in traj]), np.sqrt(
+            _scalars([x["P_theta"] for x in traj])
+        )
+        gt = reduce_theta_to_positive_y(ds.ground_truth_thetas[rx_idx]).numpy()
+        extras["frame"] = RADIO_FOLDED
+    else:
+        raise ValueError(f"unknown filter {filter_name!r}; expected one of {FILTERS}")
+
+    if params:
+        raise ValueError(f"unused params for {filter_name}: {sorted(params)}")
+
+    gt = np.asarray(gt).reshape(-1)[: theta.shape[0]]
+    return theta, sigma, gt, extras
+
+
+def summarize_run(theta, sigma, gt):
+    """The numbers printed alongside the figure, from spf.evaluation."""
+    out = metrics.summarize(theta, gt)
+    out["coverage"] = calibration.coverage(theta, gt, sigma)
+    out["calibration_ratio"] = calibration.calibration_ratio(theta, gt, sigma)
+    return out
+
+
+def plot_filter_run(ds, theta, sigma, gt, extras, title):
+    from matplotlib import pyplot as plt
+
+    posterior = extras.get("posterior")
+    nrows = 5 if posterior is not None else 4
+    fig, ax = plt.subplots(nrows, 1, figsize=(13, 3.1 * nrows))
+    n = theta.shape[0]
+    t = np.arange(n)
+
+    # ---- observations
+    colors = ["tab:blue", "tab:orange"]
+    for ridx in (0, 1):
+        mp = ds.mean_phase[f"r{ridx}"][:n].numpy()
+        ax[0].scatter(
+            t[: mp.shape[0]],
+            mp,
+            s=2.0,
+            alpha=0.45,
+            color=colors[ridx],
+            label=f"r{ridx} measured phi",
+        )
+        ax[0].plot(
+            ds.ground_truth_phis[ridx][:n].numpy(),
+            color=colors[ridx],
+            ls="dashed",
+            lw=1.0,
+            label=f"r{ridx} ground-truth phi",
+        )
+        nan_frac = float(np.isnan(mp).mean())
+        for x in t[: mp.shape[0]][np.isnan(mp)]:
+            ax[0].axvline(x, color=colors[ridx], alpha=0.05, lw=0.5)
+        ax[0].plot([], [], " ", label=f"r{ridx} dropped frames: {nan_frac:.1%}")
+    ax[0].set_ylabel("phi (rad)")
+    ax[0].set_title("Observations: phase difference per radio (bands = no segment)")
+    # phi fills [-pi, pi], so a legend inside the axes covers real data. Add
+    # headroom above and put it there.
+    ax[0].set_ylim(-3.4, 5.2)
+    ax[0].legend(fontsize=7, ncol=3, loc="upper center", framealpha=0.9)
+
+    # ---- track + confidence
+    ax[1].axhline(np.pi / 2, ls=":", c=(0.7, 0.7, 0.7))
+    ax[1].axhline(-np.pi / 2, ls=":", c=(0.7, 0.7, 0.7))
+    ax[1].plot(gt, color="black", lw=1.2, label="ground truth")
+    ax[1].fill_between(
+        t, theta - sigma, theta + sigma, color="tab:red", alpha=0.22, label="+-1 sigma"
+    )
+    ax[1].scatter(t, theta, s=3.0, color="tab:red", label="filter estimate")
+    ax[1].set_ylabel("theta (rad)")
+    ax[1].set_title(f"Estimate and confidence -- frame: {extras['frame']}")
+    ax[1].legend(fontsize=8, ncol=3)
+
+    # ---- error
+    err = metrics.angular_error(theta, gt)
+    final_rmse = float(np.sqrt((err**2).mean()))
+    ax[2].plot(np.abs(err), lw=0.8, color="tab:purple", label="|error|")
+    ax[2].plot(
+        np.sqrt(np.cumsum(err**2) / (np.arange(err.shape[0]) + 1)),
+        lw=1.6,
+        color="black",
+        label="running RMSE",
+    )
+    ax[2].axhline(
+        final_rmse,
+        ls="dashed",
+        color="tab:green",
+        label=f"final RMSE {final_rmse:.3f} rad ({np.degrees(final_rmse):.1f} deg)",
+    )
+    ax[2].set_ylabel("|error| (rad)")
+    ax[2].set_xlabel("sample index (time)")
+    ax[2].set_title(f"Error -- MSE {float((err ** 2).mean()):.4f} rad^2")
+    ax[2].legend(fontsize=8, ncol=3)
+
+    # ---- calibration
+    z = calibration.z_scores(theta, gt, sigma)
+    if z.size:
+        ax[3].hist(
+            np.clip(z, -6, 6),
+            bins=61,
+            density=True,
+            alpha=0.7,
+            color="tab:blue",
+            label="z = error / sigma (clipped to +-6)",
+        )
+        grid = np.linspace(-6, 6, 400)
+        ax[3].plot(
+            grid,
+            np.exp(-(grid**2) / 2) / np.sqrt(2 * np.pi),
+            color="black",
+            label="unit normal (perfect calibration)",
+        )
+        # 3 decimals: nominal 3-sigma is 0.9973 and rounds to "1.00" at 2,
+        # which reads as though the band is expected to hold everything
+        cov = "  ".join(
+            f"{r['k']}s: {r['measured']:.3f} (nom {r['nominal']:.3f})"
+            for r in calibration.coverage(theta, gt, sigma)
+        )
+        ratio = calibration.calibration_ratio(theta, gt, sigma)
+        ax[3].set_title(f"Calibration -- std(z)={ratio:.2f}   coverage {cov}")
+    else:
+        ax[3].set_title("Calibration -- this filter reported no usable sigma")
+    ax[3].set_xlabel("z-score")
+    ax[3].legend(fontsize=8)
+
+    # ---- posterior heat map
+    if posterior is not None:
+        post = np.asarray(posterior)[:n]
+        ax[4].imshow(
+            post.T,
+            aspect="auto",
+            origin="lower",
+            extent=[0, n, -np.pi, np.pi],
+            cmap="viridis",
+        )
+        ax[4].plot(gt, color="white", lw=1.2, label="ground truth")
+        ax[4].scatter(t, theta, s=2.0, color="red", label="filter estimate")
+        ax[4].set_ylabel("theta (rad)")
+        ax[4].set_xlabel("sample index (time)")
+        ax[4].set_title(f"Network posterior over theta ({post.shape[-1]} bins)")
+        ax[4].legend(fontsize=8, loc="upper right")
+
+    fig.suptitle(title, fontsize=11)
+    fig.tight_layout(rect=[0, 0, 1, 0.985])
+    return fig
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", type=str, required=True, help="zarr prefix")
+    parser.add_argument("--precompute-cache", type=str, required=True)
+    parser.add_argument("--empirical-pkl-fn", type=str, required=True)
+    parser.add_argument("--segmentation-version", type=float, default=3.7)
+    parser.add_argument("--nthetas", type=int, default=65)
+    parser.add_argument("--filter", type=str, required=True, choices=FILTERS)
+    parser.add_argument(
+        "--params",
+        type=str,
+        default="{}",
+        help='JSON hyperparameters, e.g. \'{"N": 4096, "theta_err": 0.01}\'',
+    )
+    parser.add_argument("--checkpoint-fn", type=str, default=None)
+    parser.add_argument("--inference-cache", type=str, default=None)
+    parser.add_argument("--output-dir", type=str, required=True)
+    return parser
+
+
+if __name__ == "__main__":
+    import matplotlib
+
+    matplotlib.use("Agg")
+    from matplotlib import pyplot as plt
+
+    logging.basicConfig(
+        format="%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s",
+        level=os.environ.get("LOGLEVEL", "INFO").upper(),
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    args = get_parser().parse_args()
+    params = json.loads(args.params)
+
+    ds = open_dataset(
+        args.dataset,
+        args.precompute_cache,
+        args.empirical_pkl_fn,
+        args.segmentation_version,
+        nthetas=args.nthetas,
+    )
+    theta, sigma, gt, extras = run_filter(
+        ds,
+        args.filter,
+        params,
+        checkpoint_fn=args.checkpoint_fn,
+        inference_cache=args.inference_cache,
+    )
+    basename = os.path.basename(str(args.dataset)).replace(".zarr", "")
+    fig = plot_filter_run(
+        ds,
+        theta,
+        sigma,
+        gt,
+        extras,
+        f"{args.filter}  {json.dumps(params, sort_keys=True)}\n{basename}",
+    )
+    os.makedirs(args.output_dir, exist_ok=True)
+    out_fn = os.path.join(args.output_dir, f"{basename}__{args.filter}.png")
+    fig.savefig(out_fn, dpi=110)
+    plt.close(fig)
+    logging.info(f"wrote {out_fn}")
+    print(json.dumps(summarize_run(theta, sigma, gt), indent=2, default=str))

--- a/spf/filters/reports/README.md
+++ b/spf/filters/reports/README.md
@@ -1,0 +1,40 @@
+# Filter sweep reports
+
+Small, reviewable outputs from `spf/filters/report.py`. Follows the append-only
+convention already used by `spf/calibrations/*/reports/`: one directory per run,
+named `<name>_<YYYYMMDD>_v1`, never edited once written — a re-run gets a new
+directory.
+
+Each directory holds:
+
+| File | Contents |
+|---|---|
+| `REPORT.md` | per-frame leaderboard, the reviewable summary |
+| `results.json` | every aggregated row, machine-readable |
+| `inputs_manifest.json` | dataset list, config, checkpoint + config md5s, git commit |
+
+## Why not CSV
+
+`.gitignore` matches `**/*.csv` repo-wide (only the JLC fab files are excepted),
+so `run_filters_report.py`'s CSV output can never be committed. That is the
+reason `report.py` exists and writes JSON + Markdown instead.
+
+Bulk output — the per-job `results.pkl` under the work dir, per-dataset PNGs —
+stays out of git entirely. Put it on qnap01. Note `.gitignore` already reserves
+`**/filter_reports` and `**/run_on_filters_results`, so those names are
+always ignored if you reach for them.
+
+## Reading a report
+
+Rows are grouped by every non-metric field **and by angular frame**, and each
+frame gets its own table. A `craft_relative` row and an `absolute_north` row of
+the same hyperparameters are answers to different questions — see
+`spf/evaluation/frames.py`. Never rank across the two.
+
+`n_runs` is the denominator behind every averaged number on a row. A row with
+`n_runs = 1` on a particle filter is one draw from a distribution whose
+per-dataset spread was measured at 42–106% of the mean; treat it accordingly.
+
+## Index
+
+_(none yet — the first sweep lands here)_

--- a/tests/test_plot_filter_run.py
+++ b/tests/test_plot_filter_run.py
@@ -1,0 +1,82 @@
+"""The unified filter visualiser.
+
+Smoke-level on purpose: assert the figure has the panels it claims and that the
+summary block is finite and frame-tagged. Pixel comparison would be brittle and
+would not catch anything a human reading the figure wouldn't.
+"""
+
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+
+from spf.evaluation.frames import CRAFT_RELATIVE, RADIO_FOLDED
+from spf.filters.plot_filter_run import (
+    open_dataset,
+    plot_filter_run,
+    run_filter,
+    summarize_run,
+)
+from spf.utils import SEGMENTATION_VERSION
+
+# empirical families only: the NN ones need a trained checkpoint fixture, which
+# costs ~11 minutes to build and exercises no plotting code the others don't.
+EMPIRICAL_FILTERS = [
+    ("pf_dual", {"N": 512, "theta_err": 0.01, "theta_dot_err": 0.01}, CRAFT_RELATIVE),
+    ("pf_single", {"N": 512, "theta_err": 0.01, "theta_dot_err": 0.01}, RADIO_FOLDED),
+    ("ekf_dual", {"phi_std": 10.0, "p": 5.0, "noise_std": 0.001}, CRAFT_RELATIVE),
+    ("ekf_single", {"phi_std": 10.0, "p": 5.0, "noise_std": 0.001}, RADIO_FOLDED),
+]
+
+
+@pytest.fixture(scope="module")
+def ds(noise1_n128_obits2):
+    dirname, empirical_pkl_fn, ds_fn = noise1_n128_obits2
+    # the fixture segments at the default version; track the constant rather
+    # than hardcode, so bumping SEGMENTATION_VERSION does not silently break this
+    return open_dataset(
+        ds_fn, dirname, empirical_pkl_fn, segmentation_version=SEGMENTATION_VERSION
+    )
+
+
+@pytest.mark.parametrize("name,params,expected_frame", EMPIRICAL_FILTERS)
+def test_each_family_produces_a_figure_and_a_summary(ds, name, params, expected_frame):
+    theta, sigma, gt, extras = run_filter(ds, name, dict(params))
+
+    assert extras["frame"] == expected_frame
+    assert theta.shape == sigma.shape == gt.shape
+    assert np.isfinite(theta).all()
+
+    fig = plot_filter_run(ds, theta, sigma, gt, extras, f"{name} test")
+    # 4 panels without a posterior, 5 with
+    assert len(fig.axes) == 4
+    matplotlib.pyplot.close(fig)
+
+    summary = summarize_run(theta, sigma, gt)
+    assert summary["n"] == theta.shape[0]
+    assert np.isfinite(summary["mse"]) and summary["mse"] >= 0
+    assert np.isclose(summary["rmse_deg"], np.degrees(summary["rmse_rad"]))
+    # coverage is REPORTED, not gated -- only that it is a well-formed fraction
+    for row in summary["coverage"]:
+        assert 0.0 <= row["measured"] <= 1.0
+        assert row["k"] in (1, 2, 3)
+
+
+def test_unknown_filter_name_is_rejected(ds):
+    with pytest.raises(ValueError, match="unknown filter"):
+        run_filter(ds, "kalman_deluxe", {})
+
+
+def test_unused_params_are_rejected_not_silently_ignored(ds):
+    """A typo'd hyperparameter must fail loudly, or a sweep silently runs defaults."""
+    with pytest.raises(ValueError, match="unused params"):
+        run_filter(ds, "pf_dual", {"N": 512, "theta_er": 0.01})
+
+
+def test_seed_is_honoured_end_to_end(ds):
+    a, _, _, _ = run_filter(ds, "pf_dual", {"N": 512, "seed": 0})
+    b, _, _, _ = run_filter(ds, "pf_dual", {"N": 512, "seed": 0})
+    c, _, _, _ = run_filter(ds, "pf_dual", {"N": 512, "seed": 1})
+    np.testing.assert_array_equal(a, b)
+    assert not np.array_equal(a, c)


### PR DESCRIPTION
Last of four. **Stacked on [#22](https://github.com/misko/spf/pull/22)**; base retargets automatically as the stack merges. Merge order: [#21](https://github.com/misko/spf/pull/21) → [#22](https://github.com/misko/spf/pull/22) → this.

## `plot_filter_run.py`

Replaces the per-filter `plot_*` helpers, which each built their own filter with hard-coded hyperparameters and each drew a different set of panels — so two filters could never be put side by side. One CLI, five panels, every family: observations, the θ track with a ±1σ band, error + running RMSE, calibration, and (NN only) the model posterior as a heat map with ground truth and the track overlaid. Scores through `spf.evaluation`, so a figure and the report agree by construction.

**Panel 4 is why it exists.** On the pilot rover capture the NN dual-radio PF's ±1σ band covers **26.7%** of errors against 68.3% nominal, `std(z) = 4.15`, and the z-score histogram piles mass at the ±6 clipping bins. That is not mild miscalibration — a substantial fraction of timesteps are many sigma off.

## `configs/`

Three grids, local paths only. The shipped `ekf_and_pf_config.yml` expands to **5,926 jobs per dataset** and points at `b2://`. At the measured 4.155 cpu-s per filter timestep and a parallel ceiling of 8.8× on this box, that is ~12 h for the rover corpus but **22 days** for the frozen val set and **87 days** for train — it was built for AWS Batch.

| config | jobs/dataset |
|---|---|
| `rover2026_smoke.yaml` | 8 |
| `rover2026_coarse.yaml` | 348 |
| `historical_coarse.yaml` | 348 |

The README records why one config can only ever cover one corpus: `precompute_caches` is a single global `segmentation_version -> path` map, and rover-2026 lives on qnap01 while the historical corpus lives on md2.

## `experiments/e_inf1_filter_sweep/`

H1–H4 pre-registered with decision rules **before** any sweep runs; `RESULTS.md` records the pilot numbers so the hypotheses can't be edited after seeing data.

It also records the blocking item: **3 of the 48 merged rover stores are RO4 at d/λ = 0.90397**, which has no entry in `empirical_dists/full.pkl`. `get_empirical_dist` is an exact-key lookup, so every empirical filter raises `KeyError` on them until `create_empirical_p_dist.py` is run for that spacing or those stores are excluded. Must be resolved before stage 2.

## Visual verification

Per CLAUDE.md, a real figure was rendered on rover data and inspected. It caught two defects, both fixed and re-rendered: the observations legend sat **on top of** the phase data (φ fills [-π, π], so there is no free space inside the axes), and the coverage line printed nominal 3σ (0.9973) as `1.00`, which reads as though the band should hold everything.

## Tests

7: one figure + summary block per empirical family, seed reproducibility end to end, and rejection of unknown filter names and typo'd hyperparameters — a silently-ignored typo would run defaults for a whole sweep. NN families are covered by `test_filter_sweep_smoke` instead; they need the trained-checkpoint fixture and exercise no plotting code the others don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)