### PR TITLE
Promote hardware-qualified gain-series v4 RC12

### DIFF
--- a/data_collection/rover/rover_v3.1/capture_configs/rover1_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover1_production_v7.yaml
@@ -16,13 +16,13 @@ distance-finder:
 boundary: auto
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Persist in mtd3; boot preparation only reflashes when the active image differs.
   boot-mode: qspi
 

--- a/data_collection/rover/rover_v3.1/capture_configs/rover2_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover2_production_v7.yaml
@@ -16,13 +16,13 @@ distance-finder:
 boundary: auto
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Persist in mtd3; boot preparation only reflashes when the active image differs.
   boot-mode: qspi
 

--- a/data_collection/rover/rover_v3.1/capture_configs/rover3_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover3_production_v7.yaml
@@ -16,13 +16,13 @@ distance-finder:
 boundary: auto
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Persist in mtd3; boot preparation only reflashes when the active image differs.
   boot-mode: qspi
 

--- a/data_collection/rover/rover_v3.1/capture_configs/rover4_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover4_production_v7.yaml
@@ -21,13 +21,13 @@ distance-finder:
 boundary: auto
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Persist in mtd3; boot preparation only reflashes when the active image differs.
   boot-mode: qspi
 

--- a/data_collection/rover/rover_v3.1/prepare_direct_usb_boot.sh
+++ b/data_collection/rover/rover_v3.1/prepare_direct_usb_boot.sh
@@ -13,6 +13,7 @@ readonly MAPPING_SCRIPT="${SCRIPT_DIR}/device_mapping.sh"
 readonly RADIO_MISSING_HANDLER="${SCRIPT_DIR}/radio_missing_shutdown.sh"
 readonly READY_FILE="${SPF_DIRECT_USB_READY_FILE:-/run/spf/direct_usb_ready.json}"
 readonly READY_DIR="$(dirname -- "$READY_FILE")"
+readonly TX_MUTE_FILE="${SPF_PLUTO_TX_MUTE_FILE:-/run/spf/pluto_tx_mute.json}"
 
 FIRMWARE_CACHE="${SPF_FIRMWARE_CACHE_DIR:-/home/pi/.cache/spf/firmware}"
 FIRMWARE_STATE="${SPF_FIRMWARE_STATE_DIR:-/var/lib/spf/pluto-firmware}"
