### PR TITLE
filters: local sweep runner + visualiser, configs and E-INF1 design (re-target of #22 and #23)

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -32,6 +32,7 @@ append-only convention.
 | [e_gsp7_conditioned_comb](e_gsp7_conditioned_comb/experiment_readme.md) | Does a 10-LO comb *chosen by conditioning* calibrate, where E-CAL3's uniform 10-LO comb failed at 11.61°? | ✅ run 2026-08-07 — yes, but only if the delays are ALSO frozen: chosen-10 frozen 4.95° vs the E-CAL3 comb's 23.50°, same session, same coverage |
 | [e_lnk1_transport_sample_rate](e_lnk1_transport_sample_rate/experiment_readme.md) | How do direct-USB, libiio/USB, IIO-over-RNDIS and IIO-over-Ethernet compare across the sample-rate range on `.18` — in throughput, integrity, metadata and measured phase? | ✅ throughput run 2026-08-07 — Ethernet holds up **exactly** as well as USB and no better: both wall at ~23 MB/s (2.9 MS/s), so the limit is the radio, not the link. Ethernet's apparent 28% lead at production buffer size is a buffer-tuning artifact. Phase/CPU metrics not yet run |
 | [e_gsp2_pad_sweep](e_gsp2_pad_sweep/experiment_readme.md) | Is the frequency ripple actually a harness reflection? | needs parts |
+| [e_inf1_filter_sweep](e_inf1_filter_sweep/experiment_readme.md) | How do the current models plus the EKF/PF trackers perform on the 2026 rover corpus versus the frozen val set, and does the reported confidence mean anything? | designed 2026-08-08, tooling landed, not yet run; blocked on the d/λ = 0.904 empirical-table gap |
 
 Designs and decision rules for the wider programme are in
 [`docs/future_experiments.md`](../docs/future_experiments.md).

--- a/experiments/e_inf1_filter_sweep/RESULTS.md
+++ b/experiments/e_inf1_filter_sweep/RESULTS.md
@@ -1,0 +1,40 @@
+# E-INF1 — results
+
+**Status: NOT RUN.** Design and decision rules are pre-registered in
+[`experiment_readme.md`](experiment_readme.md); this file exists so the
+hypotheses cannot be edited after seeing the data.
+
+| Hypothesis | Prediction | Outcome |
+|---|---|---|
+| H1 | NN dual-radio PF beats empirical on the rover corpus | _pending_ |
+| H2 | best rover MSE ≥ 2× best frozen-val MSE | _pending_ |
+| H3 | median `std(z)` > 1.5 on every corpus (filters overconfident) | _pending_ |
+| H4 | MSE worse at d/λ = 0.904 than at 0.673 | _pending_ |
+
+## Blocking item
+
+3 of the 48 merged rover stores are RO4 at **d/λ = 0.90397**, which has no entry
+in `empirical_dists/full.pkl`. `get_empirical_dist` is an exact-key lookup, so
+every empirical (non-NN) filter raises `KeyError` on those. Resolve before stage
+2 — either run `create_empirical_p_dist.py` for that spacing, or restrict the
+empirical families to the 0.673 and 0.827 stores and say so here.
+
+## Pilot observations (single dataset, 2026-08-07)
+
+Not results — these motivated the experiment and are recorded so the stage-2
+numbers can be sanity-checked against something.
+
+On `rover_2026_08_01_19_31_21…RO3` (539 timesteps, d/λ = 0.827), one seed each:
+
+| filter | MSE (rad²) | frame |
+|---|---|---|
+| PF dual, NN, `absolute=True` | 0.32–0.76 across 8 seeds | absolute_north |
+| PF dual, NN, `absolute=False` | 1.86 | craft_relative |
+| PF dual, empirical | 1.63–2.44 across 8 seeds | craft_relative |
+| PF single, empirical (r0/r1) | 0.32 / 0.58 | radio_folded |
+| EKF dual | 2.57 | craft_relative |
+
+±1σ coverage for the NN dual PF was **25.6%** against 68.3% nominal.
+
+⚠️ The two NN rows are **not** comparable — different ground truth. And the
+per-seed spread (42% empirical, 106% NN) is why stage 2 runs 5 seeds.

--- a/experiments/e_inf1_filter_sweep/experiment_readme.md
+++ b/experiments/e_inf1_filter_sweep/experiment_readme.md
@@ -1,0 +1,137 @@
+# E-INF1 — how do our best models track, locally, across three corpora?
+
+**Status:** designed 2026-08-08, not yet run. Tooling landed in changes 1–4
+(`spf/filters/resample.py`, `spf/evaluation/`, `spf/filters/report.py`,
+`spf/filters/plot_filter_run.py`, `spf/filters/configs/`).
+**Results:** [`RESULTS.md`](RESULTS.md) _(written when it runs)_
+**Est. compute:** ~8 h wall on the 24-core box. **No cloud.**
+
+This is a computational experiment, so the `experiments/README.md` "hardware
+setup" section does not apply — there is no bench, no radio, no schematic. The
+inputs are recorded datasets and trained checkpoints, all read-only.
+
+---
+
+## 1. Purpose
+
+We have never measured how the current models plus the EKF/PF trackers perform
+on the **2026 rover corpus**, and the historical numbers we do have came from a
+sweep that was (a) run on cloud infrastructure we are no longer using and (b)
+built on a particle filter whose results were not reproducible.
+
+Three things are unknown:
+
+1. **Which filter family and hyperparameters actually win**, per corpus, now
+   that runs are seeded and repeatable.
+2. **How far the 2026 rover data is out of distribution.** Its arrays run at
+   d/λ = 0.673 / 0.827 / 0.904 — all past the λ/2 unambiguous limit, so the
+   arrays are spatially aliased. The models take d/λ as an input, but whether
+   they extrapolate there is untested.
+3. **Whether the reported confidence means anything.** A single pilot run put
+   ±1σ coverage at 25.6% against 68.3% nominal. If that holds across the sweep,
+   nothing downstream can gate on filter variance.
+
+## 2. Hypotheses (pre-registered)
+
+- **H1 — NN beats empirical on rover.** The NN dual-radio PF has lower craft-relative
+  MSE than the empirical dual-radio PF on the rover corpus, because the empirical
+  `P(θ|φ)` table was built from wall-array data at different spacings.
+- **H2 — the rover corpus is materially harder.** Best-config craft-relative MSE
+  on rover is at least 2× the best on the frozen val set.
+- **H3 — filters are overconfident everywhere, not just in the pilot.** Median
+  `std(z)` across the best 10 configs is > 1.5 on every corpus.
+- **H4 — the aliased spacings are the problem.** Within the rover corpus, MSE is
+  worse at d/λ = 0.904 than at 0.673, for the same filter and hyperparameters.
+
+## 3. Approach
+
+Four stages. Each is a gate: do not start the next until the previous passes.
+
+| Stage | What | Cost |
+|---|---|---|
+| 0 | segment the rover corpus at v3.7 (`segment_zarr.py`, **unchanged**) | ~2 h GPU, ~1.3 GB |
+| 1 | build inference caches on **GPU** (`create_inference_cache.py --device cuda`) | rover 160 s; val 2.1 h |
+| 2 | coarse grid (348 configs) on a **stratified 16-dataset sample** per corpus, **5 seeds** | ~1.3 h wall per corpus |
+| 3 | top ~4 configs per family on the **full** corpora, 1 seed | ~1 h val, ~15 min rover |
+
+Stage 2 uses seeds because a 16-dataset average only cuts the 42–106% per-dataset
+PF spread by √16 = 4×. Stage 3 does not, because 565 datasets cut it by √565 ≈ 24×,
+leaving ~1.7% residual — below any effect worth acting on.
+
+**Stratification for the sample:** by (routine × d/λ × capture day) for rover, and
+by (vehicle × routine × band × d/λ) for the frozen val set. The sample list is
+written to the report directory so the stage-2 result is reproducible.
+
+### Controls
+
+- **Seeded runs.** Since change 1, `seed` fully determines a PF run; the sweep
+  records it.
+- **Frames never pooled.** `absolute=True` and `absolute=False` are scored against
+  different ground truth and are kept in separate frames end to end.
+- **Posterior scored separately from the tracker.** `spf/evaluation/posterior.py`
+  scores the network's `P(θ)` with no filter, so H1/H2 can be attributed to the
+  model or to the tracker rather than confounded.
+- **The frozen val set is untouched.** It is read-only; no new val view is created.
+
+## 4. Software setup
+
+```bash
+# stage 0 -- segmentation code is NOT modified; it is used as-is
+python spf/scripts/segment_zarr.py -i <merged>.zarr \
+    -c /mnt/qnap01/mouse9911/rovers_2026/precompute --gpu --workers 2
+
+# stage 1 -- GPU, batch >= 64. CPU at batch 16 is 42x slower (13 vs 543 sess/s)
+python spf/scripts/create_inference_cache.py --device cuda --parallel 2 \
+    --config-fn <ckpt>/config.yml --checkpoint-fn <ckpt>/best.pth \
+    --inference-cache /mnt/qnap01/.../inference_cache \
+    --precompute-cache <precompute> --segmentation-version 3.7 -d <datasets>
+
+# stage 2/3 -- 24 workers, not 30: throughput peaks at 24 and regresses at 30
+python spf/filters/run_filters_on_data.py -d <datasets> \
+    --empirical-pkl-fn empirical_dists/full.pkl \
+    --work-dir /mnt/qnap01/.../filter_runs/<stage> \
+    --config spf/filters/configs/<corpus>_coarse.yaml \
+    --results-backend local --parallel 24
+
+python spf/filters/report.py --work-dir <workdir> \
+    --output-dir spf/filters/reports/e_inf1_<corpus>_<date>_v1
+```
+
+Model: `/mnt/md0/checkpoints/jun26_2026/paired_3p7_thin_noblade/best.pth`
+(the newest paired checkpoint, 2026-07-04). Environment:
+`~/virtual-envs/spf/bin/python3`.
+
+## 5. Outputs and acceptance gates
+
+| Artifact | Location | Gate |
+|---|---|---|
+| rover precompute | `rovers_2026/precompute/` | all 48 stores segment without error |
+| inference caches | `rovers_2026/inference_cache/` | one `.npz` per dataset per model |
+| stage-2 reports | `spf/filters/reports/e_inf1_<corpus>_coarse_<date>_v1/` | every config has `n_runs = 5` |
+| stage-3 reports | `spf/filters/reports/e_inf1_<corpus>_full_<date>_v1/` | `n_runs` equals the corpus size |
+| per-dataset figures | qnap01 (gitignored) | ≥1 figure per corpus visually checked per CLAUDE.md |
+| `RESULTS.md` | this directory | states H1–H4 outcomes with numbers |
+
+## 6. Decision rules (pre-registered)
+
+- **H1** — if NN craft-relative MSE is not below empirical on rover, the NN
+  advantage does not survive the domain shift and retraining with 2026 rover data
+  becomes the priority over further filter tuning.
+- **H2** — if rover MSE is within 2× of val, the 2026 corpus is usable as-is for
+  evaluation. If it is far worse, diagnose with the posterior scores first
+  (stage 3 emits them): a bad posterior means the model, a good posterior with a
+  bad track means the tracker.
+- **H3** — if `std(z) > 1.5` holds, **no downstream component may gate on filter
+  variance** until the cause is found, and that becomes its own work item.
+- **H4** — if d/λ = 0.904 is materially worse, the RO4 rovers need re-spacing
+  before further capture, and the 3 affected stores are excluded from training.
+
+## 7. Risks
+
+| Risk | Catch |
+|---|---|
+| 3 RO4 stores at d/λ = 0.904 have no empirical-table entry → `KeyError` in every empirical filter | known; either run `create_empirical_p_dist.py` for that spacing or restrict the empirical families. **Resolve before stage 2.** |
+| The O4 emitter is bursty (60–70% NaN is healthy) so mean-over-all-frames metrics measure the silence | report `median_abs_err` alongside the mean; both are in `metrics.summarize` |
+| Stage 2 sample is unrepresentative | stratify, and record the sample list in the report |
+| Another session is using the box | timings are not a gate here; only stage-2/3 wall clock is affected |
+| Filenames are unreliable for ordering/attribution (19 captures carry a restored-clock timestamp) | group by `routine` and `gps_timestamp`, never by filename — `spf/filters/labels.py` already prefers the recorded routine |

--- a/spf/filters/configs/README.md
+++ b/spf/filters/configs/README.md
@@ -1,0 +1,34 @@
+# Filter sweep configs
+
+Grids for `spf/filters/run_filters_on_data.py`. All paths are **local** — no
+`b2://`, no DynamoDB.
+
+## One config per corpus, and why
+
+`precompute_caches` is a single global `segmentation_version -> path` map, so a
+config can only ever describe **one** corpus. The rover-2026 precompute lives on
+qnap01; the historical wall/rover corpus lives on md2. Hence `rover2026_*.yaml`
+and `historical_*.yaml` rather than one file with both.
+
+## The two stages
+
+| File | Datasets | Configs | Purpose |
+|---|---|---|---|
+| `*_smoke.yaml` | 1 | ~8 | prove the harness runs against a corpus before spending hours |
+| `*_coarse.yaml` | ~16 stratified | ~500 | find the region of good hyperparameters, **5 seeds each** |
+
+The shipped `spf/model_training_and_inference/models/ekf_and_pf_config.yml`
+expands to **5,926 jobs per dataset**. At the measured 4.155 cpu-s per filter
+timestep and a parallel ceiling of 8.8x on this box, that is ~12 h for the rover
+corpus but **22 days** for the frozen val set and **87 days** for train. It was
+designed for AWS Batch. Locally the grid has to be cut, which is what these
+configs do.
+
+## Seeds
+
+Particle filters are stochastic. Since `spf/filters/resample.py` they are
+reproducible from `seed`, but different seeds still give different answers — the
+per-dataset spread was measured at 42% (empirical dual-radio) and 106% (NN
+dual-radio) of mean MSE. Averaging over a 16-dataset sample cuts that by only
+sqrt(16) = 4x, so the coarse stage runs **5 seeds per config**. On a full corpus
+(565 datasets, sqrt = 24x) one seed is enough.

--- a/spf/filters/configs/historical_coarse.yaml
+++ b/spf/filters/configs/historical_coarse.yaml
@@ -1,0 +1,69 @@
+# Historical corpus (frozen val / train) -- coarse hyperparameter grid.
+#
+# Same grid as rover2026_coarse.yaml against the md2 precompute. Run it on a
+# STRATIFIED SAMPLE of ~16 datasets from the frozen val list, never the whole
+# corpus: at a measured 4.155 cpu-s per filter timestep and ~4.14M timesteps in
+# the frozen val set, even this reduced grid over all 565 datasets is days.
+#
+# The precompute cache on md2 is READ-ONLY -- it holds 4.3 TB of unregenerable
+# 3.4/3.5/3.6 caches. New outputs (work dirs, inference caches) go to qnap01.
+#
+# The frozen val list is /mnt/md2/splits/apr17_val_nosig_noroverbounce.txt
+# (565 datasets, 556 with 3.7 precompute).
+precompute_caches:
+  3.7: "/mnt/md2/cache/precompute_cache_3p7"
+
+runs:
+  # --- EKF: cheap (0.02-0.04 s/run), so it can afford a wider grid
+  - run_EKF_single_theta_dual_radio:
+      phi_std: [20.0, 10.0, 5.0, 2.5, 1.0]
+      p: [5.0, 1.0, 0.1]
+      noise_std: [0.01, 0.001, 0.0001, 0.00001]
+      dynamic_R: [0.0]
+      segmentation_version: [3.7]
+  - run_EKF_single_theta_dual_radio:
+      phi_std: [0.0]
+      p: [5.0, 1.0, 0.1]
+      noise_std: [0.01, 0.001, 0.0001, 0.00001]
+      dynamic_R: [1.0, 0.1]
+      segmentation_version: [3.7]
+  - run_EKF_single_theta_single_radio:
+      phi_std: [20.0, 10.0, 5.0, 1.0]
+      p: [5.0, 1.0]
+      noise_std: [0.01, 0.001, 0.0001]
+      dynamic_R: [0.0]
+      segmentation_version: [3.7]
+
+  # --- PF: ~0.7 ms per timestep per run at N=8192 and linear in N, so the grid
+  # is deliberately coarse in N. Log-spaced errs: the shipped grid's 12x13 mesh
+  # resolves far finer than the seed-to-seed spread justifies.
+  - run_PF_single_theta_dual_radio:
+      N: [128 * 8, 128 * 32, 128 * 128]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.005, 0.02, 0.1]
+      segmentation_version: [3.7]
+  - run_PF_single_theta_single_radio:
+      N: [128 * 8, 128 * 32]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.01, 0.1]
+      segmentation_version: [3.7]
+
+  # --- NN PF: the family with the most to gain, and the noisiest (106%
+  # seed-to-seed spread), so keep the grid tight and lean on repeats instead.
+  - run_PF_single_theta_dual_radio_NN:
+      checkpoint_fn_and_segmentation_version:
+        - checkpoint_fn: "/mnt/md0/checkpoints/jun26_2026/paired_3p7_thin_noblade/best.pth"
+          segmentation_version: 3.7
+      inference_cache: ["/mnt/qnap01/mouse9911/inference_cache_3p7"]
+      N: [128 * 8, 128 * 32, 128 * 128]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.005, 0.02, 0.1]
+      absolute: [True, False]
+  - run_PF_single_theta_single_radio_NN:
+      checkpoint_fn_and_segmentation_version:
+        - checkpoint_fn: "/mnt/md0/checkpoints/jun26_2026/paired_3p7_thin_noblade/best.pth"
+          segmentation_version: 3.7
+      inference_cache: ["/mnt/qnap01/mouse9911/inference_cache_3p7"]
+      N: [128 * 8, 128 * 32]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.01, 0.1]

--- a/spf/filters/configs/rover2026_coarse.yaml
+++ b/spf/filters/configs/rover2026_coarse.yaml
@@ -1,0 +1,74 @@
+# Rover 2026 merged v7 -- coarse hyperparameter grid for the tuning stage.
+#
+# ~500 jobs per dataset against the shipped grid's 5,926. Run it on a STRATIFIED
+# SAMPLE of ~16 stores (by routine x d/lambda x day), not the whole corpus: the
+# point of this stage is to find the region of good hyperparameters, and the
+# winners then get evaluated on everything.
+#
+#   python spf/filters/run_filters_on_data.py \
+#     -d $(cat sample16.txt) \
+#     --empirical-pkl-fn empirical_dists/full.pkl \
+#     --work-dir /mnt/qnap01/mouse9911/rovers_2026/filter_runs/coarse \
+#     --config spf/filters/configs/rover2026_coarse.yaml \
+#     --results-backend local --parallel 24
+#
+# Parallelism: 24, not the old default of 30. Measured throughput on this box
+# peaks at 24 workers (8.8x) and REGRESSES at 30 (7.9x) as work spills onto
+# E-cores -- total CPU for the same work rises from 51.7 s to 139 s.
+precompute_caches:
+  3.7: "/mnt/qnap01/mouse9911/rovers_2026/precompute"
+
+runs:
+  # --- EKF: cheap (0.02-0.04 s/run), so it can afford a wider grid
+  - run_EKF_single_theta_dual_radio:
+      phi_std: [20.0, 10.0, 5.0, 2.5, 1.0]
+      p: [5.0, 1.0, 0.1]
+      noise_std: [0.01, 0.001, 0.0001, 0.00001]
+      dynamic_R: [0.0]
+      segmentation_version: [3.7]
+  - run_EKF_single_theta_dual_radio:
+      phi_std: [0.0]
+      p: [5.0, 1.0, 0.1]
+      noise_std: [0.01, 0.001, 0.0001, 0.00001]
+      dynamic_R: [1.0, 0.1]
+      segmentation_version: [3.7]
+  - run_EKF_single_theta_single_radio:
+      phi_std: [20.0, 10.0, 5.0, 1.0]
+      p: [5.0, 1.0]
+      noise_std: [0.01, 0.001, 0.0001]
+      dynamic_R: [0.0]
+      segmentation_version: [3.7]
+
+  # --- PF: ~0.7 ms per timestep per run at N=8192 and linear in N, so the grid
+  # is deliberately coarse in N. Log-spaced errs: the shipped grid's 12x13 mesh
+  # resolves far finer than the seed-to-seed spread justifies.
+  - run_PF_single_theta_dual_radio:
+      N: [128 * 8, 128 * 32, 128 * 128]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.005, 0.02, 0.1]
+      segmentation_version: [3.7]
+  - run_PF_single_theta_single_radio:
+      N: [128 * 8, 128 * 32]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.01, 0.1]
+      segmentation_version: [3.7]
+
+  # --- NN PF: the family with the most to gain, and the noisiest (106%
+  # seed-to-seed spread), so keep the grid tight and lean on repeats instead.
+  - run_PF_single_theta_dual_radio_NN:
+      checkpoint_fn_and_segmentation_version:
+        - checkpoint_fn: "/mnt/md0/checkpoints/jun26_2026/paired_3p7_thin_noblade/best.pth"
+          segmentation_version: 3.7
+      inference_cache: ["/mnt/qnap01/mouse9911/rovers_2026/inference_cache"]
+      N: [128 * 8, 128 * 32, 128 * 128]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.005, 0.02, 0.1]
+      absolute: [True, False]
+  - run_PF_single_theta_single_radio_NN:
+      checkpoint_fn_and_segmentation_version:
+        - checkpoint_fn: "/mnt/md0/checkpoints/jun26_2026/paired_3p7_thin_noblade/best.pth"
+          segmentation_version: 3.7
+      inference_cache: ["/mnt/qnap01/mouse9911/rovers_2026/inference_cache"]
+      N: [128 * 8, 128 * 32]
+      theta_err: [0.001, 0.005, 0.02, 0.075, 0.2]
+      theta_dot_err: [0.001, 0.01, 0.1]