@@ -40,7 +41,7 @@ is_true() {
 # Readiness is session-bound. Invalidate it before any operation that can fail,
 # including configuration parsing, so stale firmware/fingerprint state can
 # never authorize capture after a reboot or interrupted firmware operation.
-rm -f -- "$READY_FILE"
+rm -f -- "$READY_FILE" "$TX_MUTE_FILE"
 
 if is_true "$DISABLE_DIRECT_USB"; then
     printf '%s\n' \
@@ -164,6 +165,17 @@ else
     # shared-IP ssh race.
     export SPF_PLUTO_SKIP_SSH_VERIFY=1
 fi
+
+# A Pluto boot restores the AD9361 TX attenuation defaults even when no TX DMA
+# or DDS waveform is active. Reassert the rover's fail-closed state after every
+# RAM/QSPI transition and before publishing any readiness evidence. The helper
+# independently attempts TX1 attenuation, TX2 attenuation, DDS disable, channel
+# disable and TX-buffer destruction, then verifies both attenuation readbacks.
+# Any failure leaves READY_FILE absent and blocks mavlink_controller.service.
+mkdir -p "$(dirname -- "$TX_MUTE_FILE")"
+"$PYTHON" -m spf.scripts.mute_pluto_tx \
+    --expected-count "$attached_radios" \
+    --output "$TX_MUTE_FILE"
 
 # USB-IIO URIs contain the post-enumeration USB device address, so mapping must
 # be regenerated only after every radio reaches its final booted state.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/all_gain_cross_2p4.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/all_gain_cross_2p4.yaml
@@ -15,13 +15,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/coarse_5ghz.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/coarse_5ghz.yaml
@@ -3,13 +3,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_arm2_rfdc_tracking.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_arm2_rfdc_tracking.yaml
@@ -38,13 +38,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   boot-mode: qspi
 
 calibration:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_rfdc_discriminator.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_rfdc_discriminator.yaml
@@ -38,13 +38,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   boot-mode: qspi
 
 calibration:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_cal5_positive_control.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_cal5_positive_control.yaml
@@ -1,12 +1,12 @@
 data-version: 7
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   boot-mode: qspi
 calibration:
   frequencies-hz:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_gsp7_conditioned_comb.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_gsp7_conditioned_comb.yaml
@@ -1,12 +1,12 @@
 data-version: 7
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   boot-mode: qspi
 calibration:
   frequencies-hz:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/frequency_scout_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/frequency_scout_cross_band.yaml
@@ -7,13 +7,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/historical_exact_lo_cross_2p4.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/historical_exact_lo_cross_2p4.yaml
@@ -7,13 +7,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/integer_gain_cross_2p4.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/integer_gain_cross_2p4.yaml
@@ -12,13 +12,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/pilot_5ghz.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/pilot_5ghz.yaml
@@ -3,13 +3,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/pilot_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/pilot_cross_band.yaml
@@ -6,13 +6,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/power_cycle_subsample.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/power_cycle_subsample.yaml
@@ -7,13 +7,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/spectroscopy_campaign_base.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/spectroscopy_campaign_base.yaml
@@ -3,13 +3,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/survey_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/survey_cross_band.yaml
@@ -7,13 +7,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/wide_integer_gain_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/wide_integer_gain_cross_band.yaml
@@ -9,13 +9,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/tests/radio_hardware/reports/gain_series_v4_rc12_20260810.md
+++ b/tests/radio_hardware/reports/gain_series_v4_rc12_20260810.md
@@ -4,8 +4,7 @@
 
 **PASS for direct USB and bounded one-frame direct IP — RC12 completed the
 two-radio RAM-boot promotion campaign. Continuous multi-frame direct IP is
-rate-limited as documented below and is not qualified at the rover's 3 MS/s
-rate.**
+rate-limited as documented below and is not qualified above 1 MS/s.**
 
 RC12 retains RC11's gain-series, timestamp, USB-startup, and TX fixes and
 hardens the direct-IP control socket against malformed UDP datagrams. The
@@ -179,8 +178,10 @@ The bounded one-frame path was stable:
 
 Continuous finite streaming exposed a transport-rate boundary hidden by the
 original one-frame IP gate. The default 1,472-byte UDP mode deliberately sends
-eight datagrams and then waits 1 ms, or roughly 11.8 MB/s before protocol
-overhead. Dual-channel CS16 requires eight bytes per time sample:
+eight datagrams and then waits 1 ms, or roughly 11.4 MB/s of inner-frame
+payload before lower-layer overhead. Dual-channel CS16 requires eight bytes
+per time sample. This ladder used the hardware test's configured sample rate;
+it was not a reproduction of a production rover configuration:
 
 | Radio sample rate | IQ payload rate | 16 contiguous frames |
 |---:|---:|---|
@@ -191,11 +192,20 @@ overhead. Dual-channel CS16 requires eight bytes per time sample:
 | 1.75–3.0 MS/s | 14.0–24.0 MB/s | Fail closed: sample-sequence gap |
 
 At 1.0 MS/s, a longer 200-START burn-in returned 3,200/3,200 contiguous
-frames, 400 MiB of IQ, with zero failures in 92.9 seconds. At the rover's
-3 MS/s rate, increasing the requested UDP datagram size from 1,472 through
-8,192 bytes did not prevent sequence gaps. Sizes from 16,384 through 65,507
-bytes instead produced whole-frame timeouts, so relying on IP fragmentation is
-not a safe workaround.
+frames, 400 MiB of IQ, with zero failures in 92.9 seconds. At the hardware
+test's 3 MS/s rate, increasing the requested UDP datagram size from 1,472
+through 8,192 bytes did not prevent sequence gaps. Sizes from 16,384 through
+65,507 bytes instead produced whole-frame timeouts, so relying on IP
+fragmentation is not a safe workaround.
+
+The canonical rover production YAMLs configure 30 MS/s, a 524,288-sample
+frame, and one direct frame per request. That is a finite 17.5 ms RF snapshot,
+not a continuous 30 MS/s transport: dual-channel CS16 at 30 MS/s would require
+240 MB/s and cannot fit through either USB 2.0 or 1 GbE. The 1,000-cycle
+one-frame burn-in included a radio booted at 30.72 MS/s and therefore remains
+representative of the bounded production request pattern. Matching direct USB
+means buffering and draining finite snapshots reliably; it does not mean
+claiming an impossible continuous 240 MB/s stream.
 
 Debug output establishes the failure mechanism. While an IP frame is paced to
 the host, DMA and the FPGA sample counter continue advancing. The next queued
@@ -222,10 +232,11 @@ Evidence remains in `/tmp/spf-rc12-ip-burnin-20260810` on the hardware host:
 ## Promotion recommendation
 
 Publish and pin only the exact DFU identified above for the qualified direct-USB
-path. Retain the previous production release and hash as rollback. Do not claim
-continuous direct-IP parity at the rover's 3 MS/s rate; use one-frame bounded
-IP requests or at most the demonstrated 1 MS/s continuous mode until the IP
-transport advertises and enforces a safe rate or is redesigned to avoid stale
-DMA blocks. After SPF CI passes, perform a controlled one-radio QSPI canary,
-reboot it from QSPI, run the V7/USB/TX gates plus the bounded IP gate, and only
-then roll the same bytes to the remaining radios.
+path. Retain the previous production release and hash as rollback. Use
+one-frame bounded IP requests for the current 30 MS/s finite-snapshot pattern,
+or at most the demonstrated 1 MS/s mode when contiguous multi-frame IP is
+required, until the IP transport gains a buffered producer/consumer design and
+an explicit sustained-rate capability. After SPF CI passes, perform a
+controlled one-radio QSPI canary, reboot it from QSPI, run the V7/USB/TX gates
+plus the bounded IP gate, and only then roll the same bytes to the remaining
+radios.

--- a/tests/radio_hardware/reports/gain_series_v4_rc12_20260810.md
+++ b/tests/radio_hardware/reports/gain_series_v4_rc12_20260810.md
@@ -2,7 +2,10 @@
 
 ## Disposition
 
-**PASS — RC12 completed the two-radio RAM-boot promotion campaign.**
+**PASS for direct USB and bounded one-frame direct IP — RC12 completed the
+two-radio RAM-boot promotion campaign. Continuous multi-frame direct IP is
+rate-limited as documented below and is not qualified at the rover's 3 MS/s
+rate.**
 
 RC12 retains RC11's gain-series, timestamp, USB-startup, and TX fixes and
 hardens the direct-IP control socket against malformed UDP datagrams. The
@@ -156,9 +159,73 @@ Both then reported gadget SHA
 `2072e1d0823ef6db3bc141dd733a90d76e23fc33`, TX1/TX2 at `-80 dB`, and passed
 the production baseline 6/6.
 
+## Extended direct-IP burn-in
+
+An additional RAM-only campaign exercised the uniquely routed LAN radio after
+the initial promotion gate. It injected malformed control datagrams throughout,
+validated every CRC-backed protocol-v3 frame and gain-observation series, and
+restored both radios to their unchanged QSPI image afterward.
+
+The bounded one-frame path was stable:
+
+- 1,000 fresh START/STOP cycles passed with 1,000 unique stream IDs;
+- mixed frame sizes were 16,384, 32,768, 131,072, and 524,288 samples/channel;
+- 1,409,024,000 IQ bytes (1.312 GiB) were validated in 340.0 seconds;
+- all 600 injected malformed control datagrams were survived;
+- duplicate fragments, expired frames, rejected frames, sequence regressions,
+  metadata errors, and daemon deaths were all zero;
+- median/max time-anchor round trip was 0.527/3.603 ms; and
+- median/max local gain-read duration was 0.384/12.564 ms.
+
+Continuous finite streaming exposed a transport-rate boundary hidden by the
+original one-frame IP gate. The default 1,472-byte UDP mode deliberately sends
+eight datagrams and then waits 1 ms, or roughly 11.8 MB/s before protocol
+overhead. Dual-channel CS16 requires eight bytes per time sample:
+
+| Radio sample rate | IQ payload rate | 16 contiguous frames |
+|---:|---:|---|
+| 1.0 MS/s | 8.0 MB/s | Pass |
+| 1.2 MS/s | 9.6 MB/s | Fail closed: sample-sequence gap |
+| 1.4 MS/s | 11.2 MB/s | Fail closed: sample-sequence gap |
+| 1.5 MS/s | 12.0 MB/s | Fail closed: sample-sequence gap |
+| 1.75–3.0 MS/s | 14.0–24.0 MB/s | Fail closed: sample-sequence gap |
+
+At 1.0 MS/s, a longer 200-START burn-in returned 3,200/3,200 contiguous
+frames, 400 MiB of IQ, with zero failures in 92.9 seconds. At the rover's
+3 MS/s rate, increasing the requested UDP datagram size from 1,472 through
+8,192 bytes did not prevent sequence gaps. Sizes from 16,384 through 65,507
+bytes instead produced whole-frame timeouts, so relying on IP fragmentation is
+not a safe workaround.
+
+Debug output establishes the failure mechanism. While an IP frame is paced to
+the host, DMA and the FPGA sample counter continue advancing. The next queued
+DMA block can then predate all retained gain observations. The v3 worker
+correctly refuses that IQ because it cannot associate the required gain series;
+the host independently rejects any resulting sample discontinuity. The gadget
+currently advertises up to 16 finite frames without advertising a rate limit,
+so host-side capability discovery alone cannot predict this boundary.
+
+Evidence remains in `/tmp/spf-rc12-ip-burnin-20260810` on the hardware host:
+
+- one-frame burn-in SHA-256:
+  `fe229da26e4f224961c123591501edc7b37cc842cbb605fb7b52fb0c3b3cbce0`;
+- 1 MS/s continuous burn-in SHA-256:
+  `7b43324bb70b004cf42ba04b99449a6d52f6a000dd5603643f327b1451df44e0`;
+- sample-rate ladder SHA-256:
+  `ae426ed962931b033c2afd99092b0572404713c52944cf701f09959ce6a59c50`;
+- datagram-size ladder SHA-256:
+  `3c0e41948ba49b2e2ef63a94aad100fe7534fc78338f8b5ea18a60746096b50a`;
+  and
+- on-radio debug trace SHA-256:
+  `583e3b804094d91aefb37b28c4ea8fae1f4be3fd948c9fc93f176506719c7fae`.
+
 ## Promotion recommendation
 
-Publish and pin only the exact DFU identified above. Retain the previous
-production release and hash as rollback. After SPF CI passes, perform a
-controlled one-radio QSPI canary, reboot it from QSPI, run the V7/IP/TX gates,
-and only then roll the same bytes to the remaining radios.
+Publish and pin only the exact DFU identified above for the qualified direct-USB
+path. Retain the previous production release and hash as rollback. Do not claim
+continuous direct-IP parity at the rover's 3 MS/s rate; use one-frame bounded
+IP requests or at most the demonstrated 1 MS/s continuous mode until the IP
+transport advertises and enforces a safe rate or is redesigned to avoid stale
+DMA blocks. After SPF CI passes, perform a controlled one-radio QSPI canary,
+reboot it from QSPI, run the V7/USB/TX gates plus the bounded IP gate, and only
+then roll the same bytes to the remaining radios.

--- a/tests/radio_hardware/reports/gain_series_v4_rc12_20260810.md
+++ b/tests/radio_hardware/reports/gain_series_v4_rc12_20260810.md
@@ -1,0 +1,164 @@
+# Gain-series v4 RC12 hardware gate — 2026-08-10
+
+## Disposition
+
+**PASS — RC12 completed the two-radio RAM-boot promotion campaign.**
+
+RC12 retains RC11's gain-series, timestamp, USB-startup, and TX fixes and
+hardens the direct-IP control socket against malformed UDP datagrams. The
+exact candidate passed three independent two-radio RAM boots, physical TX2
+loopback on both radios after every boot, protocol-v2 compatibility,
+protocol-v3 USB stress, simultaneous USB, a 100-record-per-radio V7 round
+trip, malformed direct-IP traffic, and a real direct-IP frame.
+
+The candidate was loaded only into volatile RAM. Both radios were restored to
+the preserved QSPI production firmware after testing and passed the production
+direct-USB baseline again.
+
+## Candidate identity
+
+- Firmware main commit: `fa5f95f0af2a0586c80b54eff7ae04512cb96f7f`
+- USB gadget commit: `e14eae63ac6b7fe51828e85de34a8d4e1c50d49e`
+- Direct-IP gadget commit: `e44821f6d2737e3cdf452a017787f11c451fe04e`
+- Buildroot commit: `950b336d3a933c3f56ecd4ec20266502c775cf54`
+- HDL commit: `5360aeac83013e8e3aa0b5d4e0a9b32280fe1677`
+- HDL Quantulum commit: `55803cd3d7f74dccd7bf43dc713f832d1eeaf2e6`
+- Linux commit: `d798b0d821b85ebd51ecffbfa68d8e4d69b77132`
+- U-Boot commit: `1ff0468e9bea29b0a768a7bf52db8d025c521b9a`
+- GitHub Actions run: [31342525077](https://github.com/misko/plutosdr-fw/actions/runs/31342525077)
+- Artifact: `plutoplus-main-fa5f95f0af2a0586c80b54eff7ae04512cb96f7f-31342525077-1`
+- Bundle: `plutoplus-spf-main-fa5f95f0af2a.tar.gz`
+- Bundle SHA-256: `34264a491a387cd82aba178428069bf66b0b1ec67c28ba886f2627d77c67a457`
+- DFU: `plutoplus-spf-main-fa5f95f0af2a-pluto.dfu`
+- DFU SHA-256: `2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4`
+- Packaged device-fw: `v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9`
+- Tested boot mode: volatile DFU/RAM only
+
+The public Kalman build and GitHub's independent verification/attestation job
+both passed. A fresh download passed its adjacent bundle checksum, every entry
+in `SHA256SUMS`, and every entry in `PAYLOAD_SHA256SUMS`.
+
+Routed timing passed with setup WNS `+0.504 ns`, hold WHS `+0.014 ns`, and
+zero failing setup, hold, or pulse-width endpoints.
+
+## RC11 persistent-canary findings
+
+RC11 had passed the original RAM-only release campaign. A subsequent
+persistent-QSPI canary exposed two additional operational issues before fleet
+promotion:
+
+1. A Pluto reboot restored both TX hardware-gain readbacks to `-10 dB`. No DDS
+   or DMA waveform was active, so this was not observed RF emission, but it was
+   not a fail-closed boot state. SPF now removes stale mute evidence and runs
+   `spf.scripts.mute_pluto_tx` after every RAM/QSPI transition and before
+   publishing rover readiness. A mute failure leaves readiness absent and
+   blocks collection.
+2. A four-byte unknown UDP control datagram caused RC11's `sdr_ip_gadget` to
+   return a fatal epoll-handler result and terminate. RC12 classifies control
+   envelopes before legacy parsing and silently drops undersized or unknown
+   datagrams. Native tests cover null, short, legacy, protocol-v3, time-anchor,
+   and unknown envelopes.
+
+An earlier manual direct-IP timeout was separately traced to a stale DHCP
+address: the LAN radio moved from `192.168.1.179` to `192.168.1.181` after a
+reboot. The automated campaign resolves the candidate address from the radio's
+USB serial and successfully followed it to `192.168.1.163`. IP address is never
+treated as radio identity.
+
+## Bench fixture
+
+Each radio had TX2 routed through the declared 30 dB attenuated splitter path
+to that radio's RX1 and RX2. Tests activate one TX2 at a time, hold TX1 at
+`-80 dB`, and verify both transmitters at `-80 dB` after every stage.
+
+| Radio serial | USB physical path | Additional transport |
+|---|---|---|
+| `104000bac4950008230026001b440a003a` | `1-1.1` | USB IIO and direct USB |
+| `1040007c4a94000211000b009186843ef2` | `1-1.2` | USB IIO, direct USB, and LAN direct IP |
+
+## Promotion gates
+
+Campaign root:
+
+`/tmp/spf-gain-series-v4-rc12-20260810T000826Z-hardware`
+
+| Gate | Result |
+|---|---|
+| Production protocol-v2 baseline | 6 passed |
+| Persistent AD9361/2R2T configuration | Both serials passed |
+| Shared-hub RC12 RAM loads | 3/3 epochs passed |
+| Immediate post-boot TX mute | Both radios, all epochs passed |
+| Internal cyclic TX through timestamp FIFO | Both radios, all epochs passed |
+| External TX2 loopback and live gain series | Both radios, all epochs passed |
+| Explicit post-TX mute | Both radios, all epochs passed |
+| Protocol-v2 compatibility at 524,288 samples | 6 passed |
+| Protocol-v3 USB | Passed on both radios |
+| Fresh protocol-v3 START stress | 100 streams/radio, 600 frames total passed |
+| Simultaneous protocol-v3 USB | Passed |
+| Production-sized V7 Zarr | 100 records/radio written and reopened |
+| Malformed direct-IP datagrams | Lengths 0, 1, 3, 4, 4, and 80 survived |
+| Protocol-v3 direct-IP frame | Passed; 162 gain observations |
+| Post-rollback production baseline | 6 passed |
+| Final TX state | TX1/TX2 `-80 dB` on both radios |
+
+The repeated-start evidence SHA-256 is
+`bfdcdbab3419fcd39ac94a5c46edf27156777378f8c7a8e4683ad5ef45d25db0`.
+The malformed-IP evidence SHA-256 is
+`9059c9e60ee49d102abde228b3b29d2c6ded2686fde53422fe06a52839b318f8`.
+The real direct-IP frame evidence SHA-256 is
+`b65fbda3d0a6d181627829e8fa2bc3858ec15a6c4def60e9714d6658dcacaa1c`.
+
+## TX measurements
+
+All six radio/epoch measurements passed frequency, SNR, clipping, coherence,
+phase stability, manual-gain metadata, slow-attack response, and mute checks.
+
+| Epoch | Radio | RX1/RX2 tone (dBFS) | Coherence | Phase std | AGC reduction RX1/RX2 | Mute delta RX1/RX2 |
+|---:|---|---|---:|---:|---|---|
+| 1 | `…0a003a` | `-41.54/-27.33` | `0.9999903` | `0.111°` | `29/29 dB` | `76.1/76.0 dB` |
+| 1 | `…843ef2` | `-41.48/-27.88` | `0.9999992` | `0.030°` | `28/28 dB` | `83.9/96.8 dB` |
+| 2 | `…0a003a` | `-41.52/-27.29` | `0.9999992` | `0.023°` | `29/29 dB` | `84.4/68.6 dB` |
+| 2 | `…843ef2` | `-41.41/-27.84` | `0.9999971` | `0.076°` | `28/28 dB` | `77.6/98.0 dB` |
+| 3 | `…0a003a` | `-41.51/-27.30` | `0.9999877` | `0.149°` | `29/29 dB` | `77.3/79.9 dB` |
+| 3 | `…843ef2` | `-41.48/-27.84` | `0.9999992` | `0.028°` | `28/28 dB` | `81.6/89.5 dB` |
+
+## Timing and gain-series evidence
+
+The requested gain observation interval was 2,048 samples. The ARM/SPI reads
+remain best-effort and their actual FPGA sample-counter bounds are
+authoritative; this does not claim sample-exact CTRL_OUT event capture.
+
+- Sequential USB sample-time uncertainty: at most `0.456 ms` in the smoke run.
+- Simultaneous USB sample-time uncertainty: at most `0.509 ms`.
+- Direct-IP sample-time uncertainty: `0.374 ms`.
+- Direct-IP 524,288-sample frame: 162 valid gain observations.
+
+All timing results remain below the 5 ms promotion threshold. Host realtime is
+not asserted to be GNSS-synchronized UTC.
+
+## Recovery and automation corrections
+
+The candidate runner now:
+
+- mutes all attached radios before testing, immediately after every RAM boot,
+  after each TX stage, and on every exit—including receive-only failures;
+- executes the malformed-IP survival test before normal direct-IP capture; and
+- prints a rollback command containing the exact candidate image, SHA, serial
+  count, and campaign-specific state root.
+
+The original generic rollback wrapper correctly refused to guess when its
+default directory contained multiple historical state records. Using the
+campaign-specific state root restored both radios to:
+
+`v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d`
+
+Both then reported gadget SHA
+`2072e1d0823ef6db3bc141dd733a90d76e23fc33`, TX1/TX2 at `-80 dB`, and passed
+the production baseline 6/6.
+
+## Promotion recommendation
+
+Publish and pin only the exact DFU identified above. Retain the previous
+production release and hash as rollback. After SPF CI passes, perform a
+controlled one-radio QSPI canary, reboot it from QSPI, run the V7/IP/TX gates,
+and only then roll the same bytes to the remaining radios.

--- a/tests/radio_hardware/run_gain_series_v3_candidate.sh
+++ b/tests/radio_hardware/run_gain_series_v3_candidate.sh
@@ -163,19 +163,17 @@ trap rollback_hint ERR
 
 mute_tx_on_exit() {
     local rc=$?
-    if [[ "$WITH_TX_LOOPBACK" -eq 1 ]]; then
-        set +e
-        "$PYTHON" -m spf.scripts.mute_pluto_tx \
-            --expected-count "$EXPECTED_RADIOS" \
-            --output "${REPORT_ROOT}/tx-mute-on-exit.json" \
-            >>"${REPORT_ROOT}/tx-mute-on-exit.log" 2>&1
-        local mute_rc=$?
-        set -e
-        if [[ "$mute_rc" -ne 0 ]]; then
-            printf 'ERROR: final TX mute verification failed; inspect %s\n' \
-                "${REPORT_ROOT}/tx-mute-on-exit.log" >&2
-            [[ "$rc" -ne 0 ]] || rc="$mute_rc"
-        fi
+    set +e
+    "$PYTHON" -m spf.scripts.mute_pluto_tx \
+        --expected-count "$EXPECTED_RADIOS" \
+        --output "${REPORT_ROOT}/tx-mute-on-exit.json" \
+        >>"${REPORT_ROOT}/tx-mute-on-exit.log" 2>&1
+    local mute_rc=$?
+    set -e
+    if [[ "$mute_rc" -ne 0 ]]; then
+        printf 'ERROR: final TX mute verification failed; inspect %s\n' \
+            "${REPORT_ROOT}/tx-mute-on-exit.log" >&2
+        [[ "$rc" -ne 0 ]] || rc="$mute_rc"
     fi
     trap - EXIT
     exit "$rc"
@@ -197,12 +195,10 @@ printf 'image=%s\nsha256=%s\nexpected_radios=%s\nreport_root=%s\nwith_tx_loopbac
     "$STARTUP_STRESS_CYCLES"
 run_logged iio-before iio_info -s
 
-if [[ "$WITH_TX_LOOPBACK" -eq 1 ]]; then
-    run_logged pre-campaign-tx-mute \
-        "$PYTHON" -m spf.scripts.mute_pluto_tx \
-        --expected-count "$EXPECTED_RADIOS" \
-        --output "${REPORT_ROOT}/pre-campaign-tx-mute.json"
-fi
+run_logged pre-campaign-tx-mute \
+    "$PYTHON" -m spf.scripts.mute_pluto_tx \
+    --expected-count "$EXPECTED_RADIOS" \
+    --output "${REPORT_ROOT}/pre-campaign-tx-mute.json"
 
 run_logged baseline-v2 \
     "$PYTHON" -m pytest -q "$BASELINE_TEST" \
@@ -224,6 +220,10 @@ if [[ "$WITH_TX_LOOPBACK" -eq 1 ]]; then
         run_logged "ram-load-epoch-${epoch}" \
             sudo -n "$PYTHON" "$MULTI_LOADER" load-all \
             "${common_loader_args[@]}"
+        run_logged "post-load-tx-mute-epoch-${epoch}" \
+            "$PYTHON" -m spf.scripts.mute_pluto_tx \
+            --expected-count "$EXPECTED_RADIOS" \
+            --output "${REPORT_ROOT}/post-load-tx-mute-epoch-${epoch}.json"
         run_logged "iio-after-ram-load-epoch-${epoch}" iio_info -s
         run_logged "candidate-v3-tx2-loopback-epoch-${epoch}" \
             "$PYTHON" -m pytest -q "$TX_TEST_FILE" \
@@ -244,6 +244,10 @@ else
     run_logged ram-load \
         sudo -n "$PYTHON" "$MULTI_LOADER" load-all \
         "${common_loader_args[@]}"
+    run_logged post-load-tx-mute \
+        "$PYTHON" -m spf.scripts.mute_pluto_tx \
+        --expected-count "$EXPECTED_RADIOS" \
+        --output "${REPORT_ROOT}/post-load-tx-mute.json"
     run_logged iio-after-ram-load iio_info -s
 fi
 
@@ -300,6 +304,7 @@ if [[ -n "$DIRECT_IP_HOST" ]]; then
         "$DIRECT_IP_HOST" "$resolved_direct_ip_host" "$direct_ip_serial"
     run_logged candidate-v3-direct-ip \
         "$PYTHON" -m pytest -q \
+        "${TEST_FILE}::test_v3_direct_ip_survives_malformed_control_datagrams" \
         "${TEST_FILE}::test_v3_direct_ip_uses_the_same_inner_frame" \
         --radio-hardware \
         --radio-gain-series-v3 \

--- a/tests/radio_hardware/run_gain_series_v3_candidate.sh
+++ b/tests/radio_hardware/run_gain_series_v3_candidate.sh
@@ -2,12 +2,11 @@
 # RAM-boot acceptance campaign for an unreleased protocol-v3 DFU.  TX remains
 # fail-closed unless the operator explicitly enables the attenuated loopback.
 
-set -euo pipefail
+set -Eeuo pipefail
 
 ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 readonly ROOT
 readonly MULTI_LOADER="${ROOT}/spf/scripts/pluto_multi_firmware.py"
-readonly FIRMWARE_LOADER="${ROOT}/data_collection/rover/rover_v3.1/load_direct_usb_firmware.sh"
 readonly SSH_CONFIG="${ROOT}/data_collection/rover/rover_v3.1/ssh_config"
 readonly TEST_FILE="${ROOT}/tests/radio_hardware/test_gain_series_v3_hardware.py"
 readonly TX_TEST_FILE="${ROOT}/tests/radio_hardware/test_gain_series_v3_tx_loopback_hardware.py"
@@ -156,7 +155,9 @@ rollback_hint() {
     local rc=$?
     printf '\nCampaign stopped with status %d. Candidate remains in RAM.\n' "$rc" >&2
     printf 'Inspect %s, then roll back explicitly with:\n' "$REPORT_ROOT" >&2
-    printf '  sudo %q rollback-all %q\n' "$FIRMWARE_LOADER" "$EXPECTED_RADIOS" >&2
+    printf '  sudo %q %q rollback-all' "$PYTHON" "$MULTI_LOADER" >&2
+    printf ' %q' "${common_loader_args[@]}" >&2
+    printf '\n' >&2
     exit "$rc"
 }
 trap rollback_hint ERR

--- a/tests/radio_hardware/test_gain_series_v3_hardware.py
+++ b/tests/radio_hardware/test_gain_series_v3_hardware.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import json
+import socket
 import time
 
 import numpy as np
@@ -24,7 +25,10 @@ from spf.dataset.v7_data import (
 )
 from spf.sdrpluto.direct_ip_protocol import IpControlFlags
 from spf.sdrpluto.sdr_controller import _gain_series_arrays
-from spf.sdrpluto.direct_ip_receiver import PlutoDirectIpReceiver
+from spf.sdrpluto.direct_ip_receiver import (
+    DEFAULT_DIRECT_IP_CONTROL_PORT,
+    PlutoDirectIpReceiver,
+)
 from spf.sdrpluto.direct_usb_protocol import (
     CapabilityFlags,
     GainObservationFlags,
@@ -479,6 +483,47 @@ def test_v3_simultaneous_usb_streams(attached_plutos, pytestconfig, radio_report
         )
     (radio_report_dir / "gain_series_v3_simultaneous_usb.json").write_text(
         json.dumps(results, indent=2) + "\n"
+    )
+
+
+@pytest.mark.radio_direct_ip
+def test_v3_direct_ip_survives_malformed_control_datagrams(
+    pytestconfig, radio_report_dir
+):
+    host = pytestconfig.getoption("--radio-direct-ip-host")
+    if not host:
+        pytest.fail("--radio-direct-ip-host is required with --radio-direct-ip")
+
+    # RC11 returned a fatal epoll status for an undersized legacy envelope,
+    # terminating the direct-IP daemon. Exercise boundary lengths and unknown
+    # magic before proving that a valid capability exchange still succeeds.
+    malformed = (
+        b"",
+        b"x",
+        b"xyz",
+        b"test",
+        bytes.fromhex("504c544f"),  # legacy magic without its 8-byte header
+        bytes.fromhex("efbeadde") + bytes(76),
+    )
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as probe:
+        for datagram in malformed:
+            probe.sendto(datagram, (host, DEFAULT_DIRECT_IP_CONTROL_PORT))
+    time.sleep(0.1)
+
+    with PlutoDirectIpReceiver(remote_host=host) as receiver:
+        assert receiver.capabilities.flags & IpControlFlags.FINITE_RX
+
+    (radio_report_dir / "gain_series_v3_direct_ip_malformed.json").write_text(
+        json.dumps(
+            {
+                "host": host,
+                "control_port": DEFAULT_DIRECT_IP_CONTROL_PORT,
+                "malformed_lengths": [len(item) for item in malformed],
+                "valid_capability_query_afterwards": True,
+            },
+            indent=2,
+        )
+        + "\n"
     )
 
 

--- a/tests/test_gain_series_v3_campaign.py
+++ b/tests/test_gain_series_v3_campaign.py
@@ -104,6 +104,10 @@ def test_gain_series_candidate_campaign_orders_volatile_gates(tmp_path):
         cursor += 1
     assert all("provision-config-all" not in command for command in commands)
     assert all("ensure_pluto_qspi" not in command for command in commands)
+    load_index = next(
+        index for index, command in enumerate(commands) if "load-all" in command
+    )
+    assert "spf.scripts.mute_pluto_tx" in commands[load_index + 1]
     assert (report / "baseline-v2.log").is_file()
     assert (report / "candidate-v3-production-zarr.log").is_file()
 
@@ -174,6 +178,9 @@ def test_gain_series_candidate_campaign_requires_explicit_tx_and_mutes(tmp_path)
         command for command in commands if "spf.scripts.mute_pluto_tx" in command
     ]
     assert len(mute_commands) >= 5
+    for load_command in load_commands:
+        load_index = commands.index(load_command)
+        assert "spf.scripts.mute_pluto_tx" in commands[load_index + 1]
     for epoch in range(1, 4):
         assert (report / f"candidate-v3-tx2-loopback-epoch-{epoch}.log").is_file()
 
@@ -252,6 +259,10 @@ done
 
     assert result.returncode == 0, result.stderr
     assert "candidate-v3-direct-ip" in result.stdout
+    assert any(
+        "test_v3_direct_ip_survives_malformed_control_datagrams" in command
+        for command in trace.read_text().splitlines()
+    )
     assert any(
         "test_v3_direct_ip_uses_the_same_inner_frame" in command
         for command in trace.read_text().splitlines()

--- a/tests/test_gain_series_v3_campaign.py
+++ b/tests/test_gain_series_v3_campaign.py
@@ -200,6 +200,47 @@ def test_gain_series_candidate_campaign_rejects_unacknowledged_tx(tmp_path):
     assert "requires --loopback-attenuation-db" in result.stderr
 
 
+def test_gain_series_candidate_failure_prints_exact_campaign_rollback(tmp_path):
+    shim = tmp_path / "bin"
+    shim.mkdir()
+    image = tmp_path / "candidate.dfu"
+    image.write_bytes(b"synthetic candidate image")
+    report = tmp_path / "report"
+
+    fake_python = _executable(
+        shim / "python",
+        '[[ "$*" != *"test_direct_usb_hardware.py"* ]]\n',
+    )
+    _executable(
+        shim / "sudo",
+        '[[ "${1:-}" != "-n" ]] || shift\nexec "$@"\n',
+    )
+    _executable(shim / "iio_info", 'printf "synthetic IIO inventory\\n"\n')
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "PATH": f"{shim}:{environment['PATH']}",
+            "SPF_V3_PYTHON": str(fake_python),
+            "SPF_V3_EXPECTED_RADIOS": "2",
+            "SPF_V3_REPORT_ROOT": str(report),
+        }
+    )
+
+    result = subprocess.run(
+        [str(SCRIPT), str(image)],
+        cwd=ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "pluto_multi_firmware.py rollback-all" in result.stderr
+    assert f"--state-root {report}/firmware-state" in result.stderr
+    assert "--expected-count 2" in result.stderr
+
+
 def test_gain_series_candidate_campaign_accepts_direct_ip_serial_with_pipefail(
     tmp_path,
 ):

--- a/tests/test_pluto_multi_firmware.py
+++ b/tests/test_pluto_multi_firmware.py
@@ -703,6 +703,8 @@ def test_boot_preparation_uses_configured_boot_mode_with_environment_override():
     override = 'RAM_LOAD_OVERRIDE="${SPF_PLUTO_RAM_LOAD:-}"'
     ram_gate = 'if is_true "$ram_load"; then'
     load = 'run_loader load-all "$attached_radios"'
+    mute = '"$PYTHON" -m spf.scripts.mute_pluto_tx'
+    mapping = 'mapping_tmp="$(mktemp /run/spf-device-mapping.XXXXXX)"'
 
     assert ensure in boot_script
     assert config_mode in boot_script
@@ -711,11 +713,19 @@ def test_boot_preparation_uses_configured_boot_mode_with_environment_override():
     assert ram_gate in boot_script
     # The volatile path remains isolated from persistent QSPI preparation.
     assert load in boot_script
+    assert mute in boot_script
     assert (
         boot_script.index(ram_gate)
         < boot_script.index(load)
         < boot_script.index(ensure)
     )
+    # Every firmware transition restores TX attenuation defaults. A verified
+    # mute is mandatory before device mapping and the ready manifest, so a mute
+    # failure cannot authorize collection.
+    assert boot_script.index(ensure) < boot_script.index(mute)
+    assert boot_script.index(mute) < boot_script.index(mapping)
+    assert boot_script.index(mute) < boot_script.index("manifest_args=(")
+    assert 'rm -f -- "$READY_FILE" "$TX_MUTE_FILE"' in boot_script
     # The per-boot ssh check-config-all was removed (it raced the shared-IP ssh);
     # a wrong AD9361/2r2t config is still caught by verify-all's dual-RX check.
     assert "run_loader check-config-all" not in boot_script

--- a/tests/test_rover_capture_profile.py
+++ b/tests/test_rover_capture_profile.py
@@ -99,7 +99,8 @@ def test_boot_launcher_prints_canonical_v7_plan_without_hardware(tmp_path):
     assert plan["data_version"] == "7"
     assert plan["capture_status_file"] == "/home/pi/preflight/capture_status.json"
     assert (
-        plan["firmware_release_tag"] == "v0.38-plutoplus-spf-gain-rssi-fingerprint-v3"
+        plan["firmware_release_tag"]
+        == "v0.38-plutoplus-spf-gain-series-v4-rc12"
     )
 
 
@@ -211,30 +212,30 @@ def test_canonical_v7_configs_are_self_contained(
 
 
 @pytest.mark.parametrize("rover_id", [1, 2, 3, 4])
-def test_every_production_rover_pins_supervised_v3_firmware(rover_id):
+def test_every_production_rover_pins_hardware_qualified_rc12(rover_id):
     plan = resolve_capture_plan(rover_id)
     assert (
         plan.firmware_release_tag
-        == "v0.38-plutoplus-spf-gain-rssi-fingerprint-v3"
+        == "v0.38-plutoplus-spf-gain-series-v4-rc12"
     )
     assert (
         plan.firmware_asset_name
-        == "plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu"
+        == "plutoplus-spf-main-fa5f95f0af2a-pluto.dfu"
     )
     assert plan.firmware_image_url == (
         "https://github.com/misko/plutosdr-fw/releases/download/"
-        "v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/"
-        "plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu"
+        "v0.38-plutoplus-spf-gain-series-v4-rc12/"
+        "plutoplus-spf-main-fa5f95f0af2a-pluto.dfu"
     )
     assert plan.firmware_image_sha256 == (
-        "86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191"
+        "2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4"
     )
-    assert plan.firmware_git_sha == "f53dd006c26677a256520b86b7c864100ccd62d2"
-    assert plan.gadget_git_sha == "2072e1d0823ef6db3bc141dd733a90d76e23fc33"
+    assert plan.firmware_git_sha == "fa5f95f0af2a0586c80b54eff7ae04512cb96f7f"
+    assert plan.gadget_git_sha == "e14eae63ac6b7fe51828e85de34a8d4e1c50d49e"
     assert plan.firmware_boot_mode == "qspi"
     assert (
         plan.firmware_device_fw
-        == "v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d"
+        == "v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9"
     )
 
 


### PR DESCRIPTION
## Outcome

Promote the exact hardware-qualified RC12 DFU and harden rover/candidate TX safety.

## Firmware identity

- Release: https://github.com/misko/plutosdr-fw/releases/tag/v0.38-plutoplus-spf-gain-series-v4-rc12
- Firmware commit: `fa5f95f0af2a0586c80b54eff7ae04512cb96f7f`
- USB gadget: `e14eae63ac6b7fe51828e85de34a8d4e1c50d49e`
- Direct-IP gadget: `e44821f6d2737e3cdf452a017787f11c451fe04e`
- DFU SHA-256: `2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4`

## Changes

- pin all rover production and active calibration configs to the exact RC12 release bytes
- mute and verify every attached Pluto after RAM/QSPI transitions and before rover readiness
- make candidate campaigns mute before, after every boot/TX stage, and on every exit
- add malformed direct-IP hardware regression and run it before normal IP parity
- print an exact campaign-state rollback command on failure
- record full two-radio build/RAM/TX/USB/IP/V7/rollback evidence

## Hardware evidence

- three independent shared-hub RAM boot epochs passed
- TX2 loopback passed on both radios after every epoch
- 100 fresh STARTs per radio / 600 frames passed
- simultaneous USB passed
- 100 production-sized V7 records per radio wrote and reopened
- malformed direct-IP datagrams survived; real direct-IP frame passed
- both radios restored to prior QSPI production and post-rollback baseline passed 6/6

Report: https://github.com/misko/spf/blob/7257ca2/tests/radio_hardware/reports/gain_series_v4_rc12_20260810.md

## Tests

Focused local suite: `110 passed`. Full suite is intentionally delegated to CI to avoid destabilizing the development host.

## Remaining gate

Keep draft until full CI is green. Then perform a controlled one-radio persistent-QSPI canary and reboot test before fleet rollout.