--- a/spf/filters/configs/rover2026_smoke.yaml
+++ b/spf/filters/configs/rover2026_smoke.yaml
@@ -1,0 +1,68 @@
+# Rover 2026 merged v7 -- one setting per filter family, ~8 jobs per dataset.
+#
+# Purpose: prove the harness runs end to end against this corpus before spending
+# hours on the coarse grid. Run it on a single dataset first.
+#
+#   python spf/filters/run_filters_on_data.py \
+#     -d /mnt/qnap01/mouse9911/rovers_2026/merged/<one>.zarr \
+#     --empirical-pkl-fn empirical_dists/full.pkl \
+#     --work-dir /mnt/qnap01/mouse9911/rovers_2026/filter_runs/smoke \
+#     --config spf/filters/configs/rover2026_smoke.yaml \
+#     --results-backend local --parallel 24
+#
+# NOTE 3 of the 48 merged stores are RO4 at d/lambda = 0.90397, which has no
+# entry in empirical_dists/full.pkl. get_empirical_dist does an exact key
+# lookup, so every empirical (non-NN) filter raises KeyError on those. Either
+# run create_empirical_p_dist.py to add the spacing, or restrict the empirical
+# families to the 0.673 and 0.827 stores.
+precompute_caches:
+  3.7: "/mnt/qnap01/mouse9911/rovers_2026/precompute"
+
+runs:
+  - run_EKF_single_theta_single_radio:
+      phi_std: [10.0]
+      p: [5.0]
+      noise_std: [0.001]
+      dynamic_R: [0.0]
+      segmentation_version: [3.7]
+  - run_EKF_single_theta_dual_radio:
+      phi_std: [10.0]
+      p: [5.0]
+      noise_std: [0.001]
+      dynamic_R: [0.0]
+      segmentation_version: [3.7]
+  - run_PF_single_theta_single_radio:
+      N: [128 * 32]
+      theta_err: [0.01]
+      theta_dot_err: [0.01]
+      segmentation_version: [3.7]
+  - run_PF_single_theta_dual_radio:
+      N: [128 * 32]
+      theta_err: [0.01]
+      theta_dot_err: [0.01]
+      segmentation_version: [3.7]
+  - run_PF_xy_dual_radio:
+      N: [128 * 8]
+      pos_err: [15]
+      vel_err: [0.5]
+      segmentation_version: [3.7]
+  - run_PF_single_theta_single_radio_NN:
+      checkpoint_fn_and_segmentation_version:
+        - checkpoint_fn: "/mnt/md0/checkpoints/jun26_2026/paired_3p7_thin_noblade/best.pth"
+          segmentation_version: 3.7
+      inference_cache: ["/mnt/qnap01/mouse9911/rovers_2026/inference_cache"]
+      N: [128 * 32]
+      theta_err: [0.01]
+      theta_dot_err: [0.01]
+  - run_PF_single_theta_dual_radio_NN:
+      checkpoint_fn_and_segmentation_version:
+        - checkpoint_fn: "/mnt/md0/checkpoints/jun26_2026/paired_3p7_thin_noblade/best.pth"
+          segmentation_version: 3.7
+      inference_cache: ["/mnt/qnap01/mouse9911/rovers_2026/inference_cache"]
+      N: [128 * 32]
+      theta_err: [0.01]
+      theta_dot_err: [0.01]
+      # absolute=True scores against a DIFFERENT ground truth (north-referenced
+      # rather than craft-relative). The report keeps them in separate frames;
+      # never read the two side by side as a like-for-like comparison.
+      absolute: [True, False]

--- a/spf/filters/labels.py
+++ b/spf/filters/labels.py
@@ -1,0 +1,65 @@
+"""Turn a raw filter result into the labels a report groups by.
+
+Two labels, both of which the reporters previously got wrong or omitted:
+
+**movement** -- vehicle plus capture routine. Inferring it from the filename by
+substring is unsafe for merged v7 rover data, whose stores are named
+``<RX capture>.<TX capture>``. A bounce-RX / circle-TX pair contains *both*
+words, and the old reporter tested ``"circle" in name`` first, so every merged
+rover store was labelled ``circle`` when its RX routine was ``bounce``. The
+capture yaml records the routine; use it, and fall back to the filename only
+when it is absent.
+
+**frame** -- which angular frame the result was scored in. This is not recorded
+on the result, but it is fully determined by the filter type and the ``absolute``
+flag, so it can be recovered rather than having to change every filter's metrics
+dict. See ``spf.evaluation.frames`` for why pooling across frames is always a
+bug.
+"""
+
+from spf.evaluation.frames import ABSOLUTE_NORTH, CRAFT_RELATIVE, RADIO_FOLDED
+
+# Order matters: the more specific routine names must be tested first, or
+# "random_circle" is swallowed by "circle".
+_ROUTINE_TOKENS = (
+    "random_circle",
+    "bounce",
+    "center",
+    "diamond",
+    "circle",
+    "calibrate",
+)
+
+
+def ds_fn_to_movement(ds_fn, routine=None):
+    """``<vehicle>_<routine>``, e.g. ``rover_bounce`` or ``2dwallarray_circle``."""
+    name = str(ds_fn).lower()
+    movement = ""
+    if routine is not None and str(routine) != "unknown":
+        movement = str(routine)
+    else:
+        for token in _ROUTINE_TOKENS:
+            if token in name:
+                movement = token
+                break
+    if movement == "":
+        raise ValueError(f"cannot determine movement for {ds_fn}")
+    vehicle = "rover" if "rover" in name else "2dwallarray"
+    return f"{vehicle}_{movement}"
+
+
+def result_to_frame(result):
+    """Recover the angular frame a result was scored in.
+
+    Single-radio filters score against the front/back-folded per-radio bearing.
+    Dual-radio filters score against the craft-relative bearing, except the NN
+    dual-radio filter with ``absolute=True``, which scores against the circular
+    mean of the north-referenced bearings -- a different ground truth reported
+    under the same ``mse_craft_theta`` key.
+    """
+    if result.get("absolute", False):
+        return ABSOLUTE_NORTH
+    _type = str(result.get("type", "")).lower()
+    if "single_radio" in _type:
+        return RADIO_FOLDED
+    return CRAFT_RELATIVE

--- a/spf/filters/plot_filter_run.py
+++ b/spf/filters/plot_filter_run.py
@@ -1,0 +1,426 @@
+"""Visualise one filter run: observations, prediction, confidence, calibration.
+
+The per-filter ``plot_*`` helpers scattered through ``spf/filters/*.py`` each
+build their own filter with hard-coded hyperparameters and each draw a different
+set of panels, so two filters cannot be put side by side. This runs a filter
+under the hyperparameters you actually swept and draws the same panels for every
+family, scoring through ``spf.evaluation`` so the numbers match the report.
+
+Panels:
+
+1. measured phi vs ground-truth phi per radio, with dropped (NaN) frames marked
+2. the theta track with a +-1 sigma band, against ground truth
+3. absolute error over time and the running RMSE
+4. calibration -- z-score histogram against a unit normal, plus measured
+   +-1/2/3 sigma coverage against nominal
+5. for NN filters, the model posterior over theta as a heat map, with ground
+   truth and the filter track drawn on top
+
+Panel 4 is the point. A filter reporting a variance nobody has checked is
+reporting decoration: pointed at the NN dual-radio PF on a rover capture, the
++-1 sigma band covered 25.6% of errors where 68.3% is nominal.
+
+Example::
+
+    python spf/filters/plot_filter_run.py \\
+        --dataset /mnt/qnap01/mouse9911/rovers_2026/merged/<prefix>.zarr \\
+        --precompute-cache /mnt/qnap01/mouse9911/rovers_2026/precompute \\
+        --empirical-pkl-fn empirical_dists/full.pkl \\
+        --segmentation-version 3.7 \\
+        --filter pf_dual_nn --params '{"N": 4096, "theta_err": 0.01}' \\
+        --checkpoint-fn <ckpt>/best.pth --inference-cache <cache> \\
+        --output-dir /tmp/filter_plots
+"""
+
+import argparse
+import json
+import logging
+import os
+
+import numpy as np
+import torch
+
+from spf.dataset.spf_dataset import v5spfdataset
+from spf.dataset.spf_nn_dataset_wrapper import v5spfdataset_nn_wrapper
+from spf.evaluation import calibration, metrics
+from spf.evaluation.frames import ABSOLUTE_NORTH, CRAFT_RELATIVE, RADIO_FOLDED
+from spf.filters.ekf_dualradio_filter import SPFPairedKalmanFilter
+from spf.filters.ekf_single_radio_filter import SPFKalmanFilter
+from spf.filters.particle_dual_radio_nn_filter import PFSingleThetaDualRadioNN
+from spf.filters.particle_dualradio_filter import PFSingleThetaDualRadio
+from spf.filters.particle_single_radio_filter import PFSingleThetaSingleRadio
+from spf.filters.particle_single_radio_nn_filter import PFSingleThetaSingleRadioNN
+from spf.rf import reduce_theta_to_positive_y
+
+FILTERS = [
+    "ekf_single",
+    "ekf_dual",
+    "pf_single",
+    "pf_dual",
+    "pf_single_nn",
+    "pf_dual_nn",
+]
+
+# The filters never read these; loading them costs minutes of IO per dataset.
+FILTER_SKIP_FIELDS = set(
+    [
+        "windowed_beamformer",
+        "weighted_beamformer",
+        "all_windows_stats",
+        "downsampled_segmentation_mask",
+        "signal_matrix",
+        "simple_segmentations",
+    ]
+)
+
+
+def open_dataset(
+    prefix, precompute_cache, empirical_pkl_fn, segmentation_version, nthetas=65
+):
+    return v5spfdataset(
+        prefix=str(prefix).replace(".zarr", ""),
+        nthetas=nthetas,
+        ignore_qc=True,
+        precompute_cache=precompute_cache,
+        paired=True,
+        snapshots_per_session=1,
+        readahead=False,
+        skip_fields=FILTER_SKIP_FIELDS,
+        empirical_data_fn=empirical_pkl_fn,
+        segmentation_version=segmentation_version,
+        segment_if_not_exist=False,
+        gpu=False,
+    )
+
+
+def _scalars(values):
+    return np.asarray([float(np.asarray(v).reshape(-1)[0]) for v in values])
+
+
+def _nn_posterior(nn_ds, key, rx_idx):
+    """(timesteps, ntheta) model posterior, or None when running realtime."""
+    cached = getattr(nn_ds, "cached_model_inference", None)
+    if cached is None or key not in cached:
+        return None
+    return np.asarray(cached[key])[:, rx_idx, 0, :]
+
+
+def run_filter(ds, filter_name, params, checkpoint_fn=None, inference_cache=None):
+    """Run one filter; return (theta, sigma, ground_truth, extras).
+
+    All three arrays are in the SAME angular frame, named in ``extras["frame"]``.
+    """
+    params = dict(params)
+    rx_idx = int(params.pop("rx_idx", 0))
+    seed = int(params.pop("seed", 0))
+    extras = {"rx_idx": rx_idx, "seed": seed}
+
+    pf_kwargs = None
+    if filter_name.startswith("pf_"):
+        pf_kwargs = dict(
+            mean=torch.tensor([[0.0, 0.0]]),
+            std=torch.tensor([[20.0, 0.1]]),
+            noise_std=torch.tensor(
+                [[params.pop("theta_err", 0.01), params.pop("theta_dot_err", 0.001)]]
+            ),
+            N=int(params.pop("N", 128 * 32)),
+            return_particles=False,
+            seed=seed,
+        )
+
+    if filter_name == "pf_single":
+        pf = PFSingleThetaSingleRadio(ds=ds, rx_idx=rx_idx)
+        traj = pf.trajectory(**pf_kwargs)
+        theta, sigma = _scalars([x["theta"] for x in traj]), np.sqrt(
+            _scalars([x["P_theta"] for x in traj])
+        )
+        gt = reduce_theta_to_positive_y(ds.ground_truth_thetas[rx_idx]).numpy()
+        extras["frame"] = RADIO_FOLDED
+    elif filter_name == "pf_single_nn":
+        pf = PFSingleThetaSingleRadioNN(
+            ds,
+            rx_idx,
+            checkpoint_fn,
+            f"{os.path.dirname(checkpoint_fn)}/config.yml",
+            inference_cache=inference_cache,
+            device="cpu",
+        )
+        traj = pf.trajectory(**pf_kwargs)
+        theta, sigma = _scalars([x["theta"] for x in traj]), np.sqrt(
+            _scalars([x["P_theta"] for x in traj])
+        )
+        gt = reduce_theta_to_positive_y(ds.ground_truth_thetas[rx_idx]).numpy()
+        extras["frame"] = RADIO_FOLDED
+        extras["posterior"] = _nn_posterior(pf.ds, "single", rx_idx)
+    elif filter_name == "pf_dual":
+        pf = PFSingleThetaDualRadio(ds=ds)
+        traj = pf.trajectory(**pf_kwargs)
+        theta, sigma = _scalars([x["craft_theta"] for x in traj]), np.sqrt(
+            _scalars([x["P_theta"] for x in traj])
+        )
+        gt = ds.craft_ground_truth_thetas.numpy()
+        extras["frame"] = CRAFT_RELATIVE
+    elif filter_name == "pf_dual_nn":
+        absolute = bool(params.pop("absolute", False))
+        nn_ds = v5spfdataset_nn_wrapper(
+            ds,
+            f"{os.path.dirname(checkpoint_fn)}/config.yml",
+            checkpoint_fn,
+            inference_cache,
+            device="cpu",
+            absolute=absolute,
+        )
+        pf = PFSingleThetaDualRadioNN(nn_ds=nn_ds)
+        traj = pf.trajectory(**pf_kwargs)
+        theta, sigma = _scalars([x["craft_theta"] for x in traj]), np.sqrt(
+            _scalars([x["P_theta"] for x in traj])
+        )
+        if absolute:
+            # matches PFSingleThetaDualRadioNN.metrics: circular mean over radios
+            gt = torch.atan2(
+                torch.sin(ds.absolute_thetas).mean(axis=0),
+                torch.cos(ds.absolute_thetas).mean(axis=0),
+            ).numpy()
+            extras["frame"] = ABSOLUTE_NORTH
+        else:
+            gt = ds.craft_ground_truth_thetas.numpy()
+            extras["frame"] = CRAFT_RELATIVE
+        extras["posterior"] = _nn_posterior(nn_ds, "paired", 0)
+    elif filter_name == "ekf_dual":
+        ekf = SPFPairedKalmanFilter(
+            ds=ds,
+            phi_std=params.pop("phi_std", 10.0),
+            p=params.pop("p", 5.0),
+            dynamic_R=params.pop("dynamic_R", 0.0),
+        )
+        # debug=True is what populates P_theta; without it the EKF reports no sigma
+        traj = ekf.trajectory(
+            dt=1.0, noise_std=params.pop("noise_std", 0.001), debug=True
+        )
+        theta, sigma = _scalars([x["craft_theta"] for x in traj]), np.sqrt(
+            _scalars([x["P_theta"] for x in traj])
+        )
+        gt = ds.craft_ground_truth_thetas.numpy()
+        extras["frame"] = CRAFT_RELATIVE
+    elif filter_name == "ekf_single":
+        ekf = SPFKalmanFilter(
+            ds=ds,
+            rx_idx=rx_idx,
+            phi_std=params.pop("phi_std", 10.0),
+            p=params.pop("p", 5.0),
+            dynamic_R=params.pop("dynamic_R", 0.0),
+        )
+        traj = ekf.trajectory(
+            dt=1.0, noise_std=params.pop("noise_std", 0.001), debug=True
+        )
+        theta, sigma = _scalars([x["theta"] for x in traj]), np.sqrt(
+            _scalars([x["P_theta"] for x in traj])
+        )
+        gt = reduce_theta_to_positive_y(ds.ground_truth_thetas[rx_idx]).numpy()
+        extras["frame"] = RADIO_FOLDED
+    else:
+        raise ValueError(f"unknown filter {filter_name!r}; expected one of {FILTERS}")
+
+    if params:
+        raise ValueError(f"unused params for {filter_name}: {sorted(params)}")
+
+    gt = np.asarray(gt).reshape(-1)[: theta.shape[0]]
+    return theta, sigma, gt, extras
+
+
+def summarize_run(theta, sigma, gt):
+    """The numbers printed alongside the figure, from spf.evaluation."""
+    out = metrics.summarize(theta, gt)
+    out["coverage"] = calibration.coverage(theta, gt, sigma)
+    out["calibration_ratio"] = calibration.calibration_ratio(theta, gt, sigma)
+    return out
+
+
+def plot_filter_run(ds, theta, sigma, gt, extras, title):
+    from matplotlib import pyplot as plt
+
+    posterior = extras.get("posterior")
+    nrows = 5 if posterior is not None else 4
+    fig, ax = plt.subplots(nrows, 1, figsize=(13, 3.1 * nrows))
+    n = theta.shape[0]
+    t = np.arange(n)
+
+    # ---- observations
+    colors = ["tab:blue", "tab:orange"]
+    for ridx in (0, 1):
+        mp = ds.mean_phase[f"r{ridx}"][:n].numpy()
+        ax[0].scatter(
+            t[: mp.shape[0]],
+            mp,
+            s=2.0,
+            alpha=0.45,
+            color=colors[ridx],
+            label=f"r{ridx} measured phi",
+        )
+        ax[0].plot(
+            ds.ground_truth_phis[ridx][:n].numpy(),
+            color=colors[ridx],
+            ls="dashed",
+            lw=1.0,
+            label=f"r{ridx} ground-truth phi",
+        )
+        nan_frac = float(np.isnan(mp).mean())
+        for x in t[: mp.shape[0]][np.isnan(mp)]:
+            ax[0].axvline(x, color=colors[ridx], alpha=0.05, lw=0.5)
+        ax[0].plot([], [], " ", label=f"r{ridx} dropped frames: {nan_frac:.1%}")
+    ax[0].set_ylabel("phi (rad)")
+    ax[0].set_title("Observations: phase difference per radio (bands = no segment)")
+    # phi fills [-pi, pi], so a legend inside the axes covers real data. Add
+    # headroom above and put it there.
+    ax[0].set_ylim(-3.4, 5.2)
+    ax[0].legend(fontsize=7, ncol=3, loc="upper center", framealpha=0.9)
+
+    # ---- track + confidence
+    ax[1].axhline(np.pi / 2, ls=":", c=(0.7, 0.7, 0.7))
+    ax[1].axhline(-np.pi / 2, ls=":", c=(0.7, 0.7, 0.7))
+    ax[1].plot(gt, color="black", lw=1.2, label="ground truth")
+    ax[1].fill_between(
+        t, theta - sigma, theta + sigma, color="tab:red", alpha=0.22, label="+-1 sigma"
+    )
+    ax[1].scatter(t, theta, s=3.0, color="tab:red", label="filter estimate")
+    ax[1].set_ylabel("theta (rad)")
+    ax[1].set_title(f"Estimate and confidence -- frame: {extras['frame']}")
+    ax[1].legend(fontsize=8, ncol=3)
+
+    # ---- error
+    err = metrics.angular_error(theta, gt)
+    final_rmse = float(np.sqrt((err**2).mean()))
+    ax[2].plot(np.abs(err), lw=0.8, color="tab:purple", label="|error|")
+    ax[2].plot(
+        np.sqrt(np.cumsum(err**2) / (np.arange(err.shape[0]) + 1)),
+        lw=1.6,
+        color="black",
+        label="running RMSE",
+    )
+    ax[2].axhline(
+        final_rmse,
+        ls="dashed",
+        color="tab:green",
+        label=f"final RMSE {final_rmse:.3f} rad ({np.degrees(final_rmse):.1f} deg)",
+    )
+    ax[2].set_ylabel("|error| (rad)")
+    ax[2].set_xlabel("sample index (time)")
+    ax[2].set_title(f"Error -- MSE {float((err ** 2).mean()):.4f} rad^2")
+    ax[2].legend(fontsize=8, ncol=3)
+
+    # ---- calibration
+    z = calibration.z_scores(theta, gt, sigma)
+    if z.size:
+        ax[3].hist(
+            np.clip(z, -6, 6),
+            bins=61,
+            density=True,
+            alpha=0.7,
+            color="tab:blue",
+            label="z = error / sigma (clipped to +-6)",
+        )
+        grid = np.linspace(-6, 6, 400)
+        ax[3].plot(
+            grid,
+            np.exp(-(grid**2) / 2) / np.sqrt(2 * np.pi),
+            color="black",
+            label="unit normal (perfect calibration)",
+        )
+        # 3 decimals: nominal 3-sigma is 0.9973 and rounds to "1.00" at 2,
+        # which reads as though the band is expected to hold everything
+        cov = "  ".join(
+            f"{r['k']}s: {r['measured']:.3f} (nom {r['nominal']:.3f})"
+            for r in calibration.coverage(theta, gt, sigma)
+        )
+        ratio = calibration.calibration_ratio(theta, gt, sigma)
+        ax[3].set_title(f"Calibration -- std(z)={ratio:.2f}   coverage {cov}")
+    else:
+        ax[3].set_title("Calibration -- this filter reported no usable sigma")
+    ax[3].set_xlabel("z-score")
+    ax[3].legend(fontsize=8)
+
+    # ---- posterior heat map
+    if posterior is not None:
+        post = np.asarray(posterior)[:n]
+        ax[4].imshow(
+            post.T,
+            aspect="auto",
+            origin="lower",
+            extent=[0, n, -np.pi, np.pi],
+            cmap="viridis",
+        )
+        ax[4].plot(gt, color="white", lw=1.2, label="ground truth")
+        ax[4].scatter(t, theta, s=2.0, color="red", label="filter estimate")
+        ax[4].set_ylabel("theta (rad)")
+        ax[4].set_xlabel("sample index (time)")
+        ax[4].set_title(f"Network posterior over theta ({post.shape[-1]} bins)")
+        ax[4].legend(fontsize=8, loc="upper right")
+
+    fig.suptitle(title, fontsize=11)
+    fig.tight_layout(rect=[0, 0, 1, 0.985])
+    return fig
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", type=str, required=True, help="zarr prefix")
+    parser.add_argument("--precompute-cache", type=str, required=True)
+    parser.add_argument("--empirical-pkl-fn", type=str, required=True)
+    parser.add_argument("--segmentation-version", type=float, default=3.7)
+    parser.add_argument("--nthetas", type=int, default=65)
+    parser.add_argument("--filter", type=str, required=True, choices=FILTERS)
+    parser.add_argument(
+        "--params",
+        type=str,
+        default="{}",
+        help='JSON hyperparameters, e.g. \'{"N": 4096, "theta_err": 0.01}\'',
+    )
+    parser.add_argument("--checkpoint-fn", type=str, default=None)
+    parser.add_argument("--inference-cache", type=str, default=None)
+    parser.add_argument("--output-dir", type=str, required=True)
+    return parser
+
+
+if __name__ == "__main__":
+    import matplotlib
+
+    matplotlib.use("Agg")
+    from matplotlib import pyplot as plt
+
+    logging.basicConfig(
+        format="%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s",
+        level=os.environ.get("LOGLEVEL", "INFO").upper(),
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    args = get_parser().parse_args()
+    params = json.loads(args.params)
+
+    ds = open_dataset(
+        args.dataset,
+        args.precompute_cache,
+        args.empirical_pkl_fn,
+        args.segmentation_version,
+        nthetas=args.nthetas,
+    )
+    theta, sigma, gt, extras = run_filter(
+        ds,
+        args.filter,
+        params,
+        checkpoint_fn=args.checkpoint_fn,
+        inference_cache=args.inference_cache,
+    )
+    basename = os.path.basename(str(args.dataset)).replace(".zarr", "")
+    fig = plot_filter_run(
+        ds,
+        theta,
+        sigma,
+        gt,
+        extras,
+        f"{args.filter}  {json.dumps(params, sort_keys=True)}\n{basename}",
+    )
+    os.makedirs(args.output_dir, exist_ok=True)
+    out_fn = os.path.join(args.output_dir, f"{basename}__{args.filter}.png")
+    fig.savefig(out_fn, dpi=110)
+    plt.close(fig)
+    logging.info(f"wrote {out_fn}")
+    print(json.dumps(summarize_run(theta, sigma, gt), indent=2, default=str))

--- a/spf/filters/report.py
+++ b/spf/filters/report.py
@@ -1,0 +1,172 @@
+"""Turn a local sweep's results into artifacts you can actually commit.
+
+``run_filters_report.py`` writes CSV, and ``.gitignore`` matches ``**/*.csv``
+(with only the JLC fab files excepted), so a sweep result in that format can
+never be checked in. This writes ``results.json`` plus a ``REPORT.md`` table,
+both of which are tracked, matching the append-only report convention already
+used under ``spf/calibrations/*/reports/<name>_<date>_v1/``.
+
+It also groups on the angular **frame**, so a craft-relative run and an
+absolute-north run of the same hyperparameters never land in one average.
+"""
+
+import argparse
+import json
+import logging
+import os
+import pickle
+
+from spf.evaluation.aggregate import aggregate
+from spf.filters.labels import ds_fn_to_movement, result_to_frame
+
+# Fields that describe the run rather than measure it; everything else that is
+# not a metric becomes part of the grouping key.
+_NON_GROUPING = {"metrics", "ds_fn", "precompute_cache", "full_name", "runtime"}
+
+
+def load_results(workdir):
+    """Every result dict written by LocalResultsStore under ``workdir``."""
+    out = []
+    for dirpath, _, filenames in os.walk(workdir):
+        for name in sorted(filenames):
+            if not name.endswith(".pkl"):
+                continue
+            with open(os.path.join(dirpath, name), "rb") as f:
+                out.extend(pickle.load(f))
+    return out
+
+
+def annotate(results):
+    """Attach ``frame`` and ``movement`` so the results can be grouped."""
+    annotated = []
+    for result in results:
+        result = dict(result)
+        result["frame"] = result_to_frame(result)
+        result["movement"] = ds_fn_to_movement(
+            result.get("ds_fn", ""), result.get("routine")
+        )
+        annotated.append(result)
+    return annotated
+
+
+def grouping_keys(results):
+    """Every non-metric field shared by all results, in stable order."""
+    if not results:
+        return []
+    common = set(results[0])
+    for result in results[1:]:
+        common &= set(result)
+    return sorted(common - _NON_GROUPING)
+
+
+def build_report(workdir):
+    results = annotate(load_results(workdir))
+    if not results:
+        raise ValueError(f"no results found under {workdir}")
+    rows = aggregate(results, grouping_keys(results))
+    return {
+        "workdir": workdir,
+        "n_results": len(results),
+        "n_groups": len(rows),
+        "rows": rows,
+    }
+
+
+def _fmt(value):
+    if isinstance(value, float):
+        return f"{value:.4f}"
+    if isinstance(value, list):
+        return ",".join(str(v) for v in value)
+    return str(value)
+
+
+# Each filter family names its error metric differently, so the column to rank on
+# cannot be hard-coded: dual-radio filters report mse_craft_theta, single-radio
+# ones mse_single_radio_theta, XY adds mse_xy. Preference order, best first.
+_SORT_PREFERENCE = (
+    "mse_craft_theta_mean",
+    "mse_single_radio_theta_mean",
+    "mse_mean",
+    "mse_xy_mean",
+)
+
+
+def default_sort_metric(rows):
+    """The metric to rank these rows by, discovered from what they carry."""
+    present = set().union(*(set(r) for r in rows)) if rows else set()
+    for name in _SORT_PREFERENCE:
+        if name in present:
+            return name
+    candidates = sorted(
+        c for c in present if c.startswith("mse") and c.endswith("_mean")
+    )
+    return candidates[0] if candidates else None
+
+
+def report_to_markdown(report, sort_by=None, top=25):
+    """A per-frame leaderboard. Frames get their own table -- never one ranking."""
+    lines = [
+        "# Filter sweep report",
+        "",
+        f"- results: **{report['n_results']}** in **{report['n_groups']}** groups",
+        f"- work dir: `{report['workdir']}`",
+        "",
+        "Rows are grouped by every non-metric field **and by angular frame**. A"
+        " craft-relative and an absolute-north run of the same hyperparameters"
+        " answer different questions and are never averaged or ranked together.",
+        "",
+    ]
+    by_frame = {}
+    for row in report["rows"]:
+        by_frame.setdefault(row["frame"], []).append(row)
+
+    for frame in sorted(by_frame):
+        rows = by_frame[frame]
+        # resolve per frame: single-radio and dual-radio rows carry different
+        # metric names, and they never share a frame anyway
+        metric = sort_by or default_sort_metric(rows)
+        if metric is not None and all(metric in r for r in rows):
+            rows = sorted(rows, key=lambda r: r[metric])
+            heading = f"## frame: `{frame}` (ranked by `{metric}`)"
+        else:
+            heading = f"## frame: `{frame}` (unranked: no shared error metric)"
+        lines += [heading, ""]
+        shown = rows[:top]
+        columns = [c for c in sorted(shown[0]) if c != "frame"]
+        lines.append("| " + " | ".join(columns) + " |")
+        lines.append("|" + "|".join(["---"] * len(columns)) + "|")
+        for row in shown:
+            lines.append(
+                "| " + " | ".join(_fmt(row.get(c, "")) for c in columns) + " |"
+            )
+        if len(rows) > top:
+            lines.append("")
+            lines.append(f"_{len(rows) - top} further rows omitted; see results.json._")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def write_report(workdir, output_dir, sort_by=None, top=25):
+    report = build_report(workdir)
+    os.makedirs(output_dir, exist_ok=True)
+    json_fn = os.path.join(output_dir, "results.json")
+    with open(json_fn, "w") as f:
+        json.dump(report, f, indent=2, sort_keys=True)
+    md_fn = os.path.join(output_dir, "REPORT.md")
+    with open(md_fn, "w") as f:
+        f.write(report_to_markdown(report, sort_by=sort_by, top=top))
+    return json_fn, md_fn
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--work-dir", type=str, required=True)
+    parser.add_argument("--output-dir", type=str, required=True)
+    parser.add_argument("--sort-by", type=str, default=None)
+    parser.add_argument("--top", type=int, default=25)
+    args = parser.parse_args()
+    logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO").upper())
+    json_fn, md_fn = write_report(
+        args.work_dir, args.output_dir, sort_by=args.sort_by, top=args.top
+    )
+    logging.info(f"wrote {json_fn} and {md_fn}")

--- a/spf/filters/reports/README.md
+++ b/spf/filters/reports/README.md
@@ -1,0 +1,40 @@
+# Filter sweep reports
+
+Small, reviewable outputs from `spf/filters/report.py`. Follows the append-only
+convention already used by `spf/calibrations/*/reports/`: one directory per run,
+named `<name>_<YYYYMMDD>_v1`, never edited once written — a re-run gets a new
+directory.
+
+Each directory holds:
+
+| File | Contents |
+|---|---|
+| `REPORT.md` | per-frame leaderboard, the reviewable summary |
+| `results.json` | every aggregated row, machine-readable |
+| `inputs_manifest.json` | dataset list, config, checkpoint + config md5s, git commit |
+
+## Why not CSV
+
+`.gitignore` matches `**/*.csv` repo-wide (only the JLC fab files are excepted),
+so `run_filters_report.py`'s CSV output can never be committed. That is the
+reason `report.py` exists and writes JSON + Markdown instead.
+
+Bulk output — the per-job `results.pkl` under the work dir, per-dataset PNGs —
+stays out of git entirely. Put it on qnap01. Note `.gitignore` already reserves
+`**/filter_reports` and `**/run_on_filters_results`, so those names are
+always ignored if you reach for them.
+
+## Reading a report
+
+Rows are grouped by every non-metric field **and by angular frame**, and each
+frame gets its own table. A `craft_relative` row and an `absolute_north` row of
+the same hyperparameters are answers to different questions — see
+`spf/evaluation/frames.py`. Never rank across the two.
+
+`n_runs` is the denominator behind every averaged number on a row. A row with
+`n_runs = 1` on a particle filter is one draw from a distribution whose
+per-dataset spread was measured at 42–106% of the mean; treat it accordingly.
+
+## Index
+
+_(none yet — the first sweep lands here)_

--- a/spf/filters/results_store.py
+++ b/spf/filters/results_store.py
@@ -1,0 +1,108 @@
+"""Where a filter sweep's results go.
+
+The runner previously wrote every result straight into a DynamoDB table, with
+the local file path behind a hard-coded ``use_file_system = False``. That made a
+local sweep impossible without AWS credentials, and left the runner and
+``run_filters_report.py`` -- which reads ``.pkl`` files out of the work dir --
+wired to two different sinks, so the local reporter had nothing to read.
+
+Both sinks now sit behind one interface, and **local is the default**. The
+DynamoDB path is preserved for the AWS Batch driver but is opt-in and imports
+boto3 lazily, so no local run touches the network.
+"""
+
+import logging
+import os
+import pickle
+from decimal import Decimal
+
+
+def float_to_decimal(obj):
+    """Recursively convert floats to Decimal, which is what DynamoDB accepts."""
+    if isinstance(obj, float):
+        # via str: Decimal(0.1) carries the binary float's full error
+        return Decimal(str(obj))
+    if isinstance(obj, dict):
+        return {k: float_to_decimal(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [float_to_decimal(v) for v in obj]
+    return obj
+
+
+class ResultsStore:
+    """Sink for one sweep. ``key`` is the workdir-relative result path."""
+
+    def already_processed(self):
+        """Keys already present, so a resumed sweep can skip them."""
+        raise NotImplementedError
+
+    def put(self, key, results):
+        raise NotImplementedError
+
+
+class LocalResultsStore(ResultsStore):
+    """One pickle per job under ``workdir``, laid out as the reporter expects."""
+
+    def __init__(self, workdir):
+        self.workdir = workdir
+
+    def path_for(self, key):
+        return os.path.join(self.workdir, key)
+
+    def already_processed(self):
+        found = set()
+        for dirpath, _, filenames in os.walk(self.workdir):
+            for name in filenames:
+                if name.endswith(".pkl"):
+                    found.add(
+                        os.path.relpath(os.path.join(dirpath, name), self.workdir)
+                    )
+        return found
+
+    def put(self, key, results):
+        path = self.path_for(key)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        # write-then-rename: a sweep killed mid-write must not leave a truncated
+        # pickle that the reporter would later fail on
+        tmp = path + ".tmp"
+        with open(tmp, "wb") as f:
+            pickle.dump(results, f)
+        os.rename(tmp, path)
+
+
+class DynamoDBResultsStore(ResultsStore):
+    """The AWS Batch sink. boto3 is imported lazily so local runs never need it."""
+
+    def __init__(self, workdir, table_name="filter_metrics"):
+        import boto3
+
+        self.workdir = workdir
+        self.table = boto3.resource("dynamodb").Table(table_name)
+
+    def already_processed(self):
+        from spf.filters.run_filters_on_data_b2 import (
+            get_all_items_by_bucket_scan_full_name,
+        )
+
+        return {
+            item["full_name"]
+            for item in get_all_items_by_bucket_scan_full_name(self.workdir)
+        }
+
+    def put(self, key, results):
+        self.table.put_item(
+            Item={
+                "bucket": self.workdir,
+                "full_name": key,
+                "results": float_to_decimal(results),
+            }
+        )
+
+
+def make_results_store(backend, workdir):
+    if backend == "local":
+        return LocalResultsStore(workdir)
+    if backend == "dynamodb":
+        logging.info("results backend: dynamodb (network writes enabled)")
+        return DynamoDBResultsStore(workdir)
+    raise ValueError(f"unknown results backend {backend!r}; expected local or dynamodb")

--- a/spf/filters/run_filters_on_data.py
+++ b/spf/filters/run_filters_on_data.py
@@ -1,14 +1,11 @@
 import argparse
 import logging
 import os
-import pickle
 import random
 import time
-from decimal import Decimal
 from functools import partial
 from multiprocessing import Pool
 
-import boto3
 import torch
 import tqdm
 import yaml
@@ -24,30 +21,10 @@ from spf.filters.particle_dualradioXY_filter import PFXYDualRadio
 from spf.filters.particle_single_radio_filter import PFSingleThetaSingleRadio
 from spf.filters.particle_single_radio_nn_filter import PFSingleThetaSingleRadioNN
 from spf.s3_utils import b2_file_to_local_with_cache, b2path_to_bucket_and_path
+from spf.filters.results_store import make_results_store
 from spf.utils import get_md5_of_file
 
 checkpoints_cache_dir = None
-
-
-def float_to_decimal(obj):
-    """
-    Recursively convert all floating point values in a dict, list, or float
-    to Decimal for DynamoDB.
-    """
-    if isinstance(obj, float):
-        # Convert float to a string, then to Decimal to avoid precision issues
-        return Decimal(str(obj))
-    elif isinstance(obj, dict):
-        for k, v in obj.items():
-            obj[k] = float_to_decimal(v)
-        return obj
-    elif isinstance(obj, list):
-        for i, v in enumerate(obj):
-            obj[i] = float_to_decimal(v)
-        return obj
-    else:
-        # For other types (int, str, bool, None, Decimal, etc.), return as-is
-        return obj
 
 
 def args_to_str(args):
@@ -68,19 +45,25 @@ def fake_runner(ds, **kwargs):
         a = ds[idx][0]
 
 
-def run_jobs_with_one_dataset(kwargs, checkpoints_cache_dir, already_processed=[]):
-
-    dynamodb = boto3.resource("dynamodb")
-    table = dynamodb.Table("filter_metrics")
+def run_jobs_with_one_dataset(
+    kwargs, checkpoints_cache_dir, already_processed=[], results_backend="local"
+):
     # b2_reset_cache()  # different processes need different folders for cache
     result_fns = []
+    store = None  # built lazily: a fully-skipped dataset should touch no sink
 
     for fn, fn_kwargs in kwargs["jobs"]:
         precompute_cache = fn_kwargs.pop("precompute_cache")
         segmentation_version = fn_kwargs.pop("segmentation_version")
 
         original_b2_paths = {}
-        if "checkpoint_fn" in fn_kwargs:
+        # Only b2:// checkpoints need fetching. b2path_to_bucket_and_path on a
+        # local path yields an empty bucket and the config fetch below then tries
+        # to download "b2:///mnt/...", so without this guard a local checkpoint
+        # cannot be used at all.
+        if "checkpoint_fn" in fn_kwargs and str(fn_kwargs["checkpoint_fn"]).startswith(
+            "b2://"
+        ):
 
             b2_checkpoint_fn = fn_kwargs["checkpoint_fn"]
             local_checkpoint_fn = b2_file_to_local_with_cache(
@@ -141,40 +124,26 @@ def run_jobs_with_one_dataset(kwargs, checkpoints_cache_dir, already_processed=[
             segmentation_version=segmentation_version,
         ) as ds:
 
-            use_file_system = False
-            if use_file_system:
+            fn_kwargs["ds"] = ds
+            new_results = fn(**fn_kwargs)
+            for result in new_results:
+                # NOTE: deliberately not storing result_fn_without_workdir on the
+                # result. It embeds the dataset basename, and the reporter builds
+                # its grouping key from every non-metric field -- storing it puts
+                # each dataset in its own group and defeats the cross-dataset
+                # averaging the report exists to do.
+                result["ds_fn"] = kwargs["ds_fn"]
+                result["segmentation_version"] = segmentation_version
+                result["precompute_cache"] = precompute_cache
+                # report the b2 path the job was configured with, not the local
+                # cache copy it was actually read from
+                for replace_key, replace_value in original_b2_paths.items():
+                    if replace_key in result:
+                        result[replace_key] = replace_value
 
-                os.makedirs(os.path.dirname(result_fn), exist_ok=True)
-                if not os.path.exists(result_fn):
-                    fn_kwargs["ds"] = ds
-                    new_results = fn(**fn_kwargs)
-                    for result in new_results:
-                        result["full_name"] = result_fn_without_workdir
-                        result["ds_fn"] = kwargs["ds_fn"]
-                        result["segmentation_version"] = segmentation_version
-                        result["precompute_cache"] = precompute_cache
-                    # dump to file
-                    pickle.dump(new_results, open(result_fn + ".tmp", "wb"))
-                    os.rename(result_fn + ".tmp", result_fn)
-                    assert os.path.exists(result_fn)
-            else:
-
-                fn_kwargs["ds"] = ds
-                new_results = fn(**fn_kwargs)
-                for result in new_results:
-                    result["ds_fn"] = kwargs["ds_fn"]
-                    result["segmentation_version"] = segmentation_version
-                    result["precompute_cache"] = precompute_cache
-                    for replace_key, replace_value in original_b2_paths.items():
-                        if replace_key in result:
-                            result[replace_key] = replace_value
-                table.put_item(
-                    Item={
-                        "bucket": workdir,
-                        "full_name": result_fn_without_workdir,
-                        "results": float_to_decimal(new_results),
-                    }
-                )
+            if store is None:
+                store = make_results_store(results_backend, workdir)
+            store.put(result_fn_without_workdir, new_results)
 
             result_fns.append(result_fn)
 
@@ -624,12 +593,18 @@ def generate_configs_to_run(
 
 
 def run_filter_jobs(
-    jobs, nparallel, debug=False, checkpoints_cache_dir=None, already_processed=[]
+    jobs,
+    nparallel,
+    debug=False,
+    checkpoints_cache_dir=None,
+    already_processed=[],
+    results_backend="local",
 ):
     f = partial(
         run_jobs_with_one_dataset,
         checkpoints_cache_dir=checkpoints_cache_dir,
         already_processed=already_processed,
+        results_backend=results_backend,
     )
     if debug:
         _ = list(
@@ -710,6 +685,31 @@ if __name__ == "__main__":
             type=str,
             required=True,
         )
+        parser.add_argument(
+            "--results-backend",
+            type=str,
+            choices=["local", "dynamodb"],
+            default="local",
+            help=(
+                "local (default): one results.pkl per job under --work-dir, which "
+                "is what run_filters_report.py reads. dynamodb: put_item into the "
+                "'filter_metrics' table -- needs AWS credentials and writes to the "
+                "network."
+            ),
+        )
+        parser.add_argument(
+            "--checkpoints-cache-dir",
+            type=str,
+            default=None,
+            required=False,
+            help="local cache for b2:// checkpoints; unused for local paths",
+        )
+        parser.add_argument(
+            "--resume",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="skip jobs already present in the results store",
+        )
 
         return parser
 
@@ -728,4 +728,18 @@ if __name__ == "__main__":
         seed=args.seed,
         empirical_pkl_fn=args.empirical_pkl_fn,
     )
-    run_filter_jobs(jobs)
+    already_processed = []
+    if args.resume:
+        already_processed = make_results_store(
+            args.results_backend, args.work_dir
+        ).already_processed()
+        if already_processed:
+            logging.info(f"resuming: {len(already_processed)} results already present")
+    run_filter_jobs(
+        jobs,
+        nparallel=args.parallel,
+        debug=args.debug,
+        checkpoints_cache_dir=args.checkpoints_cache_dir,
+        already_processed=already_processed,
+        results_backend=args.results_backend,
+    )

--- a/spf/filters/run_filters_on_data_b2.py
+++ b/spf/filters/run_filters_on_data_b2.py
@@ -22,7 +22,7 @@ from spf.s3_utils import (
     get_b2_client,
     list_b2_objects,
 )
-from spf.scripts.run_filters_on_data import generate_configs_to_run, run_filter_jobs
+from spf.filters.run_filters_on_data import generate_configs_to_run, run_filter_jobs
 
 
 def get_parser():
@@ -314,6 +314,10 @@ def main():
                                 if os.path.basename(local_zarr_fn) in x
                             ]
                         ),
+                        # explicit: run_filter_jobs now defaults to the local
+                        # sink, and this driver's whole purpose is the shared
+                        # DynamoDB table that its reporter reads back
+                        results_backend="dynamodb",
                     )
                 except Exception as e:
                     print("Failed to process", str(e))

--- a/spf/filters/run_filters_report.py
+++ b/spf/filters/run_filters_report.py
@@ -7,6 +7,8 @@ import pickle
 import torch
 import tqdm
 
+from spf.filters.labels import ds_fn_to_movement
+
 
 def read_pkl(pkl_fn):
     return pickle.load(open(pkl_fn, "rb"))
@@ -43,18 +45,8 @@ def merge_results(results, header):
     for _results in results:
         for result in _results:
             result = result.copy()
-            # _ty = result.pop("type")
-            _fn = result.pop("ds_fn").lower()
-            movement = ""
-            if "circle" in _fn:
-                movement = "circle"
-            elif "bounce" in _fn:
-                movement = "bounce"
-            elif "calibrate" in _fn:
-                movement = "calibrate"
-            else:
-                raise ValueError(f"Cannot figure out movement {_fn}")
-            result["movement"] = movement
+            _fn = result.pop("ds_fn")
+            result["movement"] = ds_fn_to_movement(_fn, result.get("routine"))
             key = result_to_tuple(result, header)
             if key not in merged:
                 merged[key] = []

--- a/spf/filters/run_filters_report_b2.py
+++ b/spf/filters/run_filters_report_b2.py
@@ -7,7 +7,7 @@ import pickle
 import torch
 import tqdm
 
-from spf.scripts.run_filters_on_data_b2 import get_all_items_by_bucket
+from spf.filters.run_filters_on_data_b2 import get_all_items_by_bucket
 
 
 def read_pkl(pkl_fn):

--- a/tests/test_filter_report.py
+++ b/tests/test_filter_report.py
@@ -1,0 +1,189 @@
+"""Labels, the local results store, and the JSON/Markdown report."""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from spf.evaluation.frames import ABSOLUTE_NORTH, CRAFT_RELATIVE, RADIO_FOLDED
+from spf.filters.labels import ds_fn_to_movement, result_to_frame
+from spf.filters.report import build_report, report_to_markdown, write_report
+from spf.filters.results_store import LocalResultsStore, make_results_store
+
+# A real merged v7 rover store name: <RX capture>.<TX capture>. The RX rover is
+# doing `bounce`, the TX rover `circle`, so the name contains BOTH words.
+MERGED_V7 = (
+    "/mnt/qnap01/mouse9911/rovers_2026/merged/"
+    "rover_2026_08_01_19_31_21_nRX2_bounce_spacing0p043_tag_RO3."
+    "rover_2026_08_01_19_54_32_nRX1_circle_spacing0p05075_tag_RO2.zarr"
+)
+WALL = "/mnt/md2/cache/nosig_data/wallarrayv3_2024_06_03_00_30_00_nRX2_rx_circle.zarr"
+
+
+# ------------------------------------------------------------------ labels
+
+
+def test_merged_v7_uses_the_recorded_routine_not_the_filename():
+    """The filename has both 'bounce' and 'circle'; only the yaml disambiguates."""
+    assert ds_fn_to_movement(MERGED_V7, routine="bounce") == "rover_bounce"
+
+
+def test_merged_v7_filename_alone_is_ambiguous():
+    """Documents why the routine is preferred: substring order decides, wrongly.
+
+    'bounce' is tested before 'circle', so the fallback happens to be right here
+    -- but it is right by token ordering, not by knowing which rover is the RX.
+    """
+    assert ds_fn_to_movement(MERGED_V7) == "rover_bounce"
+
+
+def test_wall_array_movement():
+    assert ds_fn_to_movement(WALL, routine="circle") == "2dwallarray_circle"
+
+
+def test_unknown_routine_falls_back_to_the_filename():
+    assert ds_fn_to_movement(WALL, routine="unknown") == "2dwallarray_circle"
+
+
+def test_random_circle_is_not_swallowed_by_circle():
+    name = "/data/rover_2025_01_01_random_circle_tag_RO1.zarr"
+    assert ds_fn_to_movement(name) == "rover_random_circle"
+
+
+def test_undeterminable_movement_raises():
+    with pytest.raises(ValueError):
+        ds_fn_to_movement("/data/something_unlabelled.zarr")
+
+
+@pytest.mark.parametrize(
+    "result,expected",
+    [
+        ({"type": "PF_single_theta_single_radio"}, RADIO_FOLDED),
+        ({"type": "EKF_single_theta_single_radio"}, RADIO_FOLDED),
+        ({"type": "PF_single_theta_dual_radio"}, CRAFT_RELATIVE),
+        ({"type": "EKF_XY_dual_radio"}, CRAFT_RELATIVE),
+        ({"type": "PF_single_theta_dual_radio_NN", "absolute": False}, CRAFT_RELATIVE),
+        ({"type": "PF_single_theta_dual_radio_NN", "absolute": True}, ABSOLUTE_NORTH),
+    ],
+)
+def test_frame_is_recovered_from_type_and_absolute(result, expected):
+    assert result_to_frame(result) == expected
+
+
+# ------------------------------------------------------------------- store
+
+
+def _result(ds_fn, _type, mse, **extra):
+    r = {
+        "type": _type,
+        "ds_fn": ds_fn,
+        "routine": "bounce",
+        "N": 4096,
+        "metrics": {"mse_craft_theta": mse, "runtime": 0.5},
+    }
+    r.update(extra)
+    return r
+
+
+def test_local_store_round_trip():
+    with tempfile.TemporaryDirectory() as d:
+        store = LocalResultsStore(d)
+        assert store.already_processed() == set()
+        key = "fn_run_PF/3.700/ds_x.zarr/_Nx4096_results.pkl"
+        store.put(key, [_result(MERGED_V7, "PF_single_theta_dual_radio", 1.5)])
+        assert store.already_processed() == {key}
+        assert os.path.exists(os.path.join(d, key))
+
+
+def test_local_store_leaves_no_partial_file_behind():
+    """Results are renamed into place, so a killed sweep cannot strand a .tmp."""
+    with tempfile.TemporaryDirectory() as d:
+        store = LocalResultsStore(d)
+        store.put("a/b/r.pkl", [_result(WALL, "PF_single_theta_dual_radio", 1.0)])
+        stragglers = [f for _, _, fs in os.walk(d) for f in fs if f.endswith(".tmp")]
+        assert stragglers == []
+
+
+def test_make_results_store_rejects_unknown_backend():
+    with pytest.raises(ValueError):
+        make_results_store("s3", "/tmp/x")
+
+
+def test_local_backend_needs_no_credentials():
+    """The whole point: a local sweep must not touch boto3 or the network."""
+    assert isinstance(make_results_store("local", "/tmp/x"), LocalResultsStore)
+
+
+# ------------------------------------------------------------------ report
+
+
+def test_report_groups_across_datasets_and_counts_runs():
+    with tempfile.TemporaryDirectory() as d:
+        store = LocalResultsStore(d)
+        for i, ds in enumerate([MERGED_V7, MERGED_V7.replace("19_31_21", "20_31_21")]):
+            store.put(
+                f"fn_run_PF/3.700/ds_{i}/_Nx4096_results.pkl",
+                [_result(ds, "PF_single_theta_dual_radio", 1.0 + i)],
+            )
+        report = build_report(d)
+        assert report["n_results"] == 2
+        # same hyperparameters on two datasets must land in ONE group
+        assert report["n_groups"] == 1
+        row = report["rows"][0]
+        assert row["n_runs"] == 2
+        assert row["frame"] == CRAFT_RELATIVE
+        assert row["movement"] == "rover_bounce"
+        assert abs(row["mse_craft_theta_mean"] - 1.5) < 1e-9
+
+
+def test_absolute_and_craft_relative_get_separate_rows():
+    """The trap: identical hyperparameters, different ground truth."""
+    with tempfile.TemporaryDirectory() as d:
+        store = LocalResultsStore(d)
+        store.put(
+            "fn_run_NN/3.700/ds_a/_absT_results.pkl",
+            [_result(MERGED_V7, "PF_single_theta_dual_radio_NN", 0.33, absolute=True)],
+        )
+        store.put(
+            "fn_run_NN/3.700/ds_a/_absF_results.pkl",
+            [_result(MERGED_V7, "PF_single_theta_dual_radio_NN", 1.89, absolute=False)],
+        )
+        report = build_report(d)
+        assert report["n_groups"] == 2
+        frames = {r["frame"] for r in report["rows"]}
+        assert frames == {ABSOLUTE_NORTH, CRAFT_RELATIVE}
+
+
+def test_write_report_emits_tracked_file_types():
+    """CSV is gitignored repo-wide; results must land as json + md to be committable."""
+    with tempfile.TemporaryDirectory() as d, tempfile.TemporaryDirectory() as out:
+        LocalResultsStore(d).put(
+            "fn_run_PF/3.700/ds_a/_r.pkl",
+            [_result(MERGED_V7, "PF_single_theta_dual_radio", 1.0)],
+        )
+        json_fn, md_fn = write_report(d, out)
+        assert json_fn.endswith("results.json") and os.path.exists(json_fn)
+        assert md_fn.endswith("REPORT.md") and os.path.exists(md_fn)
+        with open(json_fn) as f:
+            assert json.load(f)["n_results"] == 1
+        with open(md_fn) as f:
+            body = f.read()
+        assert "frame: `craft_relative`" in body
+
+
+def test_markdown_gives_each_frame_its_own_table():
+    rows = [
+        {"frame": CRAFT_RELATIVE, "N": 128, "mse_mean": 2.0, "n_runs": 1},
+        {"frame": ABSOLUTE_NORTH, "N": 128, "mse_mean": 0.5, "n_runs": 1},
+    ]
+    md = report_to_markdown(
+        {"workdir": "w", "n_results": 2, "n_groups": 2, "rows": rows}
+    )
+    assert md.count("## frame: `") == 2
+
+
+def test_empty_workdir_is_an_error_not_an_empty_report():
+    with tempfile.TemporaryDirectory() as d:
+        with pytest.raises(ValueError, match="no results"):
+            build_report(d)

--- a/tests/test_filter_sweep_smoke.py
+++ b/tests/test_filter_sweep_smoke.py
@@ -1,0 +1,167 @@
+"""End-to-end: config -> local sweep -> results store -> report.
+
+Guards the two defects that made a local run impossible:
+
+* ``run_filter_jobs(jobs)`` in ``__main__`` omitted the required ``nparallel``,
+  so invoking the runner directly raised TypeError before doing any work.
+* The runner wrote to DynamoDB behind a hard-coded ``use_file_system = False``
+  while ``run_filters_report.py`` read ``.pkl`` from the work dir, so the two
+  halves of the pipeline pointed at different sinks.
+
+Uses the tiny synthetic fixture, so it needs no /mnt access and no credentials.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+import yaml
+
+from spf.filters.report import build_report
+from spf.filters.run_filters_on_data import (
+    generate_configs_to_run,
+    run_filter_jobs,
+)
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _config(precompute_cache):
+    return {
+        "precompute_caches": {3.7: precompute_cache},
+        "runs": [
+            {
+                "run_EKF_single_theta_dual_radio": {
+                    "phi_std": [10.0],
+                    "p": [5.0],
+                    "noise_std": [0.001],
+                    "dynamic_R": [0.0],
+                    "segmentation_version": [3.7],
+                }
+            },
+            {
+                "run_PF_single_theta_dual_radio": {
+                    "N": [128],
+                    "theta_err": [0.01],
+                    "theta_dot_err": [0.01],
+                    "segmentation_version": [3.7],
+                }
+            },
+        ],
+    }
+
+
+def _run_sweep(noise1_n128_obits2, workdir, config_fn):
+    dirname, empirical_pkl_fn, ds_fn = noise1_n128_obits2
+    with open(config_fn, "w") as f:
+        yaml.safe_dump(_config(dirname), f)
+    jobs = generate_configs_to_run(
+        yaml_config_fn=config_fn,
+        work_dir=workdir,
+        dataset_fns=[ds_fn + ".zarr"],
+        seed=0,
+        empirical_pkl_fn=empirical_pkl_fn,
+    )
+    run_filter_jobs(jobs, nparallel=2, debug=True, results_backend="local")
+    return jobs
+
+
+def test_local_sweep_writes_results_the_reporter_can_read(noise1_n128_obits2):
+    with tempfile.TemporaryDirectory() as d:
+        workdir = os.path.join(d, "wd")
+        jobs = _run_sweep(noise1_n128_obits2, workdir, os.path.join(d, "c.yml"))
+        assert len(jobs) == 2
+
+        written = [
+            os.path.join(dp, f)
+            for dp, _, fs in os.walk(workdir)
+            for f in fs
+            if f.endswith(".pkl")
+        ]
+        assert len(written) == 2, written
+
+        report = build_report(workdir)
+        assert report["n_results"] >= 2
+        assert all("frame" in row for row in report["rows"])
+        # every run must carry a real error metric
+        for row in report["rows"]:
+            assert any(k.startswith("mse") and k.endswith("_mean") for k in row), row
+
+
+def test_sweep_is_resumable(noise1_n128_obits2):
+    """A second pass with the same work dir must skip everything already done."""
+    with tempfile.TemporaryDirectory() as d:
+        workdir = os.path.join(d, "wd")
+        config_fn = os.path.join(d, "c.yml")
+        _run_sweep(noise1_n128_obits2, workdir, config_fn)
+        before = {
+            os.path.join(dp, f): os.path.getmtime(os.path.join(dp, f))
+            for dp, _, fs in os.walk(workdir)
+            for f in fs
+        }
+
+        from spf.filters.results_store import LocalResultsStore
+
+        dirname, empirical_pkl_fn, ds_fn = noise1_n128_obits2
+        jobs = generate_configs_to_run(
+            yaml_config_fn=config_fn,
+            work_dir=workdir,
+            dataset_fns=[ds_fn + ".zarr"],
+            seed=0,
+            empirical_pkl_fn=empirical_pkl_fn,
+        )
+        run_filter_jobs(
+            jobs,
+            nparallel=2,
+            debug=True,
+            already_processed=LocalResultsStore(workdir).already_processed(),
+            results_backend="local",
+        )
+        after = {
+            os.path.join(dp, f): os.path.getmtime(os.path.join(dp, f))
+            for dp, _, fs in os.walk(workdir)
+            for f in fs
+        }
+        assert before == after, "resumed sweep rewrote already-finished results"
+
+
+def test_runner_main_accepts_its_own_arguments(noise1_n128_obits2):
+    """`run_filter_jobs(jobs)` in __main__ used to raise TypeError immediately."""
+    dirname, empirical_pkl_fn, ds_fn = noise1_n128_obits2
+    with tempfile.TemporaryDirectory() as d:
+        config_fn = os.path.join(d, "c.yml")
+        with open(config_fn, "w") as f:
+            yaml.safe_dump(_config(dirname), f)
+        proc = subprocess.run(
+            [
+                sys.executable,
+                os.path.join(REPO, "spf", "filters", "run_filters_on_data.py"),
+                "-d",
+                ds_fn + ".zarr",
+                "--empirical-pkl-fn",
+                empirical_pkl_fn,
+                "--work-dir",
+                os.path.join(d, "wd"),
+                "--config",
+                config_fn,
+                "--results-backend",
+                "local",
+                "--parallel",
+                "2",
+                "--debug",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=900,
+            cwd=REPO,
+        )
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "TypeError" not in proc.stderr
+        produced = [
+            f
+            for _, _, fs in os.walk(os.path.join(d, "wd"))
+            for f in fs
+            if f.endswith(".pkl")
+        ]
+        assert len(produced) == 2, proc.stdout + proc.stderr

--- a/tests/test_plot_filter_run.py
+++ b/tests/test_plot_filter_run.py
@@ -1,0 +1,82 @@
+"""The unified filter visualiser.
+
+Smoke-level on purpose: assert the figure has the panels it claims and that the
+summary block is finite and frame-tagged. Pixel comparison would be brittle and
+would not catch anything a human reading the figure wouldn't.
+"""
+
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+
+from spf.evaluation.frames import CRAFT_RELATIVE, RADIO_FOLDED
+from spf.filters.plot_filter_run import (
+    open_dataset,
+    plot_filter_run,
+    run_filter,
+    summarize_run,
+)
+from spf.utils import SEGMENTATION_VERSION
+
+# empirical families only: the NN ones need a trained checkpoint fixture, which
+# costs ~11 minutes to build and exercises no plotting code the others don't.
+EMPIRICAL_FILTERS = [
+    ("pf_dual", {"N": 512, "theta_err": 0.01, "theta_dot_err": 0.01}, CRAFT_RELATIVE),
+    ("pf_single", {"N": 512, "theta_err": 0.01, "theta_dot_err": 0.01}, RADIO_FOLDED),
+    ("ekf_dual", {"phi_std": 10.0, "p": 5.0, "noise_std": 0.001}, CRAFT_RELATIVE),
+    ("ekf_single", {"phi_std": 10.0, "p": 5.0, "noise_std": 0.001}, RADIO_FOLDED),
+]
+
+
+@pytest.fixture(scope="module")
+def ds(noise1_n128_obits2):
+    dirname, empirical_pkl_fn, ds_fn = noise1_n128_obits2
+    # the fixture segments at the default version; track the constant rather
+    # than hardcode, so bumping SEGMENTATION_VERSION does not silently break this
+    return open_dataset(
+        ds_fn, dirname, empirical_pkl_fn, segmentation_version=SEGMENTATION_VERSION
+    )
+
+
+@pytest.mark.parametrize("name,params,expected_frame", EMPIRICAL_FILTERS)
+def test_each_family_produces_a_figure_and_a_summary(ds, name, params, expected_frame):
+    theta, sigma, gt, extras = run_filter(ds, name, dict(params))
+
+    assert extras["frame"] == expected_frame
+    assert theta.shape == sigma.shape == gt.shape
+    assert np.isfinite(theta).all()
+
+    fig = plot_filter_run(ds, theta, sigma, gt, extras, f"{name} test")
+    # 4 panels without a posterior, 5 with
+    assert len(fig.axes) == 4
+    matplotlib.pyplot.close(fig)
+
+    summary = summarize_run(theta, sigma, gt)
+    assert summary["n"] == theta.shape[0]
+    assert np.isfinite(summary["mse"]) and summary["mse"] >= 0
+    assert np.isclose(summary["rmse_deg"], np.degrees(summary["rmse_rad"]))
+    # coverage is REPORTED, not gated -- only that it is a well-formed fraction
+    for row in summary["coverage"]:
+        assert 0.0 <= row["measured"] <= 1.0
+        assert row["k"] in (1, 2, 3)
+
+
+def test_unknown_filter_name_is_rejected(ds):
+    with pytest.raises(ValueError, match="unknown filter"):
+        run_filter(ds, "kalman_deluxe", {})
+
+
+def test_unused_params_are_rejected_not_silently_ignored(ds):
+    """A typo'd hyperparameter must fail loudly, or a sweep silently runs defaults."""
+    with pytest.raises(ValueError, match="unused params"):
+        run_filter(ds, "pf_dual", {"N": 512, "theta_er": 0.01})
+
+
+def test_seed_is_honoured_end_to_end(ds):
+    a, _, _, _ = run_filter(ds, "pf_dual", {"N": 512, "seed": 0})
+    b, _, _, _ = run_filter(ds, "pf_dual", {"N": 512, "seed": 0})
+    c, _, _, _ = run_filter(ds, "pf_dual", {"N": 512, "seed": 1})
+    np.testing.assert_array_equal(a, b)
+    assert not np.array_equal(a, c)


### PR DESCRIPTION
**Bookkeeping fix, no new code.** [#22](https://github.com/misko/spf/pull/22) and [#23](https://github.com/misko/spf/pull/23) were both merged — but into their *base branches*, not `main`.

The three PRs merged 54 seconds apart, faster than GitHub's automatic base-retargeting, which only fires when a base branch is deleted after its own merge. So the stack landed like this:

```
main                     e0f7735   <- #21 only
  evaluation-metrics     7397d56   <- #22 merged HERE
    filters-local-runner 46320d3   <- #23 merged HERE
```

`filters-local-runner` now contains both. This PR brings them to `main` in one merge. **Zero conflicts** against current `main`.

## Contents (already reviewed as #22 and #23)

**Change 3 — local sweep possible.** `results_store.py` puts the local and DynamoDB sinks behind one interface with local as the default and boto3 imported lazily; fixes the missing `nparallel` in `__main__`, the `b2://`-only checkpoint assumption that made local checkpoints unusable, and the dead `spf.scripts` imports in both cloud drivers. `labels.py` prefers the recorded `routine` over filename substrings — a merged v7 store is `<RX>.<TX>` and contains both routine words, so every merged rover store was being labelled `circle` when its RX routine was `bounce`. `report.py` emits `results.json` + `REPORT.md`, since `.gitignore` matches `**/*.csv` repo-wide and a CSV result can never be committed.

**Change 4 — visualiser, configs, experiment.** `plot_filter_run.py` gives every filter family the same five panels, scored through `spf.evaluation`. Three sweep configs at 8 / 348 / 348 jobs per dataset against the shipped 5,926. `experiments/e_inf1_filter_sweep/` pre-registers H1–H4 with decision rules.

+1761 / −79 across 19 files. Full filter suite was green at **104 passed / 1 xfailed** on change 3, plus 7 plotter tests on change 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)