### PR TITLE
Promote RC16 and accelerate buffered direct IP capture

### DIFF
--- a/data_collection/rover/rover_v3.1/PLUTO_QSPI_FLASH.md
+++ b/data_collection/rover/rover_v3.1/PLUTO_QSPI_FLASH.md
@@ -21,10 +21,11 @@ Everything below is traced to the plutosdr-fw Makefile and the on-device
 
 **The gain/RSSI features live entirely in the FIT (`mtd3`).** The bootloader
 (`mtd0`) is what bricks PlutoPlus units when a bad v0.38 build is written to it.
-The production devices run
-**`device-fw v0.38_plutoplus_with_timestamping-9-g7b02`** from `mtd3` while
-retaining the v0.37 QSPI bootloader in `mtd0`. This exact v0.38 FIT has passed
-normal-reset/direct-USB qualification on the two-radio development bench.
+The hardware-qualified RC16 image reports
+**`device-fw v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1`** from `mtd3`
+while retaining the v0.37 QSPI bootloader in `mtd0`. This exact FIT passed the
+complete two-radio RAM campaign and a serial-scoped persistent-QSPI canary,
+including a second reboot and USB/IP/TX/V7 gates.
 
 Canonical production V7 configs declare `pluto-firmware.boot-mode: qspi`.
 Boot preparation follows that setting, verifies the active version over
@@ -60,18 +61,19 @@ does this and validates the result the same way the on-device flasher does:
 
 ```bash
 # download the exact image the boot currently RAM-loads, then convert it
-gh release download v0.38-plutoplus-spf-gain-rssi-fingerprint-v3 \
+gh release download v0.38-plutoplus-spf-gain-series-v4-rc16 \
   --repo misko/plutosdr-fw \
-  --pattern "plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu" \
+  --pattern "plutoplus-spf-main-867e18542311-pluto.dfu" \
   -D /tmp/fw
 bash data_collection/rover/rover_v3.1/make_pluto_frm.sh \
-  /tmp/fw/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu \
+  /tmp/fw/plutoplus-spf-main-867e18542311-pluto.dfu \
   /tmp/fw/pluto.frm
 ```
 
-Verified: the generated v3 `pluto.frm` (13,870,584 B) carries the FRM_MAGIC and a
-self-consistent md5 trailer, so `handle_frimware_frm` will accept it and write
-`mtd3`.
+Verified: the generated RC16 `pluto.frm` is 12,725,820 bytes, has SHA-256
+`8d2623b6f8b5e5fd69d214afed20fe48dce4cd4aa0fe4714fc9825f1dccad415`,
+carries the FRM_MAGIC, and has a self-consistent MD5 trailer. The on-device
+`handle_frimware_frm` therefore accepts it and writes only `mtd3`.
 
 ## 4. Flashing via the mass-storage ("mount the drives") path
 
@@ -94,8 +96,9 @@ Alternative (equivalent, firmware-partition only): DFU — `device_reboot sf`
 then `dfu-util -a firmware.dfu -D pluto.dfu`. Both ultimately go through U-Boot's
 `dfu_sf` targeting the firmware partition.
 
-After flashing, the Pluto cold-boots the gain/RSSI FIT from QSPI and
-`grep device-fw /opt/VERSIONS` reads `v0.38_plutoplus_with_timestamping-9-g7b02`.
+After flashing, the Pluto cold-boots the gain-series FIT from QSPI and
+`grep device-fw /opt/VERSIONS` reads
+`v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1`.
 
 ## 5. Boot flow: check version over USB-IIO, flash only on mismatch
 

--- a/data_collection/rover/rover_v3.1/PRE_FIELD_CHECKLIST.md
+++ b/data_collection/rover/rover_v3.1/PRE_FIELD_CHECKLIST.md
@@ -102,9 +102,9 @@ sudo data_collection/rover/rover_v3.1/load_direct_usb_firmware.sh verify-all 2
 It obtains the exact hardware-tested image from:
 
 ```text
-https://github.com/misko/plutosdr-fw/releases/tag/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
+https://github.com/misko/plutosdr-fw/releases/tag/v0.38-plutoplus-spf-gain-series-v4-rc16
 
-86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
+27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
 ```
 
 The multi-radio loader keeps both Plutos attached. It identifies each by USB
@@ -116,20 +116,24 @@ Normal boot verifies the image hash, the image's explicit `device-fw` string,
 and the gadget Git SHA before authorizing capture.
 
 Rover 1 uses `capture_configs/rover1_production_v7.yaml`.
-It runs both radios simultaneously, negotiates protocol v2, writes data
-version 7, preserves the legacy `signal_matrix`, `gains`, and `rssis` fields,
-and also stores complete start/end gain/RSSI and stream metadata.
+It runs both radios simultaneously and writes data version 7 using protocol v3
+with a requested gain observation every 2,048 samples and 256 fixed schema
+slots. The legacy `signal_matrix`, `gains`, and `rssis` fields remain present,
+while the V7 gain-series arrays add sample-counter-bracketed observations. The
+firmware remains protocol-v2 compatible for explicitly pinned legacy configs.
 
 Pass:
 
-- the image was RAM-booted, not written to QSPI;
+- an explicit `load-all` qualification used RAM only, or normal boot verified
+  the checksum-pinned image in QSPI/mtd3;
 - standard USB-IIO and vendor interface 6 both enumerate;
 - `iiod` and `sdr_usb_gadget` both run on the Pluto;
 - the normal simultaneous 100-frame-per-radio Zarr capture and v7 validator
   pass;
 - gain and RSSI are finite for both channels;
 - every receiver stores a unique Pluto serial and physical USB path;
-- a reset restores the original QSPI firmware and removes interface 6.
+- a reset returns to the configured QSPI image; interface 6 remains present
+  when RC16 is the persistent image.
 
 Fail:
 

--- a/data_collection/rover/rover_v3.1/capture_configs/rover1_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover1_production_v7.yaml
@@ -16,13 +16,13 @@ distance-finder:
 boundary: auto
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   # Persist in mtd3; boot preparation only reflashes when the active image differs.
   boot-mode: qspi
 

--- a/data_collection/rover/rover_v3.1/capture_configs/rover1_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover1_production_v7.yaml
@@ -1,5 +1,5 @@
 # Canonical Rover 1 production capture.
-# data-version 7 implies direct-USB metadata protocol v2 for every receiver.
+# RC16 uses direct-USB metadata protocol v3 for sample-associated gain series.
 # Resting position offset from the fence centroid, metres (east, north).
 # Keeps rovers from converging on the same point at mission start/end.
 # Rover 1 = (+1, +1). Affects start/home/RTL only, never pattern geometry.
@@ -65,9 +65,13 @@ routine: bounce
 drone-uri: serial
 dry-run: false
 data-version: 7
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
 seconds-per-sample: 0.5
 
 collector:
   type: rover
   version: "3.1"
-  capture-profile: direct_usb_gain_rssi_v2
+  capture-profile: direct_usb_gain_series_v3

--- a/data_collection/rover/rover_v3.1/capture_configs/rover1_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover1_production_v7.yaml
@@ -16,13 +16,13 @@ distance-finder:
 boundary: auto
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Persist in mtd3; boot preparation only reflashes when the active image differs.
   boot-mode: qspi
 

--- a/data_collection/rover/rover_v3.1/capture_configs/rover2_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover2_production_v7.yaml
@@ -1,5 +1,5 @@
 # Canonical Rover 2 production capture.
-# data-version 7 implies direct-USB metadata protocol v2 for every receiver.
+# RC16 uses direct-USB metadata protocol v3 for sample-associated gain series.
 # Resting position offset from the fence centroid, metres (east, north).
 # Keeps rovers from converging on the same point at mission start/end.
 # Rover 2 = (+1, -1). Affects start/home/RTL only, never pattern geometry.
@@ -50,9 +50,13 @@ routine: circle
 drone-uri: serial
 dry-run: false
 data-version: 7
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
 seconds-per-sample: 0.5
 
 collector:
   type: rover
   version: "3.1"
-  capture-profile: direct_usb_gain_rssi_v2
+  capture-profile: direct_usb_gain_series_v3

--- a/data_collection/rover/rover_v3.1/capture_configs/rover2_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover2_production_v7.yaml
@@ -16,13 +16,13 @@ distance-finder:
 boundary: auto
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   # Persist in mtd3; boot preparation only reflashes when the active image differs.
   boot-mode: qspi
 

--- a/data_collection/rover/rover_v3.1/capture_configs/rover2_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover2_production_v7.yaml
@@ -16,13 +16,13 @@ distance-finder:
 boundary: auto
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Persist in mtd3; boot preparation only reflashes when the active image differs.
   boot-mode: qspi
 

--- a/data_collection/rover/rover_v3.1/capture_configs/rover3_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover3_production_v7.yaml
@@ -16,13 +16,13 @@ distance-finder:
 boundary: auto
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   # Persist in mtd3; boot preparation only reflashes when the active image differs.
   boot-mode: qspi
 

--- a/data_collection/rover/rover_v3.1/capture_configs/rover3_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover3_production_v7.yaml
@@ -16,13 +16,13 @@ distance-finder:
 boundary: auto
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Persist in mtd3; boot preparation only reflashes when the active image differs.
   boot-mode: qspi
 

--- a/data_collection/rover/rover_v3.1/capture_configs/rover3_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover3_production_v7.yaml
@@ -1,5 +1,5 @@
 # Canonical Rover 3 production capture.
-# data-version 7 implies direct-USB metadata protocol v2 for every receiver.
+# RC16 uses direct-USB metadata protocol v3 for sample-associated gain series.
 # Resting position offset from the fence centroid, metres (east, north).
 # Keeps rovers from converging on the same point at mission start/end.
 # Rover 3 = (-1, +1). Affects start/home/RTL only, never pattern geometry.
@@ -73,9 +73,13 @@ routine: bounce
 drone-uri: serial
 dry-run: false
 data-version: 7
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
 seconds-per-sample: 0.5
 
 collector:
   type: rover
   version: "3.1"
-  capture-profile: direct_usb_gain_rssi_v2
+  capture-profile: direct_usb_gain_series_v3

--- a/data_collection/rover/rover_v3.1/capture_configs/rover4_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover4_production_v7.yaml
@@ -21,13 +21,13 @@ distance-finder:
 boundary: auto
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Persist in mtd3; boot preparation only reflashes when the active image differs.
   boot-mode: qspi
 

--- a/data_collection/rover/rover_v3.1/capture_configs/rover4_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover4_production_v7.yaml
@@ -1,5 +1,5 @@
 # Canonical Rover 4 production capture.
-# data-version 7 implies direct-USB metadata protocol v2 for every receiver.
+# RC16 uses direct-USB metadata protocol v3 for sample-associated gain series.
 #
 # Antenna spacing is per-rover physical geometry, not a shared default:
 # rover1 = 35 mm, rover2 = 50.75 mm, rover3 = 43 mm, rover4 = 47 mm (fixed).
@@ -70,9 +70,13 @@ routine: bounce
 drone-uri: serial
 dry-run: false
 data-version: 7
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
 seconds-per-sample: 0.5
 
 collector:
   type: rover
   version: "3.1"
-  capture-profile: direct_usb_gain_rssi_v2
+  capture-profile: direct_usb_gain_series_v3

--- a/data_collection/rover/rover_v3.1/capture_configs/rover4_production_v7.yaml
+++ b/data_collection/rover/rover_v3.1/capture_configs/rover4_production_v7.yaml
@@ -21,13 +21,13 @@ distance-finder:
 boundary: auto
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   # Persist in mtd3; boot preparation only reflashes when the active image differs.
   boot-mode: qspi
 

--- a/data_collection/rover/rover_v3.1/load_direct_usb_firmware.sh
+++ b/data_collection/rover/rover_v3.1/load_direct_usb_firmware.sh
@@ -5,9 +5,9 @@
 
 set -euo pipefail
 
-readonly RELEASE_TAG="${SPF_FIRMWARE_RELEASE_TAG:-v0.38-plutoplus-spf-gain-rssi-fingerprint-v3}"
-readonly ASSET_NAME="${SPF_FIRMWARE_ASSET_NAME:-plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu}"
-readonly IMAGE_SHA256="${SPF_FIRMWARE_IMAGE_SHA256:-86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191}"
+readonly RELEASE_TAG="${SPF_FIRMWARE_RELEASE_TAG:-v0.38-plutoplus-spf-gain-series-v4-rc16}"
+readonly ASSET_NAME="${SPF_FIRMWARE_ASSET_NAME:-plutoplus-spf-main-867e18542311-pluto.dfu}"
+readonly IMAGE_SHA256="${SPF_FIRMWARE_IMAGE_SHA256:-27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911}"
 readonly IMAGE_URL="${SPF_FIRMWARE_IMAGE_URL:-https://github.com/misko/plutosdr-fw/releases/download/${RELEASE_TAG}/${ASSET_NAME}}"
 readonly PLUTO_RUNTIME_ID="0456:b673"
 readonly PLUTO_DFU_ID="0456:b674"

--- a/data_collection/rover/rover_v3.1/prepare_direct_usb_boot.sh
+++ b/data_collection/rover/rover_v3.1/prepare_direct_usb_boot.sh
@@ -13,6 +13,7 @@ readonly MAPPING_SCRIPT="${SCRIPT_DIR}/device_mapping.sh"
 readonly RADIO_MISSING_HANDLER="${SCRIPT_DIR}/radio_missing_shutdown.sh"
 readonly READY_FILE="${SPF_DIRECT_USB_READY_FILE:-/run/spf/direct_usb_ready.json}"
 readonly READY_DIR="$(dirname -- "$READY_FILE")"
+readonly TX_MUTE_FILE="${SPF_PLUTO_TX_MUTE_FILE:-/run/spf/pluto_tx_mute.json}"
 
 FIRMWARE_CACHE="${SPF_FIRMWARE_CACHE_DIR:-/home/pi/.cache/spf/firmware}"
 FIRMWARE_STATE="${SPF_FIRMWARE_STATE_DIR:-/var/lib/spf/pluto-firmware}"
@@ -40,7 +41,7 @@ is_true() {
 # Readiness is session-bound. Invalidate it before any operation that can fail,
 # including configuration parsing, so stale firmware/fingerprint state can
 # never authorize capture after a reboot or interrupted firmware operation.
-rm -f -- "$READY_FILE"
+rm -f -- "$READY_FILE" "$TX_MUTE_FILE"
 
 if is_true "$DISABLE_DIRECT_USB"; then
     printf '%s\n' \
@@ -164,6 +165,17 @@ else
     # shared-IP ssh race.
     export SPF_PLUTO_SKIP_SSH_VERIFY=1
 fi
+
+# A Pluto boot restores the AD9361 TX attenuation defaults even when no TX DMA
+# or DDS waveform is active. Reassert the rover's fail-closed state after every
+# RAM/QSPI transition and before publishing any readiness evidence. The helper
+# independently attempts TX1 attenuation, TX2 attenuation, DDS disable, channel
+# disable and TX-buffer destruction, then verifies both attenuation readbacks.
+# Any failure leaves READY_FILE absent and blocks mavlink_controller.service.
+mkdir -p "$(dirname -- "$TX_MUTE_FILE")"
+"$PYTHON" -m spf.scripts.mute_pluto_tx \
+    --expected-count "$attached_radios" \
+    --output "$TX_MUTE_FILE"
 
 # USB-IIO URIs contain the post-enumeration USB device address, so mapping must
 # be regenerated only after every radio reaches its final booted state.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/all_gain_cross_2p4.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/all_gain_cross_2p4.yaml
@@ -14,6 +14,11 @@
 # physical radio. Pair order is deterministic-randomized within every block.
 data-version: 7
 
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
+
 pluto-firmware:
   release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
   device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1

--- a/spf/calibrations/dual_rx_gain_frequency/configs/all_gain_cross_2p4.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/all_gain_cross_2p4.yaml
@@ -15,13 +15,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/all_gain_cross_2p4.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/all_gain_cross_2p4.yaml
@@ -15,13 +15,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/coarse_5ghz.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/coarse_5ghz.yaml
@@ -3,13 +3,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/coarse_5ghz.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/coarse_5ghz.yaml
@@ -2,6 +2,11 @@
 # frequencies. Run only after pilot_5ghz.yaml passes.
 data-version: 7
 
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
+
 pluto-firmware:
   release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
   device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1

--- a/spf/calibrations/dual_rx_gain_frequency/configs/coarse_5ghz.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/coarse_5ghz.yaml
@@ -3,13 +3,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_arm2_rfdc_tracking.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_arm2_rfdc_tracking.yaml
@@ -38,13 +38,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   boot-mode: qspi
 
 calibration:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_arm2_rfdc_tracking.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_arm2_rfdc_tracking.yaml
@@ -38,13 +38,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   boot-mode: qspi
 
 calibration:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_arm2_rfdc_tracking.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_arm2_rfdc_tracking.yaml
@@ -37,6 +37,11 @@
 # for the wrong reason -- indistinguishable from a real one.
 data-version: 7
 
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
+
 pluto-firmware:
   release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
   device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_rfdc_discriminator.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_rfdc_discriminator.yaml
@@ -38,13 +38,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   boot-mode: qspi
 
 calibration:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_rfdc_discriminator.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_rfdc_discriminator.yaml
@@ -38,13 +38,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   boot-mode: qspi
 
 calibration:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_rfdc_discriminator.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_cal1_rfdc_discriminator.yaml
@@ -37,6 +37,11 @@
 # first: a write path for the attribute plus config plumbing.
 data-version: 7
 
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
+
 pluto-firmware:
   release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
   device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_cal5_positive_control.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_cal5_positive_control.yaml
@@ -1,4 +1,9 @@
 data-version: 7
+
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
 pluto-firmware:
   release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
   device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_cal5_positive_control.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_cal5_positive_control.yaml
@@ -1,12 +1,12 @@
 data-version: 7
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   boot-mode: qspi
 calibration:
   frequencies-hz:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_cal5_positive_control.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_cal5_positive_control.yaml
@@ -1,12 +1,12 @@
 data-version: 7
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   boot-mode: qspi
 calibration:
   frequencies-hz:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_gsp7_conditioned_comb.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_gsp7_conditioned_comb.yaml
@@ -1,4 +1,9 @@
 data-version: 7
+
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
 pluto-firmware:
   release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
   device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_gsp7_conditioned_comb.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_gsp7_conditioned_comb.yaml
@@ -1,12 +1,12 @@
 data-version: 7
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   boot-mode: qspi
 calibration:
   frequencies-hz:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/e_gsp7_conditioned_comb.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/e_gsp7_conditioned_comb.yaml
@@ -1,12 +1,12 @@
 data-version: 7
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   boot-mode: qspi
 calibration:
   frequencies-hz:

--- a/spf/calibrations/dual_rx_gain_frequency/configs/frequency_scout_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/frequency_scout_cross_band.yaml
@@ -7,13 +7,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/frequency_scout_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/frequency_scout_cross_band.yaml
@@ -7,13 +7,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/frequency_scout_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/frequency_scout_cross_band.yaml
@@ -6,6 +6,11 @@
 # 3-by-3 representative gain grid in three time-separated randomized epochs.
 data-version: 7
 
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
+
 pluto-firmware:
   release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
   device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1

--- a/spf/calibrations/dual_rx_gain_frequency/configs/historical_exact_lo_cross_2p4.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/historical_exact_lo_cross_2p4.yaml
@@ -7,13 +7,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/historical_exact_lo_cross_2p4.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/historical_exact_lo_cross_2p4.yaml
@@ -6,6 +6,11 @@
 # values below; they are not separate RF calibration frequencies.
 data-version: 7
 
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
+
 pluto-firmware:
   release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
   device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1

--- a/spf/calibrations/dual_rx_gain_frequency/configs/historical_exact_lo_cross_2p4.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/historical_exact_lo_cross_2p4.yaml
@@ -7,13 +7,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/integer_gain_cross_2p4.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/integer_gain_cross_2p4.yaml
@@ -12,13 +12,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/integer_gain_cross_2p4.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/integer_gain_cross_2p4.yaml
@@ -12,13 +12,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/integer_gain_cross_2p4.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/integer_gain_cross_2p4.yaml
@@ -11,6 +11,11 @@
 # measured RX1 and RX2 gain curves predict unseen ordered gain combinations.
 data-version: 7
 
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
+
 pluto-firmware:
   release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
   device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1

--- a/spf/calibrations/dual_rx_gain_frequency/configs/pilot_5ghz.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/pilot_5ghz.yaml
@@ -3,13 +3,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/pilot_5ghz.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/pilot_5ghz.yaml
@@ -2,6 +2,11 @@
 # and every radio writes its own data-version-7 Zarr.
 data-version: 7
 
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
+
 pluto-firmware:
   release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
   device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1

--- a/spf/calibrations/dual_rx_gain_frequency/configs/pilot_5ghz.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/pilot_5ghz.yaml
@@ -3,13 +3,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/pilot_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/pilot_cross_band.yaml
@@ -5,6 +5,11 @@
 # boundaries, and the four existing Rover/VTX 5.8 GHz anchors.
 data-version: 7
 
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
+
 pluto-firmware:
   release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
   device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1

--- a/spf/calibrations/dual_rx_gain_frequency/configs/pilot_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/pilot_cross_band.yaml
@@ -6,13 +6,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/pilot_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/pilot_cross_band.yaml
@@ -6,13 +6,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/power_cycle_subsample.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/power_cycle_subsample.yaml
@@ -6,6 +6,11 @@
 # instead of 10,404 while retaining the existing V7 writer and validator.
 data-version: 7
 
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
+
 pluto-firmware:
   release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
   device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1

--- a/spf/calibrations/dual_rx_gain_frequency/configs/power_cycle_subsample.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/power_cycle_subsample.yaml
@@ -7,13 +7,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/power_cycle_subsample.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/power_cycle_subsample.yaml
@@ -7,13 +7,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/spectroscopy_campaign_base.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/spectroscopy_campaign_base.yaml
@@ -3,13 +3,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/spectroscopy_campaign_base.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/spectroscopy_campaign_base.yaml
@@ -2,6 +2,11 @@
 # The campaign renderer replaces the placeholder frequency/gain coordinates.
 data-version: 7
 
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
+
 pluto-firmware:
   release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
   device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1

--- a/spf/calibrations/dual_rx_gain_frequency/configs/spectroscopy_campaign_base.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/spectroscopy_campaign_base.yaml
@@ -3,13 +3,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/survey_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/survey_cross_band.yaml
@@ -7,13 +7,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/survey_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/survey_cross_band.yaml
@@ -6,6 +6,11 @@
 # common manual-gain range (-1..62 dB) of both attached radios.
 data-version: 7
 
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
+
 pluto-firmware:
   release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
   device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1

--- a/spf/calibrations/dual_rx_gain_frequency/configs/survey_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/survey_cross_band.yaml
@@ -7,13 +7,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/wide_integer_gain_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/wide_integer_gain_cross_band.yaml
@@ -9,13 +9,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
-  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
-  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
-  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
-  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
-  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1
+  asset-name: plutoplus-spf-main-867e18542311-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc16/plutoplus-spf-main-867e18542311-pluto.dfu
+  image-sha256: 27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911
+  firmware-git-sha: 867e18542311c25f5c1980bbdcfffc823e56f0a2
+  gadget-git-sha: 2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/wide_integer_gain_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/wide_integer_gain_cross_band.yaml
@@ -9,13 +9,13 @@
 data-version: 7
 
 pluto-firmware:
-  release-tag: v0.38-plutoplus-spf-gain-rssi-fingerprint-v3
-  device-fw: v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d
-  asset-name: plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu
-  image-sha256: 86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191
-  firmware-git-sha: f53dd006c26677a256520b86b7c864100ccd62d2
-  gadget-git-sha: 2072e1d0823ef6db3bc141dd733a90d76e23fc33
+  release-tag: v0.38-plutoplus-spf-gain-series-v4-rc12
+  device-fw: v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9
+  asset-name: plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-url: https://github.com/misko/plutosdr-fw/releases/download/v0.38-plutoplus-spf-gain-series-v4-rc12/plutoplus-spf-main-fa5f95f0af2a-pluto.dfu
+  image-sha256: 2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4
+  firmware-git-sha: fa5f95f0af2a0586c80b54eff7ae04512cb96f7f
+  gadget-git-sha: e14eae63ac6b7fe51828e85de34a8d4e1c50d49e
   # Match the rover production configs: the image is persisted in mtd3 and
   # boot preparation only reflashes when the active image differs. Calibrate
   # against the same firmware state the rovers actually fly.

--- a/spf/calibrations/dual_rx_gain_frequency/configs/wide_integer_gain_cross_band.yaml
+++ b/spf/calibrations/dual_rx_gain_frequency/configs/wide_integer_gain_cross_band.yaml
@@ -8,6 +8,11 @@
 # 53 frequencies * 175 pairs * 3 epochs = 27,825 frames per radio.
 data-version: 7
 
+direct-usb:
+  protocol-version: 3
+  gain-observation-interval-samples: 2048
+  gain-observation-capacity: 256
+
 pluto-firmware:
   release-tag: v0.38-plutoplus-spf-gain-series-v4-rc16
   device-fw: v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1

--- a/spf/capture_schema.py
+++ b/spf/capture_schema.py
@@ -22,13 +22,25 @@ V7_CONTRACT = CaptureSchemaContract(
     require_gain_metadata=True,
 )
 
+V7_SHARED_DIRECT_USB_KEYS = frozenset(
+    {
+        "protocol-version",
+        "frame-count-per-request",
+        "gain-observation-interval-samples",
+        "gain-observation-capacity",
+        "gain-event-capacity",
+        "require-gain-metadata",
+    }
+)
+
 
 def normalize_capture_config(config: dict[str, Any]) -> dict[str, Any]:
     """Return a normalized copy with implicit schema requirements materialized.
 
-    Data version 7 is SPF's direct-USB protocol-v2 gain/RSSI schema. Production
-    YAML therefore does not need to repeat transport and protocol under every
-    receiver. Explicit conflicting values are rejected rather than overwritten.
+    Data version 7 is SPF's direct-radio gain/RSSI schema. Protocol v2 remains
+    the compatibility default, while a top-level ``direct-usb`` mapping can
+    select protocol v3 gain-series settings once for every receiver. Explicit
+    conflicting values are rejected rather than overwritten.
     """
 
     normalized = deepcopy(config)
@@ -38,6 +50,16 @@ def normalize_capture_config(config: dict[str, Any]) -> dict[str, Any]:
     receivers = normalized.get("receivers")
     if not isinstance(receivers, list) or not receivers:
         raise ValueError("data-version: 7 requires at least one receiver")
+
+    shared_direct_usb = normalized.get("direct-usb", {})
+    if not isinstance(shared_direct_usb, dict):
+        raise ValueError("data-version: 7 top-level direct-usb must be a mapping")
+    unsupported_shared_keys = set(shared_direct_usb) - V7_SHARED_DIRECT_USB_KEYS
+    if unsupported_shared_keys:
+        raise ValueError(
+            "data-version: 7 top-level direct-usb contains receiver-specific "
+            f"or unsupported fields: {sorted(unsupported_shared_keys)}"
+        )
 
     for index, receiver in enumerate(receivers):
         if not isinstance(receiver, dict):
@@ -54,6 +76,13 @@ def normalize_capture_config(config: dict[str, Any]) -> dict[str, Any]:
         direct_usb = receiver.setdefault("direct-usb", {})
         if not isinstance(direct_usb, dict):
             raise ValueError(f"receivers[{index}].direct-usb must be a mapping")
+        for key, value in shared_direct_usb.items():
+            if key in direct_usb and direct_usb[key] != value:
+                raise ValueError(
+                    f"receivers[{index}].direct-usb.{key} conflicts with "
+                    "the top-level direct-usb default"
+                )
+            direct_usb.setdefault(key, value)
 
         explicit_protocol = direct_usb.get("protocol-version")
         if explicit_protocol not in (

--- a/spf/scripts/pluto_multi_firmware.py
+++ b/spf/scripts/pluto_multi_firmware.py
@@ -1110,12 +1110,6 @@ class MultiPlutoFirmwareManager:
             device = self._device(original.serial)
             expected_version = self._preload_device_fw(device.serial)
             active_version, _, _ = self._read_persistent_state(device.serial)
-            if active_version == expected_version:
-                print(
-                    f"{device.serial}: already running preserved firmware "
-                    f"{expected_version}; skipping"
-                )
-                continue
             print(
                 f"{device.serial}: resetting {active_version} to preserved "
                 f"firmware {expected_version}",

--- a/spf/scripts/resolve_pluto_ip.py
+++ b/spf/scripts/resolve_pluto_ip.py
@@ -11,6 +11,22 @@ from collections.abc import Callable, Iterable
 
 
 SERIAL_RE = re.compile(r"^hw_serial:\s*(\S+)\s*$", re.MULTILINE)
+ROUTE_DEVICE_RE = re.compile(r"(?:^|\s)dev\s+(\S+)(?:\s|$)")
+
+
+def route_interface(host: str) -> str | None:
+    """Return the interface the kernel would actually use for ``host``."""
+
+    result = subprocess.run(
+        ["ip", "-4", "route", "get", host],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return None
+    match = ROUTE_DEVICE_RE.search(result.stdout)
+    return None if match is None else match.group(1)
 
 
 def neighbor_candidates(interface: str = "eth0") -> tuple[str, ...]:
@@ -28,6 +44,14 @@ def neighbor_candidates(interface: str = "eth0") -> tuple[str, ...]:
         try:
             address = str(ipaddress.ip_address(fields[0]))
         except ValueError:
+            continue
+        # A neighbor can remain listed on the LAN while a more-specific USB
+        # Ethernet route wins for that same address (the Pluto default
+        # 192.168.2.1 is the common case). Probing without this check reaches
+        # the USB copy of a radio and can make one serial appear at two LAN
+        # addresses. Keep only candidates whose current route really exits on
+        # the requested LAN interface.
+        if route_interface(address) != interface:
             continue
         candidates.append(address)
     return tuple(sorted(set(candidates), key=ipaddress.ip_address))

--- a/spf/sdrpluto/direct_ip_protocol.py
+++ b/spf/sdrpluto/direct_ip_protocol.py
@@ -17,6 +17,7 @@ import math
 import struct
 import time
 import zlib
+from array import array
 from collections.abc import Hashable, Iterable
 from typing import Final
 
@@ -326,7 +327,7 @@ class IpFragmentV1:
 class ReassembledIpFrame:
     stream_id: int
     frame_sequence: int
-    frame: bytes
+    frame: bytes | bytearray
 
 
 def fragment_ip_frame(
@@ -382,7 +383,10 @@ class _PartialIpFrame:
     frame_crc32: int
     fragment_count: int
     first_seen: float
-    fragments: dict[int, tuple[int, bytes]] = dataclasses.field(default_factory=dict)
+    frame: bytearray
+    fragment_offsets: array
+    fragment_lengths: array
+    received_fragment_count: int = 0
 
 
 class IpFrameReassembler:
@@ -408,6 +412,9 @@ class IpFrameReassembler:
         self._recently_completed: dict[
             tuple[Hashable | None, int, int], tuple[int, int, float]
         ] = {}
+        self._pending_declared_bytes = 0
+        self._feed_count = 0
+        self._last_expiry_check = 0.0
         self.completed_frame_count = 0
         self.expired_frame_count = 0
         self.rejected_frame_count = 0
@@ -419,11 +426,12 @@ class IpFrameReassembler:
 
     @property
     def pending_declared_bytes(self) -> int:
-        return sum(partial.frame_bytes for partial in self._pending.values())
+        return self._pending_declared_bytes
 
     def reset(self) -> None:
         self._pending.clear()
         self._recently_completed.clear()
+        self._pending_declared_bytes = 0
 
     def expire(self, *, now: float | None = None) -> int:
         """Discard timed-out partial frames and return the number expired."""
@@ -435,7 +443,7 @@ class IpFrameReassembler:
             if current - partial.first_seen >= self.frame_timeout_seconds
         ]
         for key in expired:
-            del self._pending[key]
+            self._remove_pending(key)
         completed_expiry = [
             key
             for key, (_, _, completed_at) in self._recently_completed.items()
@@ -455,16 +463,42 @@ class IpFrameReassembler:
     ) -> list[ReassembledIpFrame]:
         """Consume one datagram and return zero or one complete radio frames."""
 
-        current = time.monotonic() if now is None else float(now)
-        self.expire(now=current)
-        fragment = IpFragmentV1.unpack(datagram)
-        key = (peer, fragment.stream_id, fragment.frame_sequence)
+        self._feed_count += 1
+        if now is None:
+            # A production frame contains roughly 3,000 MTU-safe datagrams.
+            # Reading the clock and scanning both dictionaries for every packet
+            # consumed a measurable share of a Pi 4 core.  A 256-packet cadence
+            # remains far below the multi-second frame timeout while keeping the
+            # per-datagram hot path allocation-light.
+            if self._last_expiry_check == 0.0 or self._feed_count % 256 == 0:
+                current = time.monotonic()
+                self.expire(now=current)
+                self._last_expiry_check = current
+            else:
+                current = self._last_expiry_check
+        else:
+            current = float(now)
+            self.expire(now=current)
+            self._last_expiry_check = current
+
+        (
+            flags,
+            stream_id,
+            frame_sequence,
+            frame_bytes,
+            frame_crc32,
+            fragment_index,
+            fragment_count,
+            fragment_offset,
+            payload,
+        ) = _unpack_ip_fragment_view(datagram)
+        key = (peer, stream_id, frame_sequence)
         completed = self._recently_completed.get(key)
         if completed is not None:
-            frame_crc32, fragment_count, _ = completed
+            completed_crc32, completed_fragment_count, _ = completed
             if (
-                frame_crc32 != fragment.frame_crc32
-                or fragment_count != fragment.fragment_count
+                completed_crc32 != frame_crc32
+                or completed_fragment_count != fragment_count
             ):
                 self.rejected_frame_count += 1
                 raise ProtocolError("conflicting late direct-IP fragment")
@@ -475,39 +509,51 @@ class IpFrameReassembler:
             if len(self._pending) >= self.max_pending_frames:
                 self.rejected_frame_count += 1
                 raise ProtocolError("direct-IP pending-frame limit exceeded")
-            if (
-                self.pending_declared_bytes + fragment.frame_bytes
-                > self.max_pending_bytes
-            ):
+            if self._pending_declared_bytes + frame_bytes > self.max_pending_bytes:
                 self.rejected_frame_count += 1
                 raise ProtocolError("direct-IP pending-byte limit exceeded")
             partial = _PartialIpFrame(
-                frame_bytes=fragment.frame_bytes,
-                frame_crc32=fragment.frame_crc32,
-                fragment_count=fragment.fragment_count,
+                frame_bytes=frame_bytes,
+                frame_crc32=frame_crc32,
+                fragment_count=fragment_count,
                 first_seen=current,
+                frame=bytearray(frame_bytes),
+                fragment_offsets=array("I", [0xFFFFFFFF]) * fragment_count,
+                fragment_lengths=array("I", [0]) * fragment_count,
             )
             self._pending[key] = partial
+            self._pending_declared_bytes += frame_bytes
         elif (
-            partial.frame_bytes != fragment.frame_bytes
-            or partial.frame_crc32 != fragment.frame_crc32
-            or partial.fragment_count != fragment.fragment_count
+            partial.frame_bytes != frame_bytes
+            or partial.frame_crc32 != frame_crc32
+            or partial.fragment_count != fragment_count
         ):
-            del self._pending[key]
+            self._remove_pending(key)
             self.rejected_frame_count += 1
             raise ProtocolError("conflicting direct-IP frame description")
 
-        candidate = (fragment.fragment_offset, fragment.payload)
-        existing = partial.fragments.get(fragment.fragment_index)
-        if existing is not None:
-            if existing != candidate:
-                del self._pending[key]
+        existing_offset = partial.fragment_offsets[fragment_index]
+        if existing_offset != 0xFFFFFFFF:
+            existing_length = partial.fragment_lengths[fragment_index]
+            existing_payload = memoryview(partial.frame)[
+                existing_offset : existing_offset + existing_length
+            ]
+            if (
+                existing_offset != fragment_offset
+                or existing_length != len(payload)
+                or existing_payload != payload
+            ):
+                self._remove_pending(key)
                 self.rejected_frame_count += 1
                 raise ProtocolError("conflicting duplicate direct-IP fragment")
             self.duplicate_fragment_count += 1
             return []
-        partial.fragments[fragment.fragment_index] = candidate
-        if len(partial.fragments) != partial.fragment_count:
+        fragment_end = fragment_offset + len(payload)
+        partial.frame[fragment_offset:fragment_end] = payload
+        partial.fragment_offsets[fragment_index] = fragment_offset
+        partial.fragment_lengths[fragment_index] = len(payload)
+        partial.received_fragment_count += 1
+        if partial.received_fragment_count != partial.fragment_count:
             return []
 
         try:
@@ -516,7 +562,7 @@ class IpFrameReassembler:
             self.rejected_frame_count += 1
             raise
         finally:
-            del self._pending[key]
+            self._remove_pending(key)
         self.completed_frame_count += 1
         self._recently_completed[key] = (
             partial.frame_crc32,
@@ -525,11 +571,15 @@ class IpFrameReassembler:
         )
         return [
             ReassembledIpFrame(
-                stream_id=fragment.stream_id,
-                frame_sequence=fragment.frame_sequence,
+                stream_id=stream_id,
+                frame_sequence=frame_sequence,
                 frame=frame,
             )
         ]
+
+    def _remove_pending(self, key: tuple[Hashable | None, int, int]) -> None:
+        partial = self._pending.pop(key)
+        self._pending_declared_bytes -= partial.frame_bytes
 
 
 def reassemble_ip_datagrams(
@@ -547,31 +597,93 @@ def reassemble_ip_datagrams(
         raise ProtocolError("direct-IP datagram collection is incomplete")
     if len(frames) != 1:
         raise ProtocolError(f"expected one direct-IP frame, received {len(frames)}")
-    return frames[0].frame
+    return bytes(frames[0].frame)
 
 
-def _assemble_complete_frame(partial: _PartialIpFrame) -> bytes:
-    chunks = []
+def _assemble_complete_frame(partial: _PartialIpFrame) -> bytearray:
     expected_offset = 0
     for fragment_index in range(partial.fragment_count):
-        try:
-            offset, payload = partial.fragments[fragment_index]
-        except (
-            KeyError
-        ) as exc:  # Defensive: count equality should make this impossible.
-            raise ProtocolError("direct-IP frame has a missing fragment index") from exc
+        offset = partial.fragment_offsets[fragment_index]
+        payload_bytes = partial.fragment_lengths[fragment_index]
+        if offset == 0xFFFFFFFF:
+            raise ProtocolError("direct-IP frame has a missing fragment index")
         if offset != expected_offset:
             relation = "overlap" if offset < expected_offset else "gap"
             raise ProtocolError(f"direct-IP frame has a fragment {relation}")
-        chunks.append(payload)
-        expected_offset += len(payload)
+        expected_offset += payload_bytes
     if expected_offset != partial.frame_bytes:
         raise ProtocolError("direct-IP fragments do not cover the declared frame")
-    frame = b"".join(chunks)
-    calculated_crc32 = zlib.crc32(frame) & 0xFFFFFFFF
+    calculated_crc32 = zlib.crc32(partial.frame) & 0xFFFFFFFF
     if calculated_crc32 != partial.frame_crc32:
         raise ProtocolError("direct-IP frame CRC mismatch")
-    return frame
+    return partial.frame
+
+
+def _unpack_ip_fragment_view(
+    datagram: bytes | bytearray | memoryview,
+) -> tuple[int, int, int, int, int, int, int, int, memoryview]:
+    """Parse one fragment without copying its payload or allocating a dataclass."""
+
+    if not IP_FRAGMENT_HEADER_BYTES < len(datagram) <= MAX_UDP_DATAGRAM_BYTES:
+        raise ProtocolError("direct-IP datagram size is outside the supported range")
+    (
+        magic,
+        version,
+        header_bytes,
+        flags,
+        stream_id,
+        frame_sequence,
+        frame_bytes,
+        frame_crc32,
+        fragment_index,
+        fragment_count,
+        fragment_offset,
+        fragment_bytes,
+    ) = _IP_FRAGMENT_STRUCT.unpack_from(datagram)
+    if magic != IP_FRAGMENT_MAGIC:
+        raise ProtocolError(f"bad direct-IP magic: 0x{magic:08x}")
+    if version != IP_FRAGMENT_VERSION:
+        raise ProtocolError(f"unsupported direct-IP version: {version}")
+    if header_bytes != IP_FRAGMENT_HEADER_BYTES:
+        raise ProtocolError(f"unsupported direct-IP header size: {header_bytes}")
+    if len(datagram) != header_bytes + fragment_bytes:
+        raise ProtocolError("direct-IP fragment length mismatch")
+    # The struct already constrains every numeric field to its unsigned wire
+    # width.  Keep the remaining semantic checks inline: constructing an enum
+    # dataclass and running generic integer validators for every UDP packet was
+    # over 80% of host reassembly CPU on the Pi 4.
+    if flags & ~int(IpFragmentFlags.FIRST | IpFragmentFlags.LAST):
+        raise ProtocolError("unknown direct-IP fragment flags")
+    if not 1 <= frame_bytes <= MAX_IP_FRAME_BYTES:
+        raise ProtocolError("direct-IP frame size is outside the supported range")
+    if not 1 <= fragment_count <= MAX_IP_FRAGMENT_COUNT:
+        raise ProtocolError("direct-IP fragment count is outside the supported range")
+    if fragment_index >= fragment_count:
+        raise ProtocolError("direct-IP fragment index is outside the frame")
+    if (
+        fragment_bytes == 0
+        or fragment_offset > frame_bytes
+        or fragment_bytes > frame_bytes - fragment_offset
+    ):
+        raise ProtocolError("direct-IP fragment range is outside the frame")
+    if bool(flags & int(IpFragmentFlags.FIRST)) != (fragment_index == 0):
+        raise ProtocolError("direct-IP FIRST flag does not match fragment index")
+    if bool(flags & int(IpFragmentFlags.LAST)) != (
+        fragment_index == fragment_count - 1
+    ):
+        raise ProtocolError("direct-IP LAST flag does not match fragment index")
+    payload = memoryview(datagram)[header_bytes:]
+    return (
+        flags,
+        stream_id,
+        frame_sequence,
+        frame_bytes,
+        frame_crc32,
+        fragment_index,
+        fragment_count,
+        fragment_offset,
+        payload,
+    )
 
 
 def _validate_fragment(fragment: IpFragmentV1) -> None:

--- a/spf/sdrpluto/direct_ip_protocol.py
+++ b/spf/sdrpluto/direct_ip_protocol.py
@@ -60,12 +60,18 @@ class IpControlFlags(enum.IntFlag):
     FINITE_RX = 1 << 0
     IDEMPOTENT_REQUESTS = 1 << 1
     TIME_ANCHOR = 1 << 2
+    QUERY_TRANSPORT_CAPABILITIES = 1 << 3
+    BUFFERED_FINITE_RX = 1 << 4
+    USB_CLASS_PACING = 1 << 5
 
 
 KNOWN_IP_CONTROL_FLAGS: Final[IpControlFlags] = (
     IpControlFlags.FINITE_RX
     | IpControlFlags.IDEMPOTENT_REQUESTS
     | IpControlFlags.TIME_ANCHOR
+    | IpControlFlags.QUERY_TRANSPORT_CAPABILITIES
+    | IpControlFlags.BUFFERED_FINITE_RX
+    | IpControlFlags.USB_CLASS_PACING
 )
 
 
@@ -191,10 +197,17 @@ class IpControlMessageV1:
         return message
 
 
-def make_ip_capability_query(*, request_id: int) -> IpControlMessageV1:
+def make_ip_capability_query(
+    *, request_id: int, transport_capabilities: bool = False
+) -> IpControlMessageV1:
     return IpControlMessageV1(
         message_type=IpControlType.QUERY_CAPABILITIES,
         request_id=request_id,
+        flags=(
+            IpControlFlags.QUERY_TRANSPORT_CAPABILITIES
+            if transport_capabilities
+            else IpControlFlags(0)
+        ),
     )
 
 
@@ -211,10 +224,12 @@ def make_ip_start_request(
     gain_observation_interval_samples: int = 0,
     gain_observation_capacity: int = 0,
     gain_event_capacity: int = 0,
+    transport_flags: IpControlFlags = IpControlFlags(0),
 ) -> IpControlMessageV1:
     return IpControlMessageV1(
         message_type=IpControlType.START_RX,
         request_id=request_id,
+        flags=transport_flags,
         protocol_min=protocol_version,
         protocol_max=protocol_version,
         features=features,
@@ -764,8 +779,7 @@ def _validate_control_message(message: IpControlMessageV1) -> None:
             raise ProtocolError("direct-IP ERROR message requires non-zero status")
         return
 
-    zero_for_query = (
-        int(message.flags),
+    zero_except_flags = (
         message.protocol_min,
         message.protocol_max,
         int(message.features),
@@ -782,13 +796,23 @@ def _validate_control_message(message: IpControlMessageV1) -> None:
         message.stream_id,
     )
     if message_type == IpControlType.QUERY_CAPABILITIES:
-        if any(zero_for_query):
+        if message.flags not in (
+            IpControlFlags(0),
+            IpControlFlags.QUERY_TRANSPORT_CAPABILITIES,
+        ) or any(zero_except_flags):
             raise ProtocolError("direct-IP capability query has non-zero fields")
         return
 
     if message_type == IpControlType.CAPABILITIES:
         if not message.flags & IpControlFlags.FINITE_RX:
             raise ProtocolError("direct-IP gadget does not advertise finite RX")
+        if message.flags & IpControlFlags.QUERY_TRANSPORT_CAPABILITIES:
+            raise ProtocolError("direct-IP capability response retained query flags")
+        if (
+            message.flags & IpControlFlags.USB_CLASS_PACING
+            and not message.flags & IpControlFlags.BUFFERED_FINITE_RX
+        ):
+            raise ProtocolError("direct-IP pacing requires buffered finite RX")
         if not (
             VERSION_V1 <= message.protocol_min <= message.protocol_max <= VERSION_V3
         ):
@@ -813,6 +837,16 @@ def _validate_control_message(message: IpControlMessageV1) -> None:
         return
 
     if message_type in (IpControlType.START_RX, IpControlType.STARTED):
+        transport_flags = (
+            IpControlFlags.BUFFERED_FINITE_RX | IpControlFlags.USB_CLASS_PACING
+        )
+        if message.flags & ~transport_flags:
+            raise ProtocolError("direct-IP START has capability-only flags")
+        if (
+            message.flags & IpControlFlags.USB_CLASS_PACING
+            and not message.flags & IpControlFlags.BUFFERED_FINITE_RX
+        ):
+            raise ProtocolError("direct-IP pacing requires buffered finite RX")
         if (
             message.protocol_min != message.protocol_max
             or message.protocol_min
@@ -871,7 +905,7 @@ def _validate_control_message(message: IpControlMessageV1) -> None:
     if message_type in (IpControlType.STOP_RX, IpControlType.STOPPED):
         if not message.stream_id:
             raise ProtocolError("direct-IP STOP requires a stream ID")
-        if any(zero_for_query[:-1]):
+        if message.flags or any(zero_except_flags[:-1]):
             raise ProtocolError("direct-IP STOP has unrelated fields")
         return
 

--- a/spf/sdrpluto/direct_ip_receiver.py
+++ b/spf/sdrpluto/direct_ip_receiver.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import dataclasses
 import secrets
 import socket
+import struct
 import time
 from contextlib import suppress
 
@@ -36,6 +37,7 @@ DEFAULT_FRAME_TIMEOUT_SECONDS = 10.0
 DEFAULT_CONTROL_ATTEMPTS = 3
 DEFAULT_DATA_RECEIVE_BUFFER_BYTES = 16 * 1024 * 1024
 MAX_CONTROL_DATAGRAM_BYTES = 4096
+SO_RXQ_OVFL = getattr(socket, "SO_RXQ_OVFL", 40)
 
 
 class DirectIpTransportError(RuntimeError):
@@ -52,6 +54,7 @@ class DirectIpCapture:
     duplicate_fragment_count: int
     expired_frame_count: int
     rejected_frame_count: int
+    receive_queue_overflow_count: int
 
 
 class PlutoDirectIpReceiver:
@@ -74,6 +77,7 @@ class PlutoDirectIpReceiver:
         gain_observation_capacity: int = 32,
         gain_event_capacity: int = 0,
         data_receive_buffer_bytes: int = DEFAULT_DATA_RECEIVE_BUFFER_BYTES,
+        minimum_effective_receive_buffer_bytes: int = 0,
         control_timeout_seconds: float = DEFAULT_CONTROL_TIMEOUT_SECONDS,
         frame_timeout_seconds: float = DEFAULT_FRAME_TIMEOUT_SECONDS,
         control_attempts: int = DEFAULT_CONTROL_ATTEMPTS,
@@ -90,6 +94,8 @@ class PlutoDirectIpReceiver:
             raise ValueError("direct-IP control attempts must be positive")
         if data_receive_buffer_bytes <= 0:
             raise ValueError("direct-IP receive buffer must be positive")
+        if minimum_effective_receive_buffer_bytes < 0:
+            raise ValueError("minimum effective receive buffer cannot be negative")
         self.remote_host = remote_host
         self.remote_control_port = int(remote_control_port)
         self.local_host = local_host
@@ -99,6 +105,9 @@ class PlutoDirectIpReceiver:
         self.gain_observation_capacity = int(gain_observation_capacity)
         self.gain_event_capacity = int(gain_event_capacity)
         self.data_receive_buffer_bytes = int(data_receive_buffer_bytes)
+        self.minimum_effective_receive_buffer_bytes = int(
+            minimum_effective_receive_buffer_bytes
+        )
         self.control_timeout_seconds = float(control_timeout_seconds)
         self.frame_timeout_seconds = float(frame_timeout_seconds)
         self.control_attempts = int(control_attempts)
@@ -106,6 +115,9 @@ class PlutoDirectIpReceiver:
         self._data_socket: socket.socket | None = None
         self._remote_ip: str | None = None
         self._capabilities: IpControlMessageV1 | None = None
+        self._effective_data_receive_buffer_bytes = 0
+        self._rxq_overflow_enabled = False
+        self._receive_queue_overflow_count = 0
         self._next_request_id = secrets.randbits(64) or 1
 
     @property
@@ -119,6 +131,12 @@ class PlutoDirectIpReceiver:
         if self._data_socket is None:
             raise RuntimeError("direct-IP receiver is not open")
         return int(self._data_socket.getsockname()[1])
+
+    @property
+    def effective_data_receive_buffer_bytes(self) -> int:
+        if self._data_socket is None:
+            raise RuntimeError("direct-IP receiver is not open")
+        return self._effective_data_receive_buffer_bytes
 
     def open(self) -> None:
         if self._control_socket is not None or self._data_socket is not None:
@@ -142,6 +160,25 @@ class PlutoDirectIpReceiver:
                 socket.SO_RCVBUF,
                 self.data_receive_buffer_bytes,
             )
+            self._effective_data_receive_buffer_bytes = int(
+                data.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)
+            )
+            if (
+                self._effective_data_receive_buffer_bytes
+                < self.minimum_effective_receive_buffer_bytes
+            ):
+                raise DirectIpTransportError(
+                    "direct-IP receive buffer is below the required minimum: "
+                    f"effective={self._effective_data_receive_buffer_bytes}, "
+                    f"required={self.minimum_effective_receive_buffer_bytes}; "
+                    "raise net.core.rmem_max before capture"
+                )
+            try:
+                data.setsockopt(socket.SOL_SOCKET, SO_RXQ_OVFL, 1)
+            except OSError:
+                self._rxq_overflow_enabled = False
+            else:
+                self._rxq_overflow_enabled = True
             data.bind((self.local_host, 0))
             data.settimeout(min(0.25, self.frame_timeout_seconds))
             self._control_socket = control
@@ -159,6 +196,8 @@ class PlutoDirectIpReceiver:
             self._data_socket = None
             self._remote_ip = None
             self._capabilities = None
+            self._effective_data_receive_buffer_bytes = 0
+            self._rxq_overflow_enabled = False
             raise
 
     def close(self) -> None:
@@ -170,6 +209,8 @@ class PlutoDirectIpReceiver:
         self._data_socket = None
         self._remote_ip = None
         self._capabilities = None
+        self._effective_data_receive_buffer_bytes = 0
+        self._rxq_overflow_enabled = False
 
     def capture(self, *, samples_per_channel: int, frame_count: int) -> DirectIpCapture:
         capabilities = self.capabilities
@@ -224,6 +265,9 @@ class PlutoDirectIpReceiver:
             frame_timeout_seconds=self.frame_timeout_seconds
         )
         frames: list[DirectUsbRxFrame] = []
+        datagram_buffer = bytearray(self.max_datagram_bytes)
+        datagram_view = memoryview(datagram_buffer)
+        overflow_at_start = self._receive_queue_overflow_count
         start_time = time.monotonic()
         deadline = start_time + self.frame_timeout_seconds
         capture_error: Exception | None = None
@@ -244,16 +288,15 @@ class PlutoDirectIpReceiver:
                         f"received {len(frames)}/{frame_count} frames, "
                         f"pending={reassembler.pending_frame_count}"
                     )
-                data.settimeout(min(0.25, remaining))
                 try:
-                    datagram, peer = data.recvfrom(self.max_datagram_bytes)
+                    received, peer = self._receive_datagram_into(data, datagram_buffer)
                 except TimeoutError:
                     continue
                 if self._remote_ip is not None and peer[0] != self._remote_ip:
                     raise ProtocolError(
                         f"direct-IP data arrived from unexpected peer {peer[0]}"
                     )
-                for outer in reassembler.feed(datagram, peer=peer[0]):
+                for outer in reassembler.feed(datagram_view[:received], peer=peer[0]):
                     inner_frames = parser.feed(outer.frame)
                     if len(inner_frames) != 1:
                         raise ProtocolError(
@@ -304,7 +347,26 @@ class PlutoDirectIpReceiver:
             duplicate_fragment_count=reassembler.duplicate_fragment_count,
             expired_frame_count=reassembler.expired_frame_count,
             rejected_frame_count=reassembler.rejected_frame_count,
+            receive_queue_overflow_count=(
+                self._receive_queue_overflow_count - overflow_at_start
+            )
+            & 0xFFFFFFFF,
         )
+
+    def _receive_datagram_into(
+        self, data: socket.socket, datagram_buffer: bytearray
+    ) -> tuple[int, tuple[str, int]]:
+        if not self._rxq_overflow_enabled:
+            return data.recvfrom_into(datagram_buffer)
+        received, ancillary, message_flags, peer = data.recvmsg_into(
+            [datagram_buffer], socket.CMSG_SPACE(4)
+        )
+        if message_flags & socket.MSG_TRUNC:
+            raise ProtocolError("direct-IP datagram was truncated by the host socket")
+        for level, kind, payload in ancillary:
+            if level == socket.SOL_SOCKET and kind == SO_RXQ_OVFL and len(payload) >= 4:
+                self._receive_queue_overflow_count = struct.unpack_from("I", payload)[0]
+        return received, peer
 
     def _required_features(self) -> MetadataFeatures:
         features = (

--- a/spf/sdrpluto/direct_ip_receiver.py
+++ b/spf/sdrpluto/direct_ip_receiver.py
@@ -36,7 +36,9 @@ DEFAULT_DIRECT_IP_CONTROL_PORT = 30_432
 DEFAULT_CONTROL_TIMEOUT_SECONDS = 0.5
 DEFAULT_FRAME_TIMEOUT_SECONDS = 10.0
 DEFAULT_CONTROL_ATTEMPTS = 3
-DEFAULT_DATA_RECEIVE_BUFFER_BYTES = 16 * 1024 * 1024
+# One maximum finite request carries 16 dual-CS16 frames of 524,288 samples,
+# or 64 MiB of IQ. Size the requested socket queue for that negotiated bound.
+DEFAULT_DATA_RECEIVE_BUFFER_BYTES = 64 * 1024 * 1024
 MAX_CONTROL_DATAGRAM_BYTES = 4096
 SO_RXQ_OVFL = getattr(socket, "SO_RXQ_OVFL", 40)
 
@@ -319,12 +321,7 @@ class PlutoDirectIpReceiver:
                         f"direct-IP data arrived from unexpected peer {peer[0]}"
                     )
                 for outer in reassembler.feed(datagram_view[:received], peer=peer[0]):
-                    inner_frames = parser.feed(outer.frame)
-                    if len(inner_frames) != 1:
-                        raise ProtocolError(
-                            "one direct-IP outer frame must contain one inner frame"
-                        )
-                    inner = inner_frames[0]
+                    inner = parser.parse_complete_frame(outer.frame)
                     if inner.metadata.stream_id != outer.stream_id:
                         raise ProtocolError("direct-IP inner/outer stream mismatch")
                     if inner.metadata.buffer_sequence != outer.frame_sequence:

--- a/spf/sdrpluto/direct_ip_receiver.py
+++ b/spf/sdrpluto/direct_ip_receiver.py
@@ -11,6 +11,7 @@ from contextlib import suppress
 
 from spf.sdrpluto.direct_ip_protocol import (
     DEFAULT_UDP_DATAGRAM_BYTES,
+    IpControlFlags,
     IpControlMessageV1,
     IpControlType,
     IpFrameReassembler,
@@ -184,10 +185,25 @@ class PlutoDirectIpReceiver:
             self._control_socket = control
             self._data_socket = data
             self._remote_ip = remote[0]
-            query = make_ip_capability_query(request_id=self._request_id())
+            base_query = make_ip_capability_query(request_id=self._request_id())
             capabilities = self._exchange_control(
-                query, expected_type=IpControlType.CAPABILITIES
+                base_query, expected_type=IpControlType.CAPABILITIES
             )
+            extended_query = make_ip_capability_query(
+                request_id=self._request_id(), transport_capabilities=True
+            )
+            try:
+                extended = self._exchange_control(
+                    extended_query, expected_type=IpControlType.CAPABILITIES
+                )
+            except DirectIpTransportError:
+                # RC12 and earlier validate unknown request flags strictly.  A
+                # legacy capability response remains usable at its conservative
+                # pacing rate; the high-rate profile is enabled only after an
+                # explicit echoed capability negotiation.
+                pass
+            else:
+                capabilities = extended
             self._capabilities = capabilities
         except Exception:
             control.close()
@@ -256,6 +272,12 @@ class PlutoDirectIpReceiver:
             ),
             data_port=self.local_data_port,
             max_datagram_bytes=self.max_datagram_bytes,
+            transport_flags=(
+                IpControlFlags.BUFFERED_FINITE_RX | IpControlFlags.USB_CLASS_PACING
+                if capabilities.flags & IpControlFlags.BUFFERED_FINITE_RX
+                and capabilities.flags & IpControlFlags.USB_CLASS_PACING
+                else IpControlFlags(0)
+            ),
         )
         started = self._exchange_control(
             start_request, expected_type=IpControlType.STARTED

--- a/spf/sdrpluto/direct_ip_receiver.py
+++ b/spf/sdrpluto/direct_ip_receiver.py
@@ -37,8 +37,9 @@ DEFAULT_CONTROL_TIMEOUT_SECONDS = 0.5
 DEFAULT_FRAME_TIMEOUT_SECONDS = 10.0
 DEFAULT_CONTROL_ATTEMPTS = 3
 # One maximum finite request carries 16 dual-CS16 frames of 524,288 samples,
-# or 64 MiB of IQ. Size the requested socket queue for that negotiated bound.
-DEFAULT_DATA_RECEIVE_BUFFER_BYTES = 64 * 1024 * 1024
+# or 64 MiB of IQ. Linux accounts socket-buffer space using skb memory rather
+# than payload bytes, so request twice the wire payload for the bounded burst.
+DEFAULT_DATA_RECEIVE_BUFFER_BYTES = 128 * 1024 * 1024
 MAX_CONTROL_DATAGRAM_BYTES = 4096
 SO_RXQ_OVFL = getattr(socket, "SO_RXQ_OVFL", 40)
 
@@ -306,11 +307,19 @@ class PlutoDirectIpReceiver:
             while len(frames) < frame_count:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
+                    pending_frame_count = reassembler.pending_frame_count
+                    receive_queue_overflow_count = (
+                        self._receive_queue_overflow_count - overflow_at_start
+                    ) & 0xFFFFFFFF
                     reassembler.expire(now=time.monotonic())
                     raise DirectIpTransportError(
                         "direct-IP finite RX timed out: "
                         f"received {len(frames)}/{frame_count} frames, "
-                        f"pending={reassembler.pending_frame_count}"
+                        f"pending={pending_frame_count}, "
+                        f"duplicates={reassembler.duplicate_fragment_count}, "
+                        f"expired={reassembler.expired_frame_count}, "
+                        f"rejected={reassembler.rejected_frame_count}, "
+                        f"rxq_overflows={receive_queue_overflow_count}"
                     )
                 try:
                     received, peer = self._receive_datagram_into(data, datagram_buffer)

--- a/spf/sdrpluto/direct_usb_protocol.py
+++ b/spf/sdrpluto/direct_usb_protocol.py
@@ -1471,6 +1471,49 @@ class RxFrameParser:
 
         return frames
 
+    def parse_complete_frame(
+        self, frame: bytes | bytearray | memoryview
+    ) -> DirectUsbRxFrame:
+        """Parse one already-delimited frame without copying it into staging.
+
+        Direct IP has already reassembled and CRC-checked the complete outer
+        frame. Feeding that 4 MiB allocation through the streaming parser made
+        another full-size staging copy before producing the IQ bytes. This
+        strict entry point preserves all metadata/sequence validation while
+        avoiding that redundant copy.
+        """
+
+        if self._buffer:
+            raise ProtocolError("cannot parse a complete frame with staged bytes")
+        view = memoryview(frame)
+        try:
+            current_header_bytes = self.header_bytes
+            if len(view) < current_header_bytes:
+                raise ProtocolError("complete frame is shorter than its header")
+            if self.protocol_version == VERSION_V3:
+                magic, version, current_header_bytes = struct.unpack_from("<IHH", view)
+                if magic != MAGIC or version != VERSION_V3:
+                    raise ProtocolError("bad protocol v3 frame identity")
+                if not HEADER_PREFIX_BYTES_V3 + 4 <= current_header_bytes <= 0xFFFF:
+                    raise ProtocolError("invalid protocol v3 header size")
+                if len(view) < current_header_bytes:
+                    raise ProtocolError("complete frame is shorter than its header")
+            metadata = self.metadata_type.unpack(view[:current_header_bytes])
+            expected_bytes = current_header_bytes + metadata.iq_payload_bytes
+            if len(view) != expected_bytes:
+                raise ProtocolError(
+                    "complete frame length mismatch: "
+                    f"expected {expected_bytes}, got {len(view)}"
+                )
+            self._validate_sequence(metadata)
+            return DirectUsbRxFrame(
+                metadata=metadata,
+                iq_payload=bytes(view[current_header_bytes:]),
+            )
+        except ProtocolError:
+            self.reset()
+            raise
+
     def finish(self) -> None:
         if self._buffer:
             remaining = len(self._buffer)

--- a/tests/radio_hardware/README.md
+++ b/tests/radio_hardware/README.md
@@ -89,11 +89,15 @@ Pluto with a unique reachable IP address and add:
 These flags must only be used after RAM-booting a protocol-v3 candidate. The
 buffered-transport gate negotiates the high-rate profile, requests 16 maximum
 524288-sample frames per START, checks every sequence and loss counter, and
-requires at least 20 MiB/s end to end. The ordered runner repeats that 64 MiB
-burst 20 times by default (320 frames, 1.25 GiB). Override the duration with
+requires at least 20 MiB/s end to end. It uses a 20 MS/s RF rate for this
+contiguous burst—fast enough to keep the IP drain saturated while remaining
+below the Zynq userspace-copy ceiling. The separate production and sample-clock
+gates remain at 30 MS/s. The ordered runner repeats that 64 MiB burst 20 times
+by default (320 frames, 1.25 GiB). Override the duration with
 `SPF_V3_IP_BURN_IN_CYCLES`; lowering the throughput threshold is not part of
-candidate acceptance. The runner temporarily raises `net.core.rmem_max` for
-the test and restores its original value on exit.
+candidate acceptance. The runner temporarily raises `net.core.rmem_max` to at
+least 64 MiB, requires the effective socket queue to cover the full bounded
+burst, and restores the original sysctl on exit.
 
 Run the complete ordered, receive-only candidate campaign with:
 

--- a/tests/radio_hardware/README.md
+++ b/tests/radio_hardware/README.md
@@ -96,8 +96,9 @@ gates remain at 30 MS/s. The ordered runner repeats that 64 MiB burst 20 times
 by default (320 frames, 1.25 GiB). Override the duration with
 `SPF_V3_IP_BURN_IN_CYCLES`; lowering the throughput threshold is not part of
 candidate acceptance. The runner temporarily raises `net.core.rmem_max` to at
-least 64 MiB, requires the effective socket queue to cover the full bounded
-burst, and restores the original sysctl on exit.
+least 128 MiB, requires an effective socket queue of at least 256 MiB so Linux
+has room for both the 64 MiB payload and per-datagram skb accounting, and
+restores the original sysctl on exit.
 
 Run the complete ordered, receive-only candidate campaign with:
 

--- a/tests/radio_hardware/README.md
+++ b/tests/radio_hardware/README.md
@@ -79,15 +79,21 @@ pytest tests/radio_hardware/test_gain_series_v3_hardware.py \
   --radio-report-dir=/tmp/spf-radio-report
 ```
 
-The direct-IP parity test is independently opt-in. Select one Pluto with a
-unique reachable IP address and add:
+The direct-IP parity and performance tests are independently opt-in. Select one
+Pluto with a unique reachable IP address and add:
 
 ```bash
 --radio-direct-ip --radio-direct-ip-host=192.168.1.163
 ```
 
 These flags must only be used after RAM-booting a protocol-v3 candidate. The
-currently promoted protocol-v2 image is expected to reject the test.
+buffered-transport gate negotiates the high-rate profile, requests 16 maximum
+524288-sample frames per START, checks every sequence and loss counter, and
+requires at least 20 MiB/s end to end. The ordered runner repeats that 64 MiB
+burst 20 times by default (320 frames, 1.25 GiB). Override the duration with
+`SPF_V3_IP_BURN_IN_CYCLES`; lowering the throughput threshold is not part of
+candidate acceptance. The runner temporarily raises `net.core.rmem_max` for
+the test and restores its original value on exit.
 
 Run the complete ordered, receive-only candidate campaign with:
 
@@ -99,7 +105,7 @@ Pass the uniquely addressed Pluto as a second argument to include direct-IP
 parity, for example `192.168.1.163`. The runner verifies the image checksum,
 records a protocol-v2 baseline, checks persistent 2R2T configuration, RAM-loads
 the exact attached radio count, re-runs v2 compatibility, then runs v3 USB,
-production-sized V7 Zarr, optional IP, and final identity gates. It never
+production-sized V7 Zarr, optional IP parity/burn-in, and final identity gates. It never
 writes QSPI or enables TX unless the explicit attenuated-loopback option below
 is supplied. A failure leaves the volatile candidate running for inspection
 and prints the explicit rollback command.

--- a/tests/radio_hardware/conftest.py
+++ b/tests/radio_hardware/conftest.py
@@ -118,6 +118,18 @@ def pytest_addoption(parser):
         help="unique LAN address of the selected Pluto direct-IP gadget",
     )
     group.addoption(
+        "--radio-direct-ip-min-payload-mibps",
+        type=float,
+        default=20.0,
+        help="minimum accepted end-to-end payload rate for the buffered IP burst",
+    )
+    group.addoption(
+        "--radio-direct-ip-min-receive-buffer-mib",
+        type=float,
+        default=4.0,
+        help="minimum effective host UDP receive buffer for the IP burst",
+    )
+    group.addoption(
         "--radio-tx-loopback",
         action="store_true",
         help="enable explicitly acknowledged, attenuated TX2 loopback tests",

--- a/tests/radio_hardware/conftest.py
+++ b/tests/radio_hardware/conftest.py
@@ -56,6 +56,15 @@ def pytest_addoption(parser):
         ),
     )
     group.addoption(
+        "--radio-direct-ip-burst-sample-rate",
+        type=float,
+        default=20_000_000.0,
+        help=(
+            "RF rate for the contiguous 16-frame direct-IP burn-in; the "
+            "production single-frame/sample-clock gates remain at 30 MS/s"
+        ),
+    )
+    group.addoption(
         "--radio-time-anchor-max-uncertainty-ms",
         type=float,
         default=5.0,

--- a/tests/radio_hardware/reports/gain_series_v4_rc12_20260810.md
+++ b/tests/radio_hardware/reports/gain_series_v4_rc12_20260810.md
@@ -4,8 +4,7 @@
 
 **PASS for direct USB and bounded one-frame direct IP — RC12 completed the
 two-radio RAM-boot promotion campaign. Continuous multi-frame direct IP is
-rate-limited as documented below and is not qualified at the rover's 3 MS/s
-rate.**
+rate-limited as documented below and is not qualified above 1 MS/s.**
 
 RC12 retains RC11's gain-series, timestamp, USB-startup, and TX fixes and
 hardens the direct-IP control socket against malformed UDP datagrams. The
@@ -179,8 +178,10 @@ The bounded one-frame path was stable:
 
 Continuous finite streaming exposed a transport-rate boundary hidden by the
 original one-frame IP gate. The default 1,472-byte UDP mode deliberately sends
-eight datagrams and then waits 1 ms, or roughly 11.8 MB/s before protocol
-overhead. Dual-channel CS16 requires eight bytes per time sample:
+eight datagrams and then waits 1 ms, or roughly 11.4 MB/s of inner-frame
+payload before lower-layer overhead. Dual-channel CS16 requires eight bytes
+per time sample. This ladder used the hardware test's configured sample rate;
+it was not a reproduction of a production rover configuration:
 
 | Radio sample rate | IQ payload rate | 16 contiguous frames |
 |---:|---:|---|
@@ -191,11 +192,20 @@ overhead. Dual-channel CS16 requires eight bytes per time sample:
 | 1.75–3.0 MS/s | 14.0–24.0 MB/s | Fail closed: sample-sequence gap |
 
 At 1.0 MS/s, a longer 200-START burn-in returned 3,200/3,200 contiguous
-frames, 400 MiB of IQ, with zero failures in 92.9 seconds. At the rover's
-3 MS/s rate, increasing the requested UDP datagram size from 1,472 through
-8,192 bytes did not prevent sequence gaps. Sizes from 16,384 through 65,507
-bytes instead produced whole-frame timeouts, so relying on IP fragmentation is
-not a safe workaround.
+frames, 400 MiB of IQ, with zero failures in 92.9 seconds. At the hardware
+test's 3 MS/s rate, increasing the requested UDP datagram size from 1,472
+through 8,192 bytes did not prevent sequence gaps. Sizes from 16,384 through
+65,507 bytes instead produced whole-frame timeouts, so relying on IP
+fragmentation is not a safe workaround.
+
+The canonical rover production YAMLs configure 30 MS/s, a 524,288-sample
+frame, and one direct frame per request. That is a finite 17.5 ms RF snapshot,
+not a continuous 30 MS/s transport: dual-channel CS16 at 30 MS/s would require
+240 MB/s and cannot fit through either USB 2.0 or 1 GbE. The 1,000-cycle
+one-frame burn-in included a radio booted at 30.72 MS/s and therefore remains
+representative of the bounded production request pattern. Matching direct USB
+means buffering and draining finite snapshots reliably; it does not mean
+claiming an impossible continuous 240 MB/s stream.
 
 Debug output establishes the failure mechanism. While an IP frame is paced to
 the host, DMA and the FPGA sample counter continue advancing. The next queued
@@ -222,10 +232,11 @@ Evidence remains in `/tmp/spf-rc12-ip-burnin-20260810` on the hardware host:
 ## Promotion recommendation
 
 Publish and pin only the exact DFU identified above for the qualified direct-USB
-path. Retain the previous production release and hash as rollback. Do not claim
-continuous direct-IP parity at the rover's 3 MS/s rate; use one-frame bounded
-IP requests or at most the demonstrated 1 MS/s continuous mode until the IP
-transport advertises and enforces a safe rate or is redesigned to avoid stale
-DMA blocks. After SPF CI passes, perform a controlled one-radio QSPI canary,
-reboot it from QSPI, run the V7/USB/TX gates plus the bounded IP gate, and only
-then roll the same bytes to the remaining radios.
+path. Retain the previous production release and hash as rollback. Use
+one-frame bounded IP requests for the current 30 MS/s finite-snapshot pattern,
+or at most the demonstrated 1 MS/s mode when contiguous multi-frame IP is
+required, until the IP transport gains a buffered producer/consumer design and
+an explicit sustained-rate capability. After SPF CI passes, perform a
+controlled one-radio QSPI canary, reboot it from QSPI, run the V7/USB/TX gates
+plus the bounded IP gate, and only then roll the same bytes to the remaining
+radios.

--- a/tests/radio_hardware/reports/gain_series_v4_rc12_20260810.md
+++ b/tests/radio_hardware/reports/gain_series_v4_rc12_20260810.md
@@ -2,7 +2,10 @@
 
 ## Disposition
 
-**PASS — RC12 completed the two-radio RAM-boot promotion campaign.**
+**PASS for direct USB and bounded one-frame direct IP — RC12 completed the
+two-radio RAM-boot promotion campaign. Continuous multi-frame direct IP is
+rate-limited as documented below and is not qualified at the rover's 3 MS/s
+rate.**
 
 RC12 retains RC11's gain-series, timestamp, USB-startup, and TX fixes and
 hardens the direct-IP control socket against malformed UDP datagrams. The
@@ -156,9 +159,73 @@ Both then reported gadget SHA
 `2072e1d0823ef6db3bc141dd733a90d76e23fc33`, TX1/TX2 at `-80 dB`, and passed
 the production baseline 6/6.
 
+## Extended direct-IP burn-in
+
+An additional RAM-only campaign exercised the uniquely routed LAN radio after
+the initial promotion gate. It injected malformed control datagrams throughout,
+validated every CRC-backed protocol-v3 frame and gain-observation series, and
+restored both radios to their unchanged QSPI image afterward.
+
+The bounded one-frame path was stable:
+
+- 1,000 fresh START/STOP cycles passed with 1,000 unique stream IDs;
+- mixed frame sizes were 16,384, 32,768, 131,072, and 524,288 samples/channel;
+- 1,409,024,000 IQ bytes (1.312 GiB) were validated in 340.0 seconds;
+- all 600 injected malformed control datagrams were survived;
+- duplicate fragments, expired frames, rejected frames, sequence regressions,
+  metadata errors, and daemon deaths were all zero;
+- median/max time-anchor round trip was 0.527/3.603 ms; and
+- median/max local gain-read duration was 0.384/12.564 ms.
+
+Continuous finite streaming exposed a transport-rate boundary hidden by the
+original one-frame IP gate. The default 1,472-byte UDP mode deliberately sends
+eight datagrams and then waits 1 ms, or roughly 11.8 MB/s before protocol
+overhead. Dual-channel CS16 requires eight bytes per time sample:
+
+| Radio sample rate | IQ payload rate | 16 contiguous frames |
+|---:|---:|---|
+| 1.0 MS/s | 8.0 MB/s | Pass |
+| 1.2 MS/s | 9.6 MB/s | Fail closed: sample-sequence gap |
+| 1.4 MS/s | 11.2 MB/s | Fail closed: sample-sequence gap |
+| 1.5 MS/s | 12.0 MB/s | Fail closed: sample-sequence gap |
+| 1.75–3.0 MS/s | 14.0–24.0 MB/s | Fail closed: sample-sequence gap |
+
+At 1.0 MS/s, a longer 200-START burn-in returned 3,200/3,200 contiguous
+frames, 400 MiB of IQ, with zero failures in 92.9 seconds. At the rover's
+3 MS/s rate, increasing the requested UDP datagram size from 1,472 through
+8,192 bytes did not prevent sequence gaps. Sizes from 16,384 through 65,507
+bytes instead produced whole-frame timeouts, so relying on IP fragmentation is
+not a safe workaround.
+
+Debug output establishes the failure mechanism. While an IP frame is paced to
+the host, DMA and the FPGA sample counter continue advancing. The next queued
+DMA block can then predate all retained gain observations. The v3 worker
+correctly refuses that IQ because it cannot associate the required gain series;
+the host independently rejects any resulting sample discontinuity. The gadget
+currently advertises up to 16 finite frames without advertising a rate limit,
+so host-side capability discovery alone cannot predict this boundary.
+
+Evidence remains in `/tmp/spf-rc12-ip-burnin-20260810` on the hardware host:
+
+- one-frame burn-in SHA-256:
+  `fe229da26e4f224961c123591501edc7b37cc842cbb605fb7b52fb0c3b3cbce0`;
+- 1 MS/s continuous burn-in SHA-256:
+  `7b43324bb70b004cf42ba04b99449a6d52f6a000dd5603643f327b1451df44e0`;
+- sample-rate ladder SHA-256:
+  `ae426ed962931b033c2afd99092b0572404713c52944cf701f09959ce6a59c50`;
+- datagram-size ladder SHA-256:
+  `3c0e41948ba49b2e2ef63a94aad100fe7534fc78338f8b5ea18a60746096b50a`;
+  and
+- on-radio debug trace SHA-256:
+  `583e3b804094d91aefb37b28c4ea8fae1f4be3fd948c9fc93f176506719c7fae`.
+
 ## Promotion recommendation
 
-Publish and pin only the exact DFU identified above. Retain the previous
-production release and hash as rollback. After SPF CI passes, perform a
-controlled one-radio QSPI canary, reboot it from QSPI, run the V7/IP/TX gates,
-and only then roll the same bytes to the remaining radios.
+Publish and pin only the exact DFU identified above for the qualified direct-USB
+path. Retain the previous production release and hash as rollback. Do not claim
+continuous direct-IP parity at the rover's 3 MS/s rate; use one-frame bounded
+IP requests or at most the demonstrated 1 MS/s continuous mode until the IP
+transport advertises and enforces a safe rate or is redesigned to avoid stale
+DMA blocks. After SPF CI passes, perform a controlled one-radio QSPI canary,
+reboot it from QSPI, run the V7/USB/TX gates plus the bounded IP gate, and only
+then roll the same bytes to the remaining radios.

--- a/tests/radio_hardware/reports/gain_series_v4_rc12_20260810.md
+++ b/tests/radio_hardware/reports/gain_series_v4_rc12_20260810.md
@@ -1,0 +1,164 @@
+# Gain-series v4 RC12 hardware gate — 2026-08-10
+
+## Disposition
+
+**PASS — RC12 completed the two-radio RAM-boot promotion campaign.**
+
+RC12 retains RC11's gain-series, timestamp, USB-startup, and TX fixes and
+hardens the direct-IP control socket against malformed UDP datagrams. The
+exact candidate passed three independent two-radio RAM boots, physical TX2
+loopback on both radios after every boot, protocol-v2 compatibility,
+protocol-v3 USB stress, simultaneous USB, a 100-record-per-radio V7 round
+trip, malformed direct-IP traffic, and a real direct-IP frame.
+
+The candidate was loaded only into volatile RAM. Both radios were restored to
+the preserved QSPI production firmware after testing and passed the production
+direct-USB baseline again.
+
+## Candidate identity
+
+- Firmware main commit: `fa5f95f0af2a0586c80b54eff7ae04512cb96f7f`
+- USB gadget commit: `e14eae63ac6b7fe51828e85de34a8d4e1c50d49e`
+- Direct-IP gadget commit: `e44821f6d2737e3cdf452a017787f11c451fe04e`
+- Buildroot commit: `950b336d3a933c3f56ecd4ec20266502c775cf54`
+- HDL commit: `5360aeac83013e8e3aa0b5d4e0a9b32280fe1677`
+- HDL Quantulum commit: `55803cd3d7f74dccd7bf43dc713f832d1eeaf2e6`
+- Linux commit: `d798b0d821b85ebd51ecffbfa68d8e4d69b77132`
+- U-Boot commit: `1ff0468e9bea29b0a768a7bf52db8d025c521b9a`
+- GitHub Actions run: [31342525077](https://github.com/misko/plutosdr-fw/actions/runs/31342525077)
+- Artifact: `plutoplus-main-fa5f95f0af2a0586c80b54eff7ae04512cb96f7f-31342525077-1`
+- Bundle: `plutoplus-spf-main-fa5f95f0af2a.tar.gz`
+- Bundle SHA-256: `34264a491a387cd82aba178428069bf66b0b1ec67c28ba886f2627d77c67a457`
+- DFU: `plutoplus-spf-main-fa5f95f0af2a-pluto.dfu`
+- DFU SHA-256: `2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4`
+- Packaged device-fw: `v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9`
+- Tested boot mode: volatile DFU/RAM only
+
+The public Kalman build and GitHub's independent verification/attestation job
+both passed. A fresh download passed its adjacent bundle checksum, every entry
+in `SHA256SUMS`, and every entry in `PAYLOAD_SHA256SUMS`.
+
+Routed timing passed with setup WNS `+0.504 ns`, hold WHS `+0.014 ns`, and
+zero failing setup, hold, or pulse-width endpoints.
+
+## RC11 persistent-canary findings
+
+RC11 had passed the original RAM-only release campaign. A subsequent
+persistent-QSPI canary exposed two additional operational issues before fleet
+promotion:
+
+1. A Pluto reboot restored both TX hardware-gain readbacks to `-10 dB`. No DDS
+   or DMA waveform was active, so this was not observed RF emission, but it was
+   not a fail-closed boot state. SPF now removes stale mute evidence and runs
+   `spf.scripts.mute_pluto_tx` after every RAM/QSPI transition and before
+   publishing rover readiness. A mute failure leaves readiness absent and
+   blocks collection.
+2. A four-byte unknown UDP control datagram caused RC11's `sdr_ip_gadget` to
+   return a fatal epoll-handler result and terminate. RC12 classifies control
+   envelopes before legacy parsing and silently drops undersized or unknown
+   datagrams. Native tests cover null, short, legacy, protocol-v3, time-anchor,
+   and unknown envelopes.
+
+An earlier manual direct-IP timeout was separately traced to a stale DHCP
+address: the LAN radio moved from `192.168.1.179` to `192.168.1.181` after a
+reboot. The automated campaign resolves the candidate address from the radio's
+USB serial and successfully followed it to `192.168.1.163`. IP address is never
+treated as radio identity.
+
+## Bench fixture
+
+Each radio had TX2 routed through the declared 30 dB attenuated splitter path
+to that radio's RX1 and RX2. Tests activate one TX2 at a time, hold TX1 at
+`-80 dB`, and verify both transmitters at `-80 dB` after every stage.
+
+| Radio serial | USB physical path | Additional transport |
+|---|---|---|
+| `104000bac4950008230026001b440a003a` | `1-1.1` | USB IIO and direct USB |
+| `1040007c4a94000211000b009186843ef2` | `1-1.2` | USB IIO, direct USB, and LAN direct IP |
+
+## Promotion gates
+
+Campaign root:
+
+`/tmp/spf-gain-series-v4-rc12-20260810T000826Z-hardware`
+
+| Gate | Result |
+|---|---|
+| Production protocol-v2 baseline | 6 passed |
+| Persistent AD9361/2R2T configuration | Both serials passed |
+| Shared-hub RC12 RAM loads | 3/3 epochs passed |
+| Immediate post-boot TX mute | Both radios, all epochs passed |
+| Internal cyclic TX through timestamp FIFO | Both radios, all epochs passed |
+| External TX2 loopback and live gain series | Both radios, all epochs passed |
+| Explicit post-TX mute | Both radios, all epochs passed |
+| Protocol-v2 compatibility at 524,288 samples | 6 passed |
+| Protocol-v3 USB | Passed on both radios |
+| Fresh protocol-v3 START stress | 100 streams/radio, 600 frames total passed |
+| Simultaneous protocol-v3 USB | Passed |
+| Production-sized V7 Zarr | 100 records/radio written and reopened |
+| Malformed direct-IP datagrams | Lengths 0, 1, 3, 4, 4, and 80 survived |
+| Protocol-v3 direct-IP frame | Passed; 162 gain observations |
+| Post-rollback production baseline | 6 passed |
+| Final TX state | TX1/TX2 `-80 dB` on both radios |
+
+The repeated-start evidence SHA-256 is
+`bfdcdbab3419fcd39ac94a5c46edf27156777378f8c7a8e4683ad5ef45d25db0`.
+The malformed-IP evidence SHA-256 is
+`9059c9e60ee49d102abde228b3b29d2c6ded2686fde53422fe06a52839b318f8`.
+The real direct-IP frame evidence SHA-256 is
+`b65fbda3d0a6d181627829e8fa2bc3858ec15a6c4def60e9714d6658dcacaa1c`.
+
+## TX measurements
+
+All six radio/epoch measurements passed frequency, SNR, clipping, coherence,
+phase stability, manual-gain metadata, slow-attack response, and mute checks.
+
+| Epoch | Radio | RX1/RX2 tone (dBFS) | Coherence | Phase std | AGC reduction RX1/RX2 | Mute delta RX1/RX2 |
+|---:|---|---|---:|---:|---|---|
+| 1 | `…0a003a` | `-41.54/-27.33` | `0.9999903` | `0.111°` | `29/29 dB` | `76.1/76.0 dB` |
+| 1 | `…843ef2` | `-41.48/-27.88` | `0.9999992` | `0.030°` | `28/28 dB` | `83.9/96.8 dB` |
+| 2 | `…0a003a` | `-41.52/-27.29` | `0.9999992` | `0.023°` | `29/29 dB` | `84.4/68.6 dB` |
+| 2 | `…843ef2` | `-41.41/-27.84` | `0.9999971` | `0.076°` | `28/28 dB` | `77.6/98.0 dB` |
+| 3 | `…0a003a` | `-41.51/-27.30` | `0.9999877` | `0.149°` | `29/29 dB` | `77.3/79.9 dB` |
+| 3 | `…843ef2` | `-41.48/-27.84` | `0.9999992` | `0.028°` | `28/28 dB` | `81.6/89.5 dB` |
+
+## Timing and gain-series evidence
+
+The requested gain observation interval was 2,048 samples. The ARM/SPI reads
+remain best-effort and their actual FPGA sample-counter bounds are
+authoritative; this does not claim sample-exact CTRL_OUT event capture.
+
+- Sequential USB sample-time uncertainty: at most `0.456 ms` in the smoke run.
+- Simultaneous USB sample-time uncertainty: at most `0.509 ms`.
+- Direct-IP sample-time uncertainty: `0.374 ms`.
+- Direct-IP 524,288-sample frame: 162 valid gain observations.
+
+All timing results remain below the 5 ms promotion threshold. Host realtime is
+not asserted to be GNSS-synchronized UTC.
+
+## Recovery and automation corrections
+
+The candidate runner now:
+
+- mutes all attached radios before testing, immediately after every RAM boot,
+  after each TX stage, and on every exit—including receive-only failures;
+- executes the malformed-IP survival test before normal direct-IP capture; and
+- prints a rollback command containing the exact candidate image, SHA, serial
+  count, and campaign-specific state root.
+
+The original generic rollback wrapper correctly refused to guess when its
+default directory contained multiple historical state records. Using the
+campaign-specific state root restored both radios to:
+
+`v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d`
+
+Both then reported gadget SHA
+`2072e1d0823ef6db3bc141dd733a90d76e23fc33`, TX1/TX2 at `-80 dB`, and passed
+the production baseline 6/6.
+
+## Promotion recommendation
+
+Publish and pin only the exact DFU identified above. Retain the previous
+production release and hash as rollback. After SPF CI passes, perform a
+controlled one-radio QSPI canary, reboot it from QSPI, run the V7/IP/TX gates,
+and only then roll the same bytes to the remaining radios.

--- a/tests/radio_hardware/reports/gain_series_v4_rc16_20260810.md
+++ b/tests/radio_hardware/reports/gain_series_v4_rc16_20260810.md
@@ -2,9 +2,11 @@
 
 ## Disposition
 
-**PASS for the complete two-radio RAM promotion gate, including direct USB,
-direct IP, TX2 loopback, protocol-v2 compatibility, and V7 Zarr. Proceed to a
-controlled one-radio QSPI canary; do not perform a fleet rollout yet.**
+**PASS for the complete two-radio RAM promotion gate and the controlled
+one-radio persistent-QSPI canary, including direct USB, direct IP, TX2
+loopback, protocol-v2 compatibility, and V7 Zarr. RC16 is hardware-qualified;
+keep the second bench radio on the prior image until the SPF promotion change
+is reviewed and merged.**
 
 RC16 restores maximum finite-burst direct-IP throughput to the same practical
 20–22 MiB/s range measured by direct USB on this host. The exact public-build
@@ -12,10 +14,13 @@ DFU transferred 320 maximum-size frames (1.25 GiB) at 21.33 MiB/s with no
 missing frames, sequence gaps, partial reassemblies, rejected fragments,
 duplicate fragments, or receive-queue overflows.
 
-The candidate was tested only through volatile DFU/RAM boot. QSPI was not
-modified. After testing, both radios were explicitly reset into the preserved
-production QSPI image, TX1/TX2 were verified at `-80 dB`, and the production
-protocol-v2 baseline passed 6/6.
+The complete two-radio campaign used volatile DFU/RAM boot. After it passed,
+both radios were explicitly reset into the preserved production QSPI image,
+TX1/TX2 were verified at `-80 dB`, and the production protocol-v2 baseline
+passed 6/6. The exact release image was then written to the firmware partition
+of one serial-scoped canary. It survived an additional QSPI reboot and passed
+the selected USB, TX, V7, and direct-IP gates. The second radio was not
+persistently modified.
 
 ## Candidate identity
 
@@ -35,7 +40,8 @@ protocol-v2 baseline passed 6/6.
 - DFU: `plutoplus-spf-main-867e18542311-pluto.dfu`
 - DFU SHA-256: `27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911`
 - Packaged device-fw: `v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1`
-- Tested boot mode: volatile DFU/RAM only
+- Tested boot modes: volatile DFU/RAM on both radios; persistent QSPI/mtd3 on
+  one canary radio
 
 The GitHub build, independent verification job, adjacent bundle checksum,
 `SHA256SUMS`, and `PAYLOAD_SHA256SUMS` all passed. The packaged gadget binaries
@@ -91,6 +97,55 @@ Key evidence SHA-256 values:
 - malformed direct IP: `0bae317f667521cd7d8aeb1f4f5a8450e837802452ec30948a8ff1dceeb011a2`;
 - direct-IP frame: `3a2ef73877e656b21406a04b64bbc5590455a8d78fd2ea7f5bfe168517c1ea35`;
 - direct-IP maximum burst: `521c21ec99f1cd82773757b3b3c1226fbe9a094226527327a0a67a76c208a02f`.
+
+## Persistent-QSPI canary
+
+Canary evidence root:
+
+`/tmp/spf-gain-series-v4-rc16-qspi-canary-20260810T7b9QnYBA`
+
+The canary was serial `1040007c4a94000211000b009186843ef2` on physical USB
+path `1-1.2`. The release DFU was converted to a firmware-only `pluto.frm` with
+SHA-256
+`8d2623b6f8b5e5fd69d214afed20fe48dce4cd4aa0fe4714fc9825f1dccad415`.
+Only `/dev/sda1` for that serial was mounted, and only `pluto.frm` was copied;
+no zip or `boot.frm` was used.
+
+The QSPI bootloader partition MD5 remained
+`0f7a6f28fc080815d45164316533bcc4` before the write, after the updater reboot,
+and after a second explicit reboot. The firmware partition MD5 became
+`4bf8e04810a984e2550cf02949758665`. Both persistent boots reported the exact
+packaged device-fw and USB gadget build ID. Both `sdr_usb_gadget` and
+`sdr_ip_gadget` were running after the second boot.
+
+| Persistent gate | Result |
+|---|---|
+| Exact device-fw and gadget SHA after updater reboot | Passed |
+| Exact device-fw and gadget SHA after second reboot | Passed |
+| Bootloader/mtd0 hash unchanged | Passed |
+| Protocol-v3 USB observations | Passed |
+| Fresh USB START/STOP stress | 100 cycles passed |
+| Internal cyclic TX and external TX2 loopback | 2 passed |
+| Hardware-backed V7 Zarr | 100 records written and reopened in 1:44 |
+| Malformed direct-IP recovery and common V3 frame | Passed |
+| Maximum direct-IP finite burst | 20 cycles, 320 frames, 1.25 GiB passed |
+| Final host `net.core.rmem_max` | Restored to `212992` |
+| Final TX state | TX1/TX2 `-80 dB` on both radios |
+
+The persistent maximum burst sustained `21.81 MiB/s` aggregate
+(`19.77`–`22.05 MiB/s` per request) with a 256 MiB effective socket queue and
+zero duplicate, expired, rejected, or receive-queue-overflow events.
+
+The reboot also exposed a host discovery ambiguity: the same canary serial was
+reachable through LAN and the Pluto USB-Ethernet `192.168.2.1` route. The LAN
+resolver now filters neighbors by the kernel's actual egress interface. A
+focused test first reproduced the duplicate match, then passed with the fix;
+live resolution selected only the current LAN address.
+
+SPF CI run
+[31367605275](https://github.com/misko/spf/actions/runs/31367605275) passed at
+commit `9710e0347312454d29150e83bbb28af095b78a00`: 1,497 passed, 32 skipped,
+and 2 expected failures.
 
 ## Direct-IP result and root cause
 
@@ -186,10 +241,11 @@ Both hardware radios were finally restored to:
 
 ## Promotion recommendation
 
-1. Publish a release containing only the exact DFU identified above.
-2. Update the production manifest/config pins only after the release asset and
-   its checksums are independently re-downloaded and verified.
-3. Persist the image to one radio, reboot from QSPI, and rerun USB, V7, TX,
-   malformed-IP, and maximum-burst gates.
-4. Keep the prior production DFU and QSPI image as rollback.
-5. Promote to the remaining radios only after the persistent canary passes.
+1. Review and merge the SPF production pin and host transport changes.
+2. Keep the prior production DFU and generated QSPI image as rollback.
+3. Roll RC16 to the remaining radios through the checksum-pinned, mtd3-only
+   boot preparation path.
+4. Verify exact device-fw, gadget SHA, serial/path identity, and TX mute after
+   each radio's first persistent boot.
+5. Retain protocol-v2 compatibility tests; canonical production and active
+   calibration configs now explicitly select protocol v3 gain-series metadata.

--- a/tests/radio_hardware/reports/gain_series_v4_rc16_20260810.md
+++ b/tests/radio_hardware/reports/gain_series_v4_rc16_20260810.md
@@ -28,6 +28,7 @@ protocol-v2 baseline passed 6/6.
 - Linux commit: `d798b0d821b85ebd51ecffbfa68d8e4d69b77132`
 - U-Boot commit: `1ff0468e9bea29b0a768a7bf52db8d025c521b9a`
 - GitHub Actions run: [31360123948](https://github.com/misko/plutosdr-fw/actions/runs/31360123948)
+- Release: [v0.38-plutoplus-spf-gain-series-v4-rc16](https://github.com/misko/plutosdr-fw/releases/tag/v0.38-plutoplus-spf-gain-series-v4-rc16)
 - Artifact: `plutoplus-main-867e18542311c25f5c1980bbdcfffc823e56f0a2-31360123948-1`
 - Bundle: `plutoplus-spf-main-867e18542311.tar.gz`
 - Bundle SHA-256: `b026afe9bed713dea58d51789749dcebfc5ebbcf580883188937fd4db07b40d9`
@@ -39,6 +40,11 @@ protocol-v2 baseline passed 6/6.
 The GitHub build, independent verification job, adjacent bundle checksum,
 `SHA256SUMS`, and `PAYLOAD_SHA256SUMS` all passed. The packaged gadget binaries
 were verified as ARM32 executables from the pinned source graph.
+
+After publication, every asset was downloaded again into a fresh directory.
+The release bundle matched its adjacent SHA-256 sidecar, all 30 entries in the
+nested `SHA256SUMS` passed, and all four deployable payloads matched
+`PAYLOAD_SHA256SUMS`, including the tested DFU digest above.
 
 Routed timing passed with setup WNS `+0.504 ns`, hold WHS `+0.014 ns`, and
 zero failing setup, hold, or pulse-width endpoints.
@@ -187,4 +193,3 @@ Both hardware radios were finally restored to:
    malformed-IP, and maximum-burst gates.
 4. Keep the prior production DFU and QSPI image as rollback.
 5. Promote to the remaining radios only after the persistent canary passes.
-

--- a/tests/radio_hardware/reports/gain_series_v4_rc16_20260810.md
+++ b/tests/radio_hardware/reports/gain_series_v4_rc16_20260810.md
@@ -1,0 +1,190 @@
+# Gain-series v4 RC16 hardware gate — 2026-08-10
+
+## Disposition
+
+**PASS for the complete two-radio RAM promotion gate, including direct USB,
+direct IP, TX2 loopback, protocol-v2 compatibility, and V7 Zarr. Proceed to a
+controlled one-radio QSPI canary; do not perform a fleet rollout yet.**
+
+RC16 restores maximum finite-burst direct-IP throughput to the same practical
+20–22 MiB/s range measured by direct USB on this host. The exact public-build
+DFU transferred 320 maximum-size frames (1.25 GiB) at 21.33 MiB/s with no
+missing frames, sequence gaps, partial reassemblies, rejected fragments,
+duplicate fragments, or receive-queue overflows.
+
+The candidate was tested only through volatile DFU/RAM boot. QSPI was not
+modified. After testing, both radios were explicitly reset into the preserved
+production QSPI image, TX1/TX2 were verified at `-80 dB`, and the production
+protocol-v2 baseline passed 6/6.
+
+## Candidate identity
+
+- Firmware main commit: `867e18542311c25f5c1980bbdcfffc823e56f0a2`
+- USB gadget commit: `2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552`
+- Direct-IP gadget commit: `7cae12eb62cfb2fb656169bd1cfe7da2a0aff583`
+- Buildroot commit: `ac893d30559baf00df34c38e0b9e5c9e62500f46`
+- HDL commit: `5360aeac83013e8e3aa0b5d4e0a9b32280fe1677`
+- HDL Quantulum commit: `55803cd3d7f74dccd7bf43dc713f832d1eeaf2e6`
+- Linux commit: `d798b0d821b85ebd51ecffbfa68d8e4d69b77132`
+- U-Boot commit: `1ff0468e9bea29b0a768a7bf52db8d025c521b9a`
+- GitHub Actions run: [31360123948](https://github.com/misko/plutosdr-fw/actions/runs/31360123948)
+- Artifact: `plutoplus-main-867e18542311c25f5c1980bbdcfffc823e56f0a2-31360123948-1`
+- Bundle: `plutoplus-spf-main-867e18542311.tar.gz`
+- Bundle SHA-256: `b026afe9bed713dea58d51789749dcebfc5ebbcf580883188937fd4db07b40d9`
+- DFU: `plutoplus-spf-main-867e18542311-pluto.dfu`
+- DFU SHA-256: `27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911`
+- Packaged device-fw: `v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1`
+- Tested boot mode: volatile DFU/RAM only
+
+The GitHub build, independent verification job, adjacent bundle checksum,
+`SHA256SUMS`, and `PAYLOAD_SHA256SUMS` all passed. The packaged gadget binaries
+were verified as ARM32 executables from the pinned source graph.
+
+Routed timing passed with setup WNS `+0.504 ns`, hold WHS `+0.014 ns`, and
+zero failing setup, hold, or pulse-width endpoints.
+
+## Bench fixture
+
+Each radio had TX2 routed through the declared 30 dB attenuated splitter path
+to that radio's RX1 and RX2. Tests activate one TX2 at a time, hold TX1 at
+`-80 dB`, and verify both transmitters at `-80 dB` after every stage.
+
+| Radio serial | USB physical path | Additional transport |
+|---|---|---|
+| `104000bac4950008230026001b440a003a` | `1-1.1` | USB IIO and direct USB |
+| `1040007c4a94000211000b009186843ef2` | `1-1.2` | USB IIO, direct USB, and LAN direct IP |
+
+## Promotion gates
+
+Campaign root:
+
+`/tmp/spf-gain-series-v4-rc16-rmem128-full-20260810T073500Z-hardware`
+
+| Gate | Result |
+|---|---|
+| Persistent AD9361/2R2T configuration | Both serials passed |
+| Shared-hub RC16 RAM loads | 3/3 epochs passed |
+| Immediate post-boot TX mute | Both radios, all epochs passed |
+| Internal cyclic TX through timestamp FIFO | Both radios, all epochs passed |
+| External TX2 loopback and live gain series | Both radios, all epochs passed |
+| Explicit post-TX mute | Both radios, all epochs passed |
+| Protocol-v2 compatibility at 524,288 samples | 6 passed |
+| Protocol-v3 USB | Passed on both radios |
+| Fresh protocol-v3 START stress | 100 streams/radio, 600 frames total passed |
+| Simultaneous protocol-v3 USB | Passed |
+| Production-sized V7 Zarr | 100 records/radio written and reopened in 3:28 |
+| Malformed direct-IP datagrams | Survived; subsequent valid request passed |
+| Protocol-v3 direct-IP frame | Passed with 162 gain observations |
+| Maximum direct-IP finite burst | 20 cycles, 320 frames, 1.25 GiB passed |
+| Post-rollback production baseline | 6 passed |
+| Final TX state | TX1/TX2 `-80 dB` on both radios |
+
+Key evidence SHA-256 values:
+
+- repeated USB starts: `1898609cc5a3cac13fdbec84605504a1b35a5c2b77209fd8f8fbeb4209a031a0`;
+- malformed direct IP: `0bae317f667521cd7d8aeb1f4f5a8450e837802452ec30948a8ff1dceeb011a2`;
+- direct-IP frame: `3a2ef73877e656b21406a04b64bbc5590455a8d78fd2ea7f5bfe168517c1ea35`;
+- direct-IP maximum burst: `521c21ec99f1cd82773757b3b3c1226fbe9a094226527327a0a67a76c208a02f`.
+
+## Direct-IP result and root cause
+
+RC12 coupled DMA capture to paced UDP transmission. At about 11.36 MiB/s,
+later DMA blocks could become too old to associate with retained gain
+observations, so multi-frame requests correctly failed closed with a sample
+gap. RC16 separates the operations:
+
+1. capture the complete finite request into eight kernel IIO buffers and a
+   bounded on-radio queue;
+2. snapshot gain metadata while capture is active;
+3. drain the queue over MTU-safe UDP using GSO and absolute pacing; and
+4. validate the common inner V3 frame, sequence, CRC, and metadata on the host.
+
+The first exact-RC16 campaign then exposed a host-only queue-sizing issue. A
+64 MiB IQ request produced a nominal 128 MiB effective `SO_RCVBUF`, but Linux
+charges UDP socket memory by skb allocation, not just payload bytes. Tens of
+thousands of 1,472-byte datagrams exhausted that queue and left 12/16 complete
+frames plus three partial frames. This was not a radio DMA, gain-series, or
+wire-rate regression.
+
+The qualified host setting requests 128 MiB with `net.core.rmem_max` at least
+128 MiB. Linux reports a 256 MiB effective socket queue, leaving room for the
+64 MiB IQ payload and skb overhead. The campaign restores the original sysctl
+on every exit.
+
+| Measurement | Result |
+|---|---:|
+| Radio burst sample rate | 20 MS/s |
+| Frames per finite request | 16 |
+| Samples per channel per frame | 524,288 |
+| IQ payload per request | 64 MiB |
+| Burn-in requests | 20 |
+| Total frames / payload | 320 / 1.25 GiB |
+| Aggregate payload throughput | 21.33 MiB/s |
+| Minimum / maximum request throughput | 18.68 / 22.07 MiB/s |
+| Effective host receive queue | 256 MiB |
+| Duplicate / expired / rejected fragments | 0 / 0 / 0 |
+| Socket receive-queue overflows | 0 |
+
+Before the final gate, three independent exact-binary burn-ins with the same
+256 MiB effective queue transferred another 960 frames / 3.75 GiB without a
+sequence, reassembly, or kernel UDP error. Their aggregate rates were 21.89,
+21.95, and 21.58 MiB/s.
+
+This qualifies the maximum finite burst. It does not claim that 20 MS/s of
+dual-CS16 can stream indefinitely over this transport: that source rate is
+160 MB/s, while the finite request is captured first and drained afterward.
+
+## TX, timing, and gain-series evidence
+
+All six radio/epoch TX measurements passed tone frequency, SNR, clipping,
+coherence, phase stability, manual-gain metadata, slow-attack response, and
+mute checks. Coherence was at least `0.9999965`, within-capture phase standard
+deviation was at most `0.080 degrees`, and AGC reduced both channels by 28 or
+29 dB. The smallest measured active-to-muted tone reduction was 67.4 dB.
+
+The requested gain-observation interval was 2,048 samples. ARM/SPI snapshots
+remain best-effort; their FPGA sample-counter brackets are authoritative. This
+does not claim sample-exact CTRL_OUT event capture.
+
+- Sequential USB sample-time uncertainty: at most `0.482 ms`.
+- Simultaneous USB sample-time uncertainty: at most `0.547 ms`.
+- Direct-IP sample-time uncertainty: `0.379 ms`.
+- Direct-IP 524,288-sample frame: 162 valid gain observations.
+
+All timing results remain below the 5 ms promotion threshold. Host realtime is
+not asserted to be GNSS-synchronized UTC.
+
+## Candidate history
+
+| Candidate | Finding | Resolution |
+|---|---|---|
+| RC14 | USB path passed; IP retained the old coupled capture/send failure | Added bounded capture-first queue and GSO sender |
+| RC15 source build | 320 frames / 1.25 GiB passed at 21.94 MiB/s | Sent exact source graph to the public builder |
+| RC15 public build | Buildroot headers lacked the `UDP_SEGMENT` definition | Added the Linux ABI-compatible fallback value and rebuilt |
+| RC16 first exact campaign | 64 MiB host request was marginal after skb accounting | Raised request to 128 MiB / 256 MiB effective and added overflow diagnostics |
+| RC16 final campaign | Every USB, IP, TX, V7, compatibility, and recovery gate passed | Ready for controlled QSPI canary |
+
+## Recovery automation correction
+
+The campaign also exposed an ambiguity in the rollback helper. If a candidate
+was already RAM-booted before the campaign, the saved pre-load version string
+could equal the active version and `rollback-all` could skip the reset even
+though the boot mode remained volatile. The helper now treats an explicit
+rollback literally: it always resets each serial into QSPI and then verifies
+the preserved version and physical USB identity. A focused regression test
+covers the equal-version/unknown-boot-mode case.
+
+Both hardware radios were finally restored to:
+
+`v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d`
+
+## Promotion recommendation
+
+1. Publish a release containing only the exact DFU identified above.
+2. Update the production manifest/config pins only after the release asset and
+   its checksums are independently re-downloaded and verified.
+3. Persist the image to one radio, reboot from QSPI, and rerun USB, V7, TX,
+   malformed-IP, and maximum-burst gates.
+4. Keep the prior production DFU and QSPI image as rollback.
+5. Promote to the remaining radios only after the persistent canary passes.
+

--- a/tests/radio_hardware/run_gain_series_v3_candidate.sh
+++ b/tests/radio_hardware/run_gain_series_v3_candidate.sh
@@ -120,7 +120,7 @@ readonly LOOPBACK_ATTENUATION_DB="$loopback_attenuation_db"
 [[ -f "$TEST_FILE" ]] || die "protocol-v3 hardware tests are missing"
 [[ -f "$TX_TEST_FILE" ]] || die "protocol-v3 TX hardware tests are missing"
 
-for command_name in iio_attr iio_info lsusb sha256sum sudo tee; do
+for command_name in iio_attr iio_info lsusb sha256sum sudo sysctl tee; do
     require_command "$command_name"
 done
 sudo -n true 2>/dev/null ||
@@ -134,6 +134,7 @@ expected_sha="${SPF_V3_IMAGE_SHA256:-$actual_sha}"
 readonly actual_sha expected_sha
 
 direct_ip_serial=""
+original_rmem_max=""
 if [[ -n "$DIRECT_IP_HOST" ]]; then
     direct_ip_serial="$(
         iio_attr -u "ip:${DIRECT_IP_HOST}" -C hw_serial |
@@ -141,8 +142,15 @@ if [[ -n "$DIRECT_IP_HOST" ]]; then
     )"
     [[ -n "$direct_ip_serial" ]] ||
         die "could not read hw_serial from initial ip:${DIRECT_IP_HOST}"
+    original_rmem_max="$(sysctl -n net.core.rmem_max)"
+    target_rmem_max="$original_rmem_max"
+    if (( target_rmem_max < 16777216 )); then
+        target_rmem_max=16777216
+    fi
+    sudo -n sysctl -q -w "net.core.rmem_max=${target_rmem_max}" |
+        tee "${REPORT_ROOT}/direct-ip-sysctl.log"
 fi
-readonly direct_ip_serial
+readonly direct_ip_serial original_rmem_max
 
 run_logged() {
     local name="$1"
@@ -170,11 +178,20 @@ mute_tx_on_exit() {
         --output "${REPORT_ROOT}/tx-mute-on-exit.json" \
         >>"${REPORT_ROOT}/tx-mute-on-exit.log" 2>&1
     local mute_rc=$?
-    set -e
     if [[ "$mute_rc" -ne 0 ]]; then
         printf 'ERROR: final TX mute verification failed; inspect %s\n' \
             "${REPORT_ROOT}/tx-mute-on-exit.log" >&2
         [[ "$rc" -ne 0 ]] || rc="$mute_rc"
+    fi
+    if [[ -n "$original_rmem_max" ]]; then
+        sudo -n sysctl -q -w "net.core.rmem_max=${original_rmem_max}" \
+            >>"${REPORT_ROOT}/direct-ip-sysctl.log" 2>&1
+        local sysctl_rc=$?
+        if [[ "$sysctl_rc" -ne 0 ]]; then
+            printf 'ERROR: failed to restore net.core.rmem_max=%s\n' \
+                "$original_rmem_max" >&2
+            [[ "$rc" -ne 0 ]] || rc="$sysctl_rc"
+        fi
     fi
     trap - EXIT
     exit "$rc"
@@ -315,6 +332,20 @@ if [[ -n "$DIRECT_IP_HOST" ]]; then
         --radio-gain-observation-interval=2048 \
         --radio-gain-observation-capacity=256 \
         --radio-report-dir="${REPORT_ROOT}/candidate-v3-ip-report"
+    run_logged candidate-v3-direct-ip-buffered-burst \
+        "$PYTHON" -m pytest -q \
+        "${TEST_FILE}::test_v3_direct_ip_buffers_a_maximum_finite_burst" \
+        --radio-hardware \
+        --radio-gain-series-v3 \
+        --radio-direct-ip \
+        --radio-direct-ip-host="$resolved_direct_ip_host" \
+        --radio-samples=524288 \
+        --radio-frames-per-request=16 \
+        --radio-gain-observation-interval=2048 \
+        --radio-gain-observation-capacity=256 \
+        --radio-direct-ip-min-payload-mibps=20 \
+        --radio-direct-ip-min-receive-buffer-mib=4 \
+        --radio-report-dir="${REPORT_ROOT}/candidate-v3-ip-burst-report"
 fi
 
 run_logged final-status \

--- a/tests/radio_hardware/run_gain_series_v3_candidate.sh
+++ b/tests/radio_hardware/run_gain_series_v3_candidate.sh
@@ -36,6 +36,7 @@ Environment:
   SPF_V3_PRODUCTION_RECORDS    V7 records per radio (default: 100)
   SPF_V3_TX_BOOT_EPOCHS        Independent RAM-boot TX epochs (default: 3)
   SPF_V3_STARTUP_STRESS_CYCLES Fresh v3 STARTs per radio (default: 100)
+  SPF_V3_IP_BURN_IN_CYCLES     Maximum-size buffered IP bursts (default: 20)
   SPF_V3_REPORT_ROOT           Artifact directory (default: timestamped /tmp)
 
 The script loads only volatile RAM and never writes QSPI. TX remains disabled
@@ -101,6 +102,7 @@ readonly PYTHON="${SPF_V3_PYTHON:-/home/pi/spf-virtualenv/bin/python}"
 readonly PRODUCTION_RECORDS="${SPF_V3_PRODUCTION_RECORDS:-100}"
 readonly TX_BOOT_EPOCHS="${SPF_V3_TX_BOOT_EPOCHS:-3}"
 readonly STARTUP_STRESS_CYCLES="${SPF_V3_STARTUP_STRESS_CYCLES:-100}"
+readonly IP_BURN_IN_CYCLES="${SPF_V3_IP_BURN_IN_CYCLES:-20}"
 readonly REPORT_ROOT="${SPF_V3_REPORT_ROOT:-/tmp/spf-gain-series-v3-$(date -u +%Y%m%dT%H%M%SZ)}"
 readonly STATE_ROOT="${REPORT_ROOT}/firmware-state"
 readonly WITH_TX_LOOPBACK="$with_tx_loopback"
@@ -115,6 +117,8 @@ readonly LOOPBACK_ATTENUATION_DB="$loopback_attenuation_db"
     die "SPF_V3_TX_BOOT_EPOCHS must be positive"
 [[ "$STARTUP_STRESS_CYCLES" =~ ^[1-9][0-9]*$ ]] ||
     die "SPF_V3_STARTUP_STRESS_CYCLES must be positive"
+[[ "$IP_BURN_IN_CYCLES" =~ ^[1-9][0-9]*$ ]] ||
+    die "SPF_V3_IP_BURN_IN_CYCLES must be positive"
 [[ -x "$PYTHON" ]] || die "test Python is not executable: $PYTHON"
 [[ -f "$MULTI_LOADER" ]] || die "multi-radio loader is missing"
 [[ -f "$TEST_FILE" ]] || die "protocol-v3 hardware tests are missing"
@@ -207,10 +211,10 @@ common_loader_args=(
     --expected-count "$EXPECTED_RADIOS"
 )
 
-printf 'image=%s\nsha256=%s\nexpected_radios=%s\nreport_root=%s\nwith_tx_loopback=%s\nloopback_attenuation_db=%s\ntx_boot_epochs=%s\nstartup_stress_cycles=%s\n' \
+printf 'image=%s\nsha256=%s\nexpected_radios=%s\nreport_root=%s\nwith_tx_loopback=%s\nloopback_attenuation_db=%s\ntx_boot_epochs=%s\nstartup_stress_cycles=%s\nip_burn_in_cycles=%s\n' \
     "$IMAGE" "$actual_sha" "$EXPECTED_RADIOS" "$REPORT_ROOT" \
     "$WITH_TX_LOOPBACK" "$LOOPBACK_ATTENUATION_DB" "$TX_BOOT_EPOCHS" \
-    "$STARTUP_STRESS_CYCLES"
+    "$STARTUP_STRESS_CYCLES" "$IP_BURN_IN_CYCLES"
 run_logged iio-before iio_info -s
 
 run_logged pre-campaign-tx-mute \
@@ -341,6 +345,7 @@ if [[ -n "$DIRECT_IP_HOST" ]]; then
         --radio-direct-ip-host="$resolved_direct_ip_host" \
         --radio-samples=524288 \
         --radio-frames-per-request=16 \
+        --radio-cycles="$IP_BURN_IN_CYCLES" \
         --radio-gain-observation-interval=2048 \
         --radio-gain-observation-capacity=256 \
         --radio-direct-ip-min-payload-mibps=20 \

--- a/tests/radio_hardware/run_gain_series_v3_candidate.sh
+++ b/tests/radio_hardware/run_gain_series_v3_candidate.sh
@@ -163,19 +163,17 @@ trap rollback_hint ERR
 
 mute_tx_on_exit() {
     local rc=$?
-    if [[ "$WITH_TX_LOOPBACK" -eq 1 ]]; then
-        set +e
-        "$PYTHON" -m spf.scripts.mute_pluto_tx \
-            --expected-count "$EXPECTED_RADIOS" \
-            --output "${REPORT_ROOT}/tx-mute-on-exit.json" \
-            >>"${REPORT_ROOT}/tx-mute-on-exit.log" 2>&1
-        local mute_rc=$?
-        set -e
-        if [[ "$mute_rc" -ne 0 ]]; then
-            printf 'ERROR: final TX mute verification failed; inspect %s\n' \
-                "${REPORT_ROOT}/tx-mute-on-exit.log" >&2
-            [[ "$rc" -ne 0 ]] || rc="$mute_rc"
-        fi
+    set +e
+    "$PYTHON" -m spf.scripts.mute_pluto_tx \
+        --expected-count "$EXPECTED_RADIOS" \
+        --output "${REPORT_ROOT}/tx-mute-on-exit.json" \
+        >>"${REPORT_ROOT}/tx-mute-on-exit.log" 2>&1
+    local mute_rc=$?
+    set -e
+    if [[ "$mute_rc" -ne 0 ]]; then
+        printf 'ERROR: final TX mute verification failed; inspect %s\n' \
+            "${REPORT_ROOT}/tx-mute-on-exit.log" >&2
+        [[ "$rc" -ne 0 ]] || rc="$mute_rc"
     fi
     trap - EXIT
     exit "$rc"
@@ -197,12 +195,10 @@ printf 'image=%s\nsha256=%s\nexpected_radios=%s\nreport_root=%s\nwith_tx_loopbac
     "$STARTUP_STRESS_CYCLES"
 run_logged iio-before iio_info -s
 
-if [[ "$WITH_TX_LOOPBACK" -eq 1 ]]; then
-    run_logged pre-campaign-tx-mute \
-        "$PYTHON" -m spf.scripts.mute_pluto_tx \
-        --expected-count "$EXPECTED_RADIOS" \
-        --output "${REPORT_ROOT}/pre-campaign-tx-mute.json"
-fi
+run_logged pre-campaign-tx-mute \
+    "$PYTHON" -m spf.scripts.mute_pluto_tx \
+    --expected-count "$EXPECTED_RADIOS" \
+    --output "${REPORT_ROOT}/pre-campaign-tx-mute.json"
 
 run_logged baseline-v2 \
     "$PYTHON" -m pytest -q "$BASELINE_TEST" \
@@ -224,6 +220,10 @@ if [[ "$WITH_TX_LOOPBACK" -eq 1 ]]; then
         run_logged "ram-load-epoch-${epoch}" \
             sudo -n "$PYTHON" "$MULTI_LOADER" load-all \
             "${common_loader_args[@]}"
+        run_logged "post-load-tx-mute-epoch-${epoch}" \
+            "$PYTHON" -m spf.scripts.mute_pluto_tx \
+            --expected-count "$EXPECTED_RADIOS" \
+            --output "${REPORT_ROOT}/post-load-tx-mute-epoch-${epoch}.json"
         run_logged "iio-after-ram-load-epoch-${epoch}" iio_info -s
         run_logged "candidate-v3-tx2-loopback-epoch-${epoch}" \
             "$PYTHON" -m pytest -q "$TX_TEST_FILE" \
@@ -244,6 +244,10 @@ else
     run_logged ram-load \
         sudo -n "$PYTHON" "$MULTI_LOADER" load-all \
         "${common_loader_args[@]}"
+    run_logged post-load-tx-mute \
+        "$PYTHON" -m spf.scripts.mute_pluto_tx \
+        --expected-count "$EXPECTED_RADIOS" \
+        --output "${REPORT_ROOT}/post-load-tx-mute.json"
     run_logged iio-after-ram-load iio_info -s
 fi
 
@@ -300,6 +304,7 @@ if [[ -n "$DIRECT_IP_HOST" ]]; then
         "$DIRECT_IP_HOST" "$resolved_direct_ip_host" "$direct_ip_serial"
     run_logged candidate-v3-direct-ip \
         "$PYTHON" -m pytest -q \
+        "${TEST_FILE}::test_v3_direct_ip_survives_malformed_control_datagrams" \
         "${TEST_FILE}::test_v3_direct_ip_uses_the_same_inner_frame" \
         --radio-hardware \
         --radio-gain-series-v3 \

--- a/tests/radio_hardware/run_gain_series_v3_candidate.sh
+++ b/tests/radio_hardware/run_gain_series_v3_candidate.sh
@@ -148,8 +148,8 @@ if [[ -n "$DIRECT_IP_HOST" ]]; then
         die "could not read hw_serial from initial ip:${DIRECT_IP_HOST}"
     original_rmem_max="$(sysctl -n net.core.rmem_max)"
     target_rmem_max="$original_rmem_max"
-    if (( target_rmem_max < 67108864 )); then
-        target_rmem_max=67108864
+    if (( target_rmem_max < 134217728 )); then
+        target_rmem_max=134217728
     fi
     sudo -n sysctl -q -w "net.core.rmem_max=${target_rmem_max}" |
         tee "${REPORT_ROOT}/direct-ip-sysctl.log"
@@ -349,7 +349,7 @@ if [[ -n "$DIRECT_IP_HOST" ]]; then
         --radio-gain-observation-interval=2048 \
         --radio-gain-observation-capacity=256 \
         --radio-direct-ip-min-payload-mibps=20 \
-        --radio-direct-ip-min-receive-buffer-mib=64 \
+        --radio-direct-ip-min-receive-buffer-mib=256 \
         --radio-report-dir="${REPORT_ROOT}/candidate-v3-ip-burst-report"
 fi
 

--- a/tests/radio_hardware/run_gain_series_v3_candidate.sh
+++ b/tests/radio_hardware/run_gain_series_v3_candidate.sh
@@ -2,12 +2,11 @@
 # RAM-boot acceptance campaign for an unreleased protocol-v3 DFU.  TX remains
 # fail-closed unless the operator explicitly enables the attenuated loopback.
 
-set -euo pipefail
+set -Eeuo pipefail
 
 ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 readonly ROOT
 readonly MULTI_LOADER="${ROOT}/spf/scripts/pluto_multi_firmware.py"
-readonly FIRMWARE_LOADER="${ROOT}/data_collection/rover/rover_v3.1/load_direct_usb_firmware.sh"
 readonly SSH_CONFIG="${ROOT}/data_collection/rover/rover_v3.1/ssh_config"
 readonly TEST_FILE="${ROOT}/tests/radio_hardware/test_gain_series_v3_hardware.py"
 readonly TX_TEST_FILE="${ROOT}/tests/radio_hardware/test_gain_series_v3_tx_loopback_hardware.py"
@@ -156,7 +155,9 @@ rollback_hint() {
     local rc=$?
     printf '\nCampaign stopped with status %d. Candidate remains in RAM.\n' "$rc" >&2
     printf 'Inspect %s, then roll back explicitly with:\n' "$REPORT_ROOT" >&2
-    printf '  sudo %q rollback-all %q\n' "$FIRMWARE_LOADER" "$EXPECTED_RADIOS" >&2
+    printf '  sudo %q %q rollback-all' "$PYTHON" "$MULTI_LOADER" >&2
+    printf ' %q' "${common_loader_args[@]}" >&2
+    printf '\n' >&2
     exit "$rc"
 }
 trap rollback_hint ERR

--- a/tests/radio_hardware/run_gain_series_v3_candidate.sh
+++ b/tests/radio_hardware/run_gain_series_v3_candidate.sh
@@ -148,8 +148,8 @@ if [[ -n "$DIRECT_IP_HOST" ]]; then
         die "could not read hw_serial from initial ip:${DIRECT_IP_HOST}"
     original_rmem_max="$(sysctl -n net.core.rmem_max)"
     target_rmem_max="$original_rmem_max"
-    if (( target_rmem_max < 16777216 )); then
-        target_rmem_max=16777216
+    if (( target_rmem_max < 67108864 )); then
+        target_rmem_max=67108864
     fi
     sudo -n sysctl -q -w "net.core.rmem_max=${target_rmem_max}" |
         tee "${REPORT_ROOT}/direct-ip-sysctl.log"
@@ -349,7 +349,7 @@ if [[ -n "$DIRECT_IP_HOST" ]]; then
         --radio-gain-observation-interval=2048 \
         --radio-gain-observation-capacity=256 \
         --radio-direct-ip-min-payload-mibps=20 \
-        --radio-direct-ip-min-receive-buffer-mib=4 \
+        --radio-direct-ip-min-receive-buffer-mib=64 \
         --radio-report-dir="${REPORT_ROOT}/candidate-v3-ip-burst-report"
 fi
 

--- a/tests/radio_hardware/test_gain_series_v3_hardware.py
+++ b/tests/radio_hardware/test_gain_series_v3_hardware.py
@@ -11,6 +11,7 @@ import json
 import socket
 import time
 
+import iio
 import numpy as np
 import pytest
 
@@ -179,6 +180,35 @@ def _iq_power_dbfs(signal: np.ndarray) -> np.ndarray:
     power = np.mean(np.abs(signal.astype(np.complex64)) ** 2, axis=1)
     with np.errstate(divide="ignore"):
         return (10.0 * np.log10(power / (2.0 * 2048.0**2))).astype(np.float32)
+
+
+def _direct_ip_sample_rate(host: str) -> int:
+    context = iio.Context(f"ip:{host}")
+    try:
+        phy = context.find_device("ad9361-phy")
+        if phy is None:
+            raise RuntimeError("direct-IP radio has no ad9361-phy")
+        channel = phy.find_channel("voltage0", True)
+        if channel is None or "sampling_frequency" not in channel.attrs:
+            raise RuntimeError("direct-IP radio has no RX sampling-frequency control")
+        return int(channel.attrs["sampling_frequency"].value)
+    finally:
+        del context
+
+
+def _set_direct_ip_sample_rate(host: str, sample_rate_hz: int) -> int:
+    context = iio.Context(f"ip:{host}")
+    try:
+        phy = context.find_device("ad9361-phy")
+        if phy is None:
+            raise RuntimeError("direct-IP radio has no ad9361-phy")
+        channel = phy.find_channel("voltage0", True)
+        if channel is None or "sampling_frequency" not in channel.attrs:
+            raise RuntimeError("direct-IP radio has no RX sampling-frequency control")
+        channel.attrs["sampling_frequency"].value = str(int(sample_rate_hz))
+        return int(channel.attrs["sampling_frequency"].value)
+    finally:
+        del context
 
 
 def _first_change(metadata: RadioMetadataV3) -> np.ndarray:
@@ -577,6 +607,7 @@ def test_v3_direct_ip_buffers_a_maximum_finite_burst(pytestconfig, radio_report_
     samples = pytestconfig.getoption("--radio-samples")
     frame_count = pytestconfig.getoption("--radio-frames-per-request")
     cycles = pytestconfig.getoption("--radio-cycles")
+    requested_sample_rate_hz = int(pytestconfig.getoption("--radio-sample-rate"))
     interval = min(pytestconfig.getoption("--radio-gain-observation-interval"), samples)
     capacity = pytestconfig.getoption("--radio-gain-observation-capacity")
     minimum_mibps = pytestconfig.getoption("--radio-direct-ip-min-payload-mibps")
@@ -589,44 +620,59 @@ def test_v3_direct_ip_buffers_a_maximum_finite_burst(pytestconfig, radio_report_
     cycle_reports = []
     total_elapsed_seconds = 0.0
     total_payload_bytes = 0
-    with PlutoDirectIpReceiver(
-        remote_host=host,
-        protocol_version=3,
-        gain_observation_interval_samples=interval,
-        gain_observation_capacity=capacity,
-        minimum_effective_receive_buffer_bytes=minimum_receive_buffer_bytes,
-    ) as receiver:
-        required_transport = (
-            IpControlFlags.BUFFERED_FINITE_RX | IpControlFlags.USB_CLASS_PACING
+    original_sample_rate_hz = _direct_ip_sample_rate(host)
+    try:
+        configured_sample_rate_hz = _set_direct_ip_sample_rate(
+            host, requested_sample_rate_hz
         )
-        assert receiver.capabilities.flags & required_transport == required_transport
-        effective_receive_buffer_bytes = receiver.effective_data_receive_buffer_bytes
-        transport_flags = int(receiver.capabilities.flags)
-        for cycle in range(cycles):
-            capture = receiver.capture(
-                samples_per_channel=samples,
-                frame_count=frame_count,
+        assert configured_sample_rate_hz == requested_sample_rate_hz
+        with PlutoDirectIpReceiver(
+            remote_host=host,
+            protocol_version=3,
+            gain_observation_interval_samples=interval,
+            gain_observation_capacity=capacity,
+            minimum_effective_receive_buffer_bytes=minimum_receive_buffer_bytes,
+        ) as receiver:
+            required_transport = (
+                IpControlFlags.BUFFERED_FINITE_RX | IpControlFlags.USB_CLASS_PACING
             )
-            assert capture.duplicate_fragment_count == 0
-            assert capture.expired_frame_count == 0
-            assert capture.rejected_frame_count == 0
-            assert capture.receive_queue_overflow_count == 0
-            assert len(capture.frames) == frame_count
-            _assert_contiguous_frames(capture.frames, samples)
-            payload_bytes = samples * 8 * frame_count
-            cycle_reports.append(
-                {
-                    "cycle": cycle,
-                    "elapsed_seconds": capture.elapsed_seconds,
-                    "payload_mibps": payload_bytes
-                    / capture.elapsed_seconds
-                    / (1024 * 1024),
-                    "first_frame": _validate_v3_frame(capture.frames[0], samples),
-                    "last_frame": _validate_v3_frame(capture.frames[-1], samples),
-                }
+            assert (
+                receiver.capabilities.flags & required_transport == required_transport
             )
-            total_elapsed_seconds += capture.elapsed_seconds
-            total_payload_bytes += payload_bytes
+            effective_receive_buffer_bytes = (
+                receiver.effective_data_receive_buffer_bytes
+            )
+            transport_flags = int(receiver.capabilities.flags)
+            for cycle in range(cycles):
+                capture = receiver.capture(
+                    samples_per_channel=samples,
+                    frame_count=frame_count,
+                )
+                assert capture.duplicate_fragment_count == 0
+                assert capture.expired_frame_count == 0
+                assert capture.rejected_frame_count == 0
+                assert capture.receive_queue_overflow_count == 0
+                assert len(capture.frames) == frame_count
+                _assert_contiguous_frames(capture.frames, samples)
+                payload_bytes = samples * 8 * frame_count
+                cycle_reports.append(
+                    {
+                        "cycle": cycle,
+                        "elapsed_seconds": capture.elapsed_seconds,
+                        "payload_mibps": payload_bytes
+                        / capture.elapsed_seconds
+                        / (1024 * 1024),
+                        "first_frame": _validate_v3_frame(capture.frames[0], samples),
+                        "last_frame": _validate_v3_frame(capture.frames[-1], samples),
+                    }
+                )
+                total_elapsed_seconds += capture.elapsed_seconds
+                total_payload_bytes += payload_bytes
+    finally:
+        restored_sample_rate_hz = _set_direct_ip_sample_rate(
+            host, original_sample_rate_hz
+        )
+        assert restored_sample_rate_hz == original_sample_rate_hz
 
     aggregate_payload_mibps = (
         total_payload_bytes / total_elapsed_seconds / (1024 * 1024)
@@ -638,6 +684,9 @@ def test_v3_direct_ip_buffers_a_maximum_finite_burst(pytestconfig, radio_report_
         "test": "maximum buffered finite burst",
         "host": host,
         "samples_per_channel": samples,
+        "requested_sample_rate_hz": requested_sample_rate_hz,
+        "configured_sample_rate_hz": configured_sample_rate_hz,
+        "restored_sample_rate_hz": restored_sample_rate_hz,
         "frame_count": frame_count,
         "cycles": cycles,
         "payload_bytes": total_payload_bytes,

--- a/tests/radio_hardware/test_gain_series_v3_hardware.py
+++ b/tests/radio_hardware/test_gain_series_v3_hardware.py
@@ -679,7 +679,6 @@ def test_v3_direct_ip_buffers_a_maximum_finite_burst(pytestconfig, radio_report_
     aggregate_payload_mibps = (
         total_payload_bytes / total_elapsed_seconds / (1024 * 1024)
     )
-    assert aggregate_payload_mibps >= minimum_mibps
 
     report = {
         "transport": "direct_ip",
@@ -694,6 +693,7 @@ def test_v3_direct_ip_buffers_a_maximum_finite_burst(pytestconfig, radio_report_
         "payload_bytes": total_payload_bytes,
         "elapsed_seconds": total_elapsed_seconds,
         "payload_mibps": aggregate_payload_mibps,
+        "performance_pass": aggregate_payload_mibps >= minimum_mibps,
         "minimum_cycle_payload_mibps": min(
             cycle["payload_mibps"] for cycle in cycle_reports
         ),
@@ -714,6 +714,7 @@ def test_v3_direct_ip_buffers_a_maximum_finite_burst(pytestconfig, radio_report_
     (radio_report_dir / "gain_series_v3_direct_ip_buffered_burst.json").write_text(
         json.dumps(report, indent=2) + "\n"
     )
+    assert aggregate_payload_mibps >= minimum_mibps
 
 
 @pytest.mark.radio_zarr

--- a/tests/radio_hardware/test_gain_series_v3_hardware.py
+++ b/tests/radio_hardware/test_gain_series_v3_hardware.py
@@ -607,7 +607,9 @@ def test_v3_direct_ip_buffers_a_maximum_finite_burst(pytestconfig, radio_report_
     samples = pytestconfig.getoption("--radio-samples")
     frame_count = pytestconfig.getoption("--radio-frames-per-request")
     cycles = pytestconfig.getoption("--radio-cycles")
-    requested_sample_rate_hz = int(pytestconfig.getoption("--radio-sample-rate"))
+    requested_sample_rate_hz = int(
+        pytestconfig.getoption("--radio-direct-ip-burst-sample-rate")
+    )
     interval = min(pytestconfig.getoption("--radio-gain-observation-interval"), samples)
     capacity = pytestconfig.getoption("--radio-gain-observation-capacity")
     minimum_mibps = pytestconfig.getoption("--radio-direct-ip-min-payload-mibps")

--- a/tests/radio_hardware/test_gain_series_v3_hardware.py
+++ b/tests/radio_hardware/test_gain_series_v3_hardware.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import json
+import socket
 import time
 
 import numpy as np
@@ -24,7 +25,10 @@ from spf.dataset.v7_data import (
 )
 from spf.sdrpluto.direct_ip_protocol import IpControlFlags
 from spf.sdrpluto.sdr_controller import _gain_series_arrays
-from spf.sdrpluto.direct_ip_receiver import PlutoDirectIpReceiver
+from spf.sdrpluto.direct_ip_receiver import (
+    DEFAULT_DIRECT_IP_CONTROL_PORT,
+    PlutoDirectIpReceiver,
+)
 from spf.sdrpluto.direct_usb_protocol import (
     CapabilityFlags,
     GainObservationFlags,
@@ -479,6 +483,47 @@ def test_v3_simultaneous_usb_streams(attached_plutos, pytestconfig, radio_report
         )
     (radio_report_dir / "gain_series_v3_simultaneous_usb.json").write_text(
         json.dumps(results, indent=2) + "\n"
+    )
+
+
+@pytest.mark.radio_direct_ip
+def test_v3_direct_ip_survives_malformed_control_datagrams(
+    pytestconfig, radio_report_dir
+):
+    host = pytestconfig.getoption("--radio-direct-ip-host")
+    if not host:
+        pytest.fail("--radio-direct-ip-host is required with --radio-direct-ip")
+
+    # RC11 returned a fatal epoll status for an undersized legacy envelope,
+    # terminating the direct-IP daemon. Exercise boundary lengths and unknown
+    # magic before proving that a valid capability exchange still succeeds.
+    malformed = (
+        b"",
+        b"x",
+        b"xyz",
+        b"test",
+        bytes.fromhex("504c544f"),  # legacy magic without its 8-byte header
+        bytes.fromhex("efbeadde") + bytes(76),
+    )
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as probe:
+        for datagram in malformed:
+            probe.sendto(datagram, (host, DEFAULT_DIRECT_IP_CONTROL_PORT))
+    time.sleep(0.1)
+
+    with PlutoDirectIpReceiver(remote_host=host) as receiver:
+        assert receiver.capabilities.flags & IpControlFlags.FINITE_RX
+
+    (radio_report_dir / "gain_series_v3_direct_ip_malformed.json").write_text(
+        json.dumps(
+            {
+                "host": host,
+                "control_port": DEFAULT_DIRECT_IP_CONTROL_PORT,
+                "malformed_lengths": [len(item) for item in malformed],
+                "valid_capability_query_afterwards": True,
+            },
+            indent=2,
+        )
+        + "\n"
     )
 
 

--- a/tests/radio_hardware/test_gain_series_v3_hardware.py
+++ b/tests/radio_hardware/test_gain_series_v3_hardware.py
@@ -576,6 +576,7 @@ def test_v3_direct_ip_buffers_a_maximum_finite_burst(pytestconfig, radio_report_
         pytest.fail("--radio-direct-ip-host is required with --radio-direct-ip")
     samples = pytestconfig.getoption("--radio-samples")
     frame_count = pytestconfig.getoption("--radio-frames-per-request")
+    cycles = pytestconfig.getoption("--radio-cycles")
     interval = min(pytestconfig.getoption("--radio-gain-observation-interval"), samples)
     capacity = pytestconfig.getoption("--radio-gain-observation-capacity")
     minimum_mibps = pytestconfig.getoption("--radio-direct-ip-min-payload-mibps")
@@ -583,7 +584,11 @@ def test_v3_direct_ip_buffers_a_maximum_finite_burst(pytestconfig, radio_report_
         pytestconfig.getoption("--radio-direct-ip-min-receive-buffer-mib") * 1024 * 1024
     )
     assert frame_count == 16, "performance gate must exercise the maximum finite burst"
+    assert cycles > 0
 
+    cycle_reports = []
+    total_elapsed_seconds = 0.0
+    total_payload_bytes = 0
     with PlutoDirectIpReceiver(
         remote_host=host,
         protocol_version=3,
@@ -596,21 +601,37 @@ def test_v3_direct_ip_buffers_a_maximum_finite_burst(pytestconfig, radio_report_
         )
         assert receiver.capabilities.flags & required_transport == required_transport
         effective_receive_buffer_bytes = receiver.effective_data_receive_buffer_bytes
-        capture = receiver.capture(
-            samples_per_channel=samples,
-            frame_count=frame_count,
-        )
+        transport_flags = int(receiver.capabilities.flags)
+        for cycle in range(cycles):
+            capture = receiver.capture(
+                samples_per_channel=samples,
+                frame_count=frame_count,
+            )
+            assert capture.duplicate_fragment_count == 0
+            assert capture.expired_frame_count == 0
+            assert capture.rejected_frame_count == 0
+            assert capture.receive_queue_overflow_count == 0
+            assert len(capture.frames) == frame_count
+            _assert_contiguous_frames(capture.frames, samples)
+            payload_bytes = samples * 8 * frame_count
+            cycle_reports.append(
+                {
+                    "cycle": cycle,
+                    "elapsed_seconds": capture.elapsed_seconds,
+                    "payload_mibps": payload_bytes
+                    / capture.elapsed_seconds
+                    / (1024 * 1024),
+                    "first_frame": _validate_v3_frame(capture.frames[0], samples),
+                    "last_frame": _validate_v3_frame(capture.frames[-1], samples),
+                }
+            )
+            total_elapsed_seconds += capture.elapsed_seconds
+            total_payload_bytes += payload_bytes
 
-    assert capture.duplicate_fragment_count == 0
-    assert capture.expired_frame_count == 0
-    assert capture.rejected_frame_count == 0
-    assert capture.receive_queue_overflow_count == 0
-    assert len(capture.frames) == frame_count
-    _assert_contiguous_frames(capture.frames, samples)
-    frame_reports = [_validate_v3_frame(frame, samples) for frame in capture.frames]
-    payload_bytes = samples * 8 * frame_count
-    payload_mibps = payload_bytes / capture.elapsed_seconds / (1024 * 1024)
-    assert payload_mibps >= minimum_mibps
+    aggregate_payload_mibps = (
+        total_payload_bytes / total_elapsed_seconds / (1024 * 1024)
+    )
+    assert aggregate_payload_mibps >= minimum_mibps
 
     report = {
         "transport": "direct_ip",
@@ -618,18 +639,26 @@ def test_v3_direct_ip_buffers_a_maximum_finite_burst(pytestconfig, radio_report_
         "host": host,
         "samples_per_channel": samples,
         "frame_count": frame_count,
-        "payload_bytes": payload_bytes,
-        "elapsed_seconds": capture.elapsed_seconds,
-        "payload_mibps": payload_mibps,
+        "cycles": cycles,
+        "payload_bytes": total_payload_bytes,
+        "elapsed_seconds": total_elapsed_seconds,
+        "payload_mibps": aggregate_payload_mibps,
+        "minimum_cycle_payload_mibps": min(
+            cycle["payload_mibps"] for cycle in cycle_reports
+        ),
+        "maximum_cycle_payload_mibps": max(
+            cycle["payload_mibps"] for cycle in cycle_reports
+        ),
         "minimum_payload_mibps": minimum_mibps,
         "effective_receive_buffer_bytes": effective_receive_buffer_bytes,
         "minimum_receive_buffer_bytes": minimum_receive_buffer_bytes,
-        "transport_flags": int(capture.capabilities.flags),
-        "duplicate_fragment_count": capture.duplicate_fragment_count,
-        "expired_frame_count": capture.expired_frame_count,
-        "rejected_frame_count": capture.rejected_frame_count,
-        "receive_queue_overflow_count": capture.receive_queue_overflow_count,
-        "frames": frame_reports,
+        "transport_flags": transport_flags,
+        "total_frames": cycles * frame_count,
+        "duplicate_fragment_count": 0,
+        "expired_frame_count": 0,
+        "rejected_frame_count": 0,
+        "receive_queue_overflow_count": 0,
+        "cycle_reports": cycle_reports,
     }
     (radio_report_dir / "gain_series_v3_direct_ip_buffered_burst.json").write_text(
         json.dumps(report, indent=2) + "\n"

--- a/tests/radio_hardware/test_gain_series_v3_hardware.py
+++ b/tests/radio_hardware/test_gain_series_v3_hardware.py
@@ -567,6 +567,75 @@ def test_v3_direct_ip_uses_the_same_inner_frame(pytestconfig, radio_report_dir):
     )
 
 
+@pytest.mark.radio_direct_ip
+def test_v3_direct_ip_buffers_a_maximum_finite_burst(pytestconfig, radio_report_dir):
+    """Prove capture is decoupled from UDP drain at the production frame size."""
+
+    host = pytestconfig.getoption("--radio-direct-ip-host")
+    if not host:
+        pytest.fail("--radio-direct-ip-host is required with --radio-direct-ip")
+    samples = pytestconfig.getoption("--radio-samples")
+    frame_count = pytestconfig.getoption("--radio-frames-per-request")
+    interval = min(pytestconfig.getoption("--radio-gain-observation-interval"), samples)
+    capacity = pytestconfig.getoption("--radio-gain-observation-capacity")
+    minimum_mibps = pytestconfig.getoption("--radio-direct-ip-min-payload-mibps")
+    minimum_receive_buffer_bytes = int(
+        pytestconfig.getoption("--radio-direct-ip-min-receive-buffer-mib") * 1024 * 1024
+    )
+    assert frame_count == 16, "performance gate must exercise the maximum finite burst"
+
+    with PlutoDirectIpReceiver(
+        remote_host=host,
+        protocol_version=3,
+        gain_observation_interval_samples=interval,
+        gain_observation_capacity=capacity,
+        minimum_effective_receive_buffer_bytes=minimum_receive_buffer_bytes,
+    ) as receiver:
+        required_transport = (
+            IpControlFlags.BUFFERED_FINITE_RX | IpControlFlags.USB_CLASS_PACING
+        )
+        assert receiver.capabilities.flags & required_transport == required_transport
+        effective_receive_buffer_bytes = receiver.effective_data_receive_buffer_bytes
+        capture = receiver.capture(
+            samples_per_channel=samples,
+            frame_count=frame_count,
+        )
+
+    assert capture.duplicate_fragment_count == 0
+    assert capture.expired_frame_count == 0
+    assert capture.rejected_frame_count == 0
+    assert capture.receive_queue_overflow_count == 0
+    assert len(capture.frames) == frame_count
+    _assert_contiguous_frames(capture.frames, samples)
+    frame_reports = [_validate_v3_frame(frame, samples) for frame in capture.frames]
+    payload_bytes = samples * 8 * frame_count
+    payload_mibps = payload_bytes / capture.elapsed_seconds / (1024 * 1024)
+    assert payload_mibps >= minimum_mibps
+
+    report = {
+        "transport": "direct_ip",
+        "test": "maximum buffered finite burst",
+        "host": host,
+        "samples_per_channel": samples,
+        "frame_count": frame_count,
+        "payload_bytes": payload_bytes,
+        "elapsed_seconds": capture.elapsed_seconds,
+        "payload_mibps": payload_mibps,
+        "minimum_payload_mibps": minimum_mibps,
+        "effective_receive_buffer_bytes": effective_receive_buffer_bytes,
+        "minimum_receive_buffer_bytes": minimum_receive_buffer_bytes,
+        "transport_flags": int(capture.capabilities.flags),
+        "duplicate_fragment_count": capture.duplicate_fragment_count,
+        "expired_frame_count": capture.expired_frame_count,
+        "rejected_frame_count": capture.rejected_frame_count,
+        "receive_queue_overflow_count": capture.receive_queue_overflow_count,
+        "frames": frame_reports,
+    }
+    (radio_report_dir / "gain_series_v3_direct_ip_buffered_burst.json").write_text(
+        json.dumps(report, indent=2) + "\n"
+    )
+
+
 @pytest.mark.radio_zarr
 def test_v3_gain_series_round_trips_through_v7_zarr(
     attached_plutos, pytestconfig, tmp_path

--- a/tests/test_calibration_firmware_pins.py
+++ b/tests/test_calibration_firmware_pins.py
@@ -77,6 +77,24 @@ def test_calibration_firmware_matches_rover_production(config_path: Path):
     )
 
 
+@pytest.mark.parametrize(
+    "config_path", _calibration_configs_with_firmware(), ids=lambda p: p.name
+)
+def test_calibration_direct_usb_protocol_matches_rover_production(
+    config_path: Path,
+):
+    """Calibration and deployment must record the same gain-series metadata."""
+
+    reference = yaml.safe_load(canonical_config_path(REFERENCE_ROVER_ID).read_text())[
+        "direct-usb"
+    ]
+    actual = yaml.safe_load(config_path.read_text()).get("direct-usb")
+    assert actual == reference, (
+        f"{config_path.name} direct-usb settings {actual!r} differ from "
+        f"production {reference!r}"
+    )
+
+
 def test_all_rover_configs_pin_identical_firmware():
     """The three rover configs must agree with each other, or 'the' pin is ambiguous."""
     blocks = {

--- a/tests/test_direct_ip_protocol.py
+++ b/tests/test_direct_ip_protocol.py
@@ -206,6 +206,33 @@ def test_production_sized_frame_reassembles_out_of_order_with_duplicates():
     assert reassembler.duplicate_fragment_count == 2
 
 
+def test_reassembler_uses_one_preallocated_destination_buffer():
+    frame = bytes(range(251)) * 100
+    datagrams = fragment_ip_frame(
+        frame, stream_id=0xCAFE, frame_sequence=7, max_datagram_bytes=256
+    )
+    reassembler = IpFrameReassembler()
+
+    assert reassembler.feed(datagrams[0], peer="radio") == []
+    partial = next(iter(reassembler._pending.values()))
+    destination = partial.frame
+    assert isinstance(destination, bytearray)
+    assert len(destination) == len(frame)
+    assert partial.received_fragment_count == 1
+    assert reassembler.pending_declared_bytes == len(frame)
+
+    completed = []
+    for datagram in datagrams[1:]:
+        completed.extend(reassembler.feed(datagram, peer="radio"))
+    assert len(completed) == 1
+    # Completion transfers ownership of the already-filled allocation.  It
+    # must not concatenate thousands of copied fragment payloads into another
+    # full-frame allocation.
+    assert completed[0].frame is destination
+    assert bytes(completed[0].frame) == frame
+    assert reassembler.pending_declared_bytes == 0
+
+
 def test_identical_duplicate_before_completion_is_counted_and_ignored():
     frame = bytes(range(256)) * 20
     datagrams = fragment_ip_frame(

--- a/tests/test_direct_ip_protocol.py
+++ b/tests/test_direct_ip_protocol.py
@@ -46,6 +46,33 @@ def test_control_capability_query_has_stable_golden_bytes():
     assert IpControlMessageV1.unpack(payload) == query
 
 
+def test_extended_transport_capability_negotiation_round_trip():
+    query = make_ip_capability_query(request_id=9, transport_capabilities=True)
+    assert query.flags == IpControlFlags.QUERY_TRANSPORT_CAPABILITIES
+    assert IpControlMessageV1.unpack(query.pack()) == query
+
+    capabilities = IpControlMessageV1(
+        message_type=IpControlType.CAPABILITIES,
+        request_id=9,
+        flags=(
+            IpControlFlags.FINITE_RX
+            | IpControlFlags.IDEMPOTENT_REQUESTS
+            | IpControlFlags.TIME_ANCHOR
+            | IpControlFlags.BUFFERED_FINITE_RX
+            | IpControlFlags.USB_CLASS_PACING
+        ),
+        protocol_min=3,
+        protocol_max=3,
+        features=(
+            MetadataFeatures.GAIN_OBSERVATION_SERIES
+            | MetadataFeatures.HARDWARE_SAMPLE_COUNTER
+        ),
+        max_samples_per_channel=524_288,
+        max_finite_frames=16,
+    )
+    assert IpControlMessageV1.unpack(capabilities.pack()) == capabilities
+
+
 def test_control_capabilities_round_trip():
     capabilities = IpControlMessageV1(
         message_type=IpControlType.CAPABILITIES,
@@ -93,6 +120,9 @@ def test_v3_start_started_and_stop_control_round_trip():
         gain_observation_capacity=32,
         gain_event_capacity=0,
         data_port=40_000,
+        transport_flags=(
+            IpControlFlags.BUFFERED_FINITE_RX | IpControlFlags.USB_CLASS_PACING
+        ),
     )
     assert IpControlMessageV1.unpack(start.pack()) == start
     started = dataclasses.replace(
@@ -109,6 +139,25 @@ def test_v3_start_started_and_stop_control_round_trip():
     assert IpControlMessageV1.unpack(stop.pack()) == stop
     stopped = dataclasses.replace(stop, message_type=IpControlType.STOPPED)
     assert IpControlMessageV1.unpack(stopped.pack()) == stopped
+
+
+def test_high_rate_pacing_requires_buffered_capture():
+    with pytest.raises(ProtocolError, match="requires buffered"):
+        make_ip_start_request(
+            request_id=1,
+            protocol_version=3,
+            features=(
+                MetadataFeatures.GAIN_OBSERVATION_SERIES
+                | MetadataFeatures.HARDWARE_SAMPLE_COUNTER
+            ),
+            enabled_scan_mask=0x0F,
+            samples_per_channel=16_384,
+            frame_count=1,
+            gain_observation_interval_samples=16_384,
+            gain_observation_capacity=1,
+            data_port=30_433,
+            transport_flags=IpControlFlags.USB_CLASS_PACING,
+        ).pack()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_direct_ip_receiver.py
+++ b/tests/test_direct_ip_receiver.py
@@ -346,8 +346,12 @@ def test_missing_data_times_out_explicitly_and_stops_stream():
             frame_timeout_seconds=0.1,
         )
         with receiver:
-            with pytest.raises(DirectIpTransportError, match="timed out"):
+            with pytest.raises(DirectIpTransportError) as error:
                 receiver.capture(samples_per_channel=1024, frame_count=1)
+        assert str(error.value).endswith(
+            "received 0/1 frames, pending=0, duplicates=0, expired=0, "
+            "rejected=0, rxq_overflows=0"
+        )
         assert gadget.stop_request_count == 1
     finally:
         gadget.close()

--- a/tests/test_direct_ip_receiver.py
+++ b/tests/test_direct_ip_receiver.py
@@ -102,6 +102,7 @@ class _SyntheticIpGadget:
         outer_sequence_delta: int = 0,
         drop_first_start_reply: bool = True,
         bad_started_echo: bool = False,
+        advertise_transport_profiles: bool = True,
     ) -> None:
         self.control = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.control.bind(("127.0.0.1", 0))
@@ -111,9 +112,11 @@ class _SyntheticIpGadget:
         self.outer_sequence_delta = outer_sequence_delta
         self.drop_first_start_reply = drop_first_start_reply
         self.bad_started_echo = bad_started_echo
+        self.advertise_transport_profiles = advertise_transport_profiles
         self.start_request_count = 0
         self.stop_request_count = 0
         self.time_anchor_request_count = 0
+        self.last_start_request: IpControlMessageV1 | None = None
         self.error: Exception | None = None
         self._stop = threading.Event()
         self._thread = threading.Thread(target=self._run, daemon=True)
@@ -161,6 +164,13 @@ class _SyntheticIpGadget:
                     continue
                 request = IpControlMessageV1.unpack(payload)
                 if request.message_type == IpControlType.QUERY_CAPABILITIES:
+                    transport_flags = (
+                        IpControlFlags.BUFFERED_FINITE_RX
+                        | IpControlFlags.USB_CLASS_PACING
+                        if self.advertise_transport_profiles
+                        and request.flags & IpControlFlags.QUERY_TRANSPORT_CAPABILITIES
+                        else IpControlFlags(0)
+                    )
                     response = IpControlMessageV1(
                         message_type=IpControlType.CAPABILITIES,
                         request_id=request.request_id,
@@ -168,6 +178,7 @@ class _SyntheticIpGadget:
                             IpControlFlags.FINITE_RX
                             | IpControlFlags.IDEMPOTENT_REQUESTS
                             | IpControlFlags.TIME_ANCHOR
+                            | transport_flags
                         ),
                         protocol_min=2,
                         protocol_max=3,
@@ -178,6 +189,7 @@ class _SyntheticIpGadget:
                     self.control.sendto(response.pack(), peer)
                 elif request.message_type == IpControlType.START_RX:
                     self.start_request_count += 1
+                    self.last_start_request = request
                     started = self._cached_started.setdefault(
                         request.request_id,
                         dataclasses.replace(
@@ -255,6 +267,10 @@ def test_finite_v3_capture_retries_control_and_parses_common_inner_frames():
         assert capture.expired_frame_count == 0
         assert capture.rejected_frame_count == 0
         assert capture.receive_queue_overflow_count == 0
+        assert gadget.last_start_request is not None
+        assert gadget.last_start_request.flags == (
+            IpControlFlags.BUFFERED_FINITE_RX | IpControlFlags.USB_CLASS_PACING
+        )
         assert gadget.start_request_count == 2
         assert gadget.stop_request_count == 1
     finally:
@@ -277,6 +293,26 @@ def test_direct_ip_time_anchor_uses_common_record_and_host_bracket():
         assert measurement.anchor.counter_delta == 32
         assert measurement.round_trip_ns >= 0
         assert gadget.time_anchor_request_count == 1
+    finally:
+        gadget.close()
+
+
+def test_rc12_capability_fallback_uses_conservative_start_flags():
+    gadget = _SyntheticIpGadget(
+        drop_first_start_reply=False,
+        advertise_transport_profiles=False,
+    )
+    gadget.start()
+    try:
+        receiver = PlutoDirectIpReceiver(
+            remote_host="127.0.0.1",
+            remote_control_port=gadget.control_port,
+            control_timeout_seconds=0.05,
+        )
+        with receiver:
+            receiver.capture(samples_per_channel=1024, frame_count=1)
+        assert gadget.last_start_request is not None
+        assert gadget.last_start_request.flags == 0
     finally:
         gadget.close()
 

--- a/tests/test_direct_ip_receiver.py
+++ b/tests/test_direct_ip_receiver.py
@@ -254,6 +254,7 @@ def test_finite_v3_capture_retries_control_and_parses_common_inner_frames():
         assert capture.duplicate_fragment_count == 2
         assert capture.expired_frame_count == 0
         assert capture.rejected_frame_count == 0
+        assert capture.receive_queue_overflow_count == 0
         assert gadget.start_request_count == 2
         assert gadget.stop_request_count == 1
     finally:
@@ -319,6 +320,15 @@ def test_missing_data_times_out_explicitly_and_stops_stream():
 def test_receive_buffer_must_be_positive():
     with pytest.raises(ValueError, match="receive buffer"):
         PlutoDirectIpReceiver(remote_host="127.0.0.1", data_receive_buffer_bytes=0)
+
+
+def test_receive_buffer_requirement_fails_with_actionable_sysctl_message():
+    receiver = PlutoDirectIpReceiver(
+        remote_host="127.0.0.1",
+        minimum_effective_receive_buffer_bytes=1 << 30,
+    )
+    with pytest.raises(DirectIpTransportError, match="net.core.rmem_max"):
+        receiver.open()
 
 
 def test_bad_started_echo_fails_closed_and_stops_assigned_stream():

--- a/tests/test_direct_usb_protocol.py
+++ b/tests/test_direct_usb_protocol.py
@@ -622,6 +622,18 @@ def test_extra_payload_is_not_silently_accepted():
         parser.finish()
 
 
+def test_complete_frame_fast_path_matches_streaming_parser():
+    wire = frame(metadata())
+    expected = RxFrameParser().feed(wire)[0]
+    assert RxFrameParser().parse_complete_frame(bytearray(wire)) == expected
+
+
+def test_complete_frame_fast_path_rejects_length_mismatch():
+    parser = RxFrameParser()
+    with pytest.raises(ProtocolError, match="complete frame length mismatch"):
+        parser.parse_complete_frame(frame(metadata()) + b"unexpected")
+
+
 def test_missing_required_feature_is_rejected():
     with pytest.raises(ProtocolError, match="GAIN_ENDPOINT_SNAPSHOTS"):
         dataclasses.replace(

--- a/tests/test_gain_series_v3_campaign.py
+++ b/tests/test_gain_series_v3_campaign.py
@@ -267,6 +267,13 @@ fi
     )
     _executable(shim / "iio_info", 'printf "synthetic IIO inventory\\n"\n')
     _executable(shim / "iio_attr", f'printf "hw_serial: {serial}\\n"\n')
+    _executable(
+        shim / "sysctl",
+        """if [[ "${1:-}" == "-n" ]]; then
+    printf '%s\n' 212992
+fi
+""",
+    )
     # Enough output after the early serial match makes grep -q close the pipe
     # and this producer exit 141.  The campaign must consume all lsusb output.
     _executable(
@@ -308,3 +315,9 @@ done
         "test_v3_direct_ip_uses_the_same_inner_frame" in command
         for command in trace.read_text().splitlines()
     )
+    assert any(
+        "test_v3_direct_ip_buffers_a_maximum_finite_burst" in command
+        for command in trace.read_text().splitlines()
+    )
+    assert "--radio-frames-per-request=16" in trace.read_text()
+    assert "net.core.rmem_max" in SCRIPT.read_text()

--- a/tests/test_gain_series_v3_campaign.py
+++ b/tests/test_gain_series_v3_campaign.py
@@ -104,6 +104,10 @@ def test_gain_series_candidate_campaign_orders_volatile_gates(tmp_path):
         cursor += 1
     assert all("provision-config-all" not in command for command in commands)
     assert all("ensure_pluto_qspi" not in command for command in commands)
+    load_index = next(
+        index for index, command in enumerate(commands) if "load-all" in command
+    )
+    assert "spf.scripts.mute_pluto_tx" in commands[load_index + 1]
     assert (report / "baseline-v2.log").is_file()
     assert (report / "candidate-v3-production-zarr.log").is_file()
 
@@ -174,6 +178,9 @@ def test_gain_series_candidate_campaign_requires_explicit_tx_and_mutes(tmp_path)
         command for command in commands if "spf.scripts.mute_pluto_tx" in command
     ]
     assert len(mute_commands) >= 5
+    for load_command in load_commands:
+        load_index = commands.index(load_command)
+        assert "spf.scripts.mute_pluto_tx" in commands[load_index + 1]
     for epoch in range(1, 4):
         assert (report / f"candidate-v3-tx2-loopback-epoch-{epoch}.log").is_file()
 
@@ -252,6 +259,10 @@ done
 
     assert result.returncode == 0, result.stderr
     assert "candidate-v3-direct-ip" in result.stdout
+    assert any(
+        "test_v3_direct_ip_survives_malformed_control_datagrams" in command
+        for command in trace.read_text().splitlines()
+    )
     assert any(
         "test_v3_direct_ip_uses_the_same_inner_frame" in command
         for command in trace.read_text().splitlines()

--- a/tests/test_gain_series_v3_campaign.py
+++ b/tests/test_gain_series_v3_campaign.py
@@ -200,6 +200,47 @@ def test_gain_series_candidate_campaign_rejects_unacknowledged_tx(tmp_path):
     assert "requires --loopback-attenuation-db" in result.stderr
 
 
+def test_gain_series_candidate_failure_prints_exact_campaign_rollback(tmp_path):
+    shim = tmp_path / "bin"
+    shim.mkdir()
+    image = tmp_path / "candidate.dfu"
+    image.write_bytes(b"synthetic candidate image")
+    report = tmp_path / "report"
+
+    fake_python = _executable(
+        shim / "python",
+        '[[ "$*" != *"test_direct_usb_hardware.py"* ]]\n',
+    )
+    _executable(
+        shim / "sudo",
+        '[[ "${1:-}" != "-n" ]] || shift\nexec "$@"\n',
+    )
+    _executable(shim / "iio_info", 'printf "synthetic IIO inventory\\n"\n')
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "PATH": f"{shim}:{environment['PATH']}",
+            "SPF_V3_PYTHON": str(fake_python),
+            "SPF_V3_EXPECTED_RADIOS": "2",
+            "SPF_V3_REPORT_ROOT": str(report),
+        }
+    )
+
+    result = subprocess.run(
+        [str(SCRIPT), str(image)],
+        cwd=ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "pluto_multi_firmware.py rollback-all" in result.stderr
+    assert f"--state-root {report}/firmware-state" in result.stderr
+    assert "--expected-count 2" in result.stderr
+
+
 def test_gain_series_candidate_campaign_accepts_direct_ip_serial_with_pipefail(
     tmp_path,
 ):

--- a/tests/test_load_direct_usb_firmware.py
+++ b/tests/test_load_direct_usb_firmware.py
@@ -12,6 +12,28 @@ LOADER = (
 )
 
 
+def test_loader_defaults_to_hardware_qualified_rc16():
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; printf "%s\\n%s\\n%s\\n" '
+            '"$RELEASE_TAG" "$ASSET_NAME" "$IMAGE_SHA256"',
+            "bash",
+            str(LOADER),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.splitlines() == [
+        "v0.38-plutoplus-spf-gain-series-v4-rc16",
+        "plutoplus-spf-main-867e18542311-pluto.dfu",
+        "27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911",
+    ]
+
+
 def _run_usb_count(tmp_path: Path, lsusb_body: str) -> subprocess.CompletedProcess[str]:
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()

--- a/tests/test_mavlink_radio_collect.py
+++ b/tests/test_mavlink_radio_collect.py
@@ -132,6 +132,35 @@ def test_v7_infers_direct_usb_protocol_v2_and_rejects_conflicts():
         )
 
 
+def test_v7_applies_top_level_direct_usb_defaults_to_every_receiver():
+    normalized = normalize_capture_config(
+        {
+            "data-version": 7,
+            "direct-usb": {
+                "protocol-version": 3,
+                "gain-observation-interval-samples": 2048,
+                "gain-observation-capacity": 256,
+            },
+            "receivers": [
+                {"receiver-port": 1},
+                {"receiver-port": 2},
+            ],
+        }
+    )
+
+    for receiver in normalized["receivers"]:
+        assert receiver["rx-transport"] == "direct_usb"
+        assert receiver["direct-usb"] == {
+            "protocol-version": 3,
+            "gain-observation-interval-samples": 2048,
+            "gain-observation-capacity": 256,
+            "gain-event-capacity": 0,
+            "require-gain-metadata": True,
+            "frame-count-per-request": 1,
+        }
+    validate_transport_schema(normalized)
+
+
 def test_mavlink_radio_collect_v7_requires_boot_verified_firmware():
     with tempfile.TemporaryDirectory() as tmpdirname:
         with open(f"{root_dir}/tests/test_config.yaml") as source:

--- a/tests/test_pluto_multi_firmware.py
+++ b/tests/test_pluto_multi_firmware.py
@@ -703,6 +703,8 @@ def test_boot_preparation_uses_configured_boot_mode_with_environment_override():
     override = 'RAM_LOAD_OVERRIDE="${SPF_PLUTO_RAM_LOAD:-}"'
     ram_gate = 'if is_true "$ram_load"; then'
     load = 'run_loader load-all "$attached_radios"'
+    mute = '"$PYTHON" -m spf.scripts.mute_pluto_tx'
+    mapping = 'mapping_tmp="$(mktemp /run/spf-device-mapping.XXXXXX)"'
 
     assert ensure in boot_script
     assert config_mode in boot_script
@@ -711,11 +713,19 @@ def test_boot_preparation_uses_configured_boot_mode_with_environment_override():
     assert ram_gate in boot_script
     # The volatile path remains isolated from persistent QSPI preparation.
     assert load in boot_script
+    assert mute in boot_script
     assert (
         boot_script.index(ram_gate)
         < boot_script.index(load)
         < boot_script.index(ensure)
     )
+    # Every firmware transition restores TX attenuation defaults. A verified
+    # mute is mandatory before device mapping and the ready manifest, so a mute
+    # failure cannot authorize collection.
+    assert boot_script.index(ensure) < boot_script.index(mute)
+    assert boot_script.index(mute) < boot_script.index(mapping)
+    assert boot_script.index(mute) < boot_script.index("manifest_args=(")
+    assert 'rm -f -- "$READY_FILE" "$TX_MUTE_FILE"' in boot_script
     # The per-boot ssh check-config-all was removed (it raced the shared-IP ssh);
     # a wrong AD9361/2r2t config is still caught by verify-all's dual-RX check.
     assert "run_loader check-config-all" not in boot_script

--- a/tests/test_pluto_multi_firmware.py
+++ b/tests/test_pluto_multi_firmware.py
@@ -614,7 +614,7 @@ def test_preload_backup_is_immutable_across_repeated_ram_boots(
     assert manager._preload_device_fw("SERIAL_A") == "production-v1"
 
 
-def test_rollback_skips_direct_usb_firmware_when_version_matches_backup(
+def test_rollback_resets_when_version_matches_backup_but_boot_mode_is_unknown(
     tmp_path, monkeypatch
 ):
     manager = _manager(tmp_path)
@@ -634,10 +634,16 @@ def test_rollback_skips_direct_usb_firmware_when_version_matches_backup(
     monkeypatch.setattr(
         manager,
         "_ssh",
-        lambda *args, **kwargs: pytest.fail("matching firmware must not reboot"),
+        lambda serial, command, **kwargs: calls.append(("ssh", serial, command)),
     )
+    monkeypatch.setattr(manager, "_wait_absent", lambda *args: None)
+    monkeypatch.setattr(manager, "_wait_product", lambda *args: None)
+    monkeypatch.setattr(manager, "_wait_for_ssh", lambda *args: None)
+    calls = []
 
     manager.rollback_all()
+
+    assert any("device_reboot reset" in command for _, _, command in calls)
 
 
 def test_rollback_waits_for_disconnect_and_restores_preload_version(

--- a/tests/test_pluto_ready_manifest.py
+++ b/tests/test_pluto_ready_manifest.py
@@ -104,11 +104,11 @@ def test_ready_manifest_records_config_firmware_and_each_serial(tmp_path, monkey
     assert manifest["attached_radio_count"] == 2
     assert (
         manifest["firmware"]["image_sha256"]
-        == "86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191"
+        == "27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911"
     )
     assert (
         manifest["firmware"]["device_fw"]
-        == "v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d"
+        == "v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1"
     )
     assert [radio["serial"] for radio in manifest["radios"]] == [
         "SERIAL_A",

--- a/tests/test_resolve_pluto_ip.py
+++ b/tests/test_resolve_pluto_ip.py
@@ -1,6 +1,8 @@
+import subprocess
+
 import pytest
 
-from spf.scripts.resolve_pluto_ip import resolve_pluto_ip
+from spf.scripts.resolve_pluto_ip import neighbor_candidates, resolve_pluto_ip
 
 
 def test_resolve_pluto_ip_follows_serial_when_preferred_address_changes():
@@ -20,3 +22,23 @@ def test_resolve_pluto_ip_rejects_ambiguous_serial():
     }
     with pytest.raises(RuntimeError, match="exactly one"):
         resolve_pluto_ip("SERIAL-A", serials, probe=serials.get)
+
+
+def test_neighbor_candidates_excludes_addresses_routed_over_usb(monkeypatch):
+    def fake_run(command, **kwargs):
+        if command == ["ip", "-4", "neigh", "show", "dev", "eth0"]:
+            stdout = (
+                "192.168.1.165 lladdr 00:11:22:33:44:55 REACHABLE\n"
+                "192.168.2.1 lladdr 66:77:88:99:aa:bb STALE\n"
+            )
+        elif command == ["ip", "-4", "route", "get", "192.168.1.165"]:
+            stdout = "192.168.1.165 dev eth0 src 192.168.1.153\n"
+        elif command == ["ip", "-4", "route", "get", "192.168.2.1"]:
+            stdout = "192.168.2.1 dev eth2 src 192.168.2.10\n"
+        else:
+            raise AssertionError(command)
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert neighbor_candidates("eth0") == ("192.168.1.165",)

--- a/tests/test_rover_capture_profile.py
+++ b/tests/test_rover_capture_profile.py
@@ -98,10 +98,7 @@ def test_boot_launcher_prints_canonical_v7_plan_without_hardware(tmp_path):
     assert plan["rx_transport"] == "direct_usb"
     assert plan["data_version"] == "7"
     assert plan["capture_status_file"] == "/home/pi/preflight/capture_status.json"
-    assert (
-        plan["firmware_release_tag"]
-        == "v0.38-plutoplus-spf-gain-series-v4-rc16"
-    )
+    assert plan["firmware_release_tag"] == "v0.38-plutoplus-spf-gain-series-v4-rc16"
 
 
 def test_every_production_boot_waits_for_firmware_loader_by_default():
@@ -205,6 +202,11 @@ def test_canonical_v7_configs_are_self_contained(
     config = yaml.safe_load(Path(plan.config_path).read_text())
     assert "rx-transport" not in config["receivers"][0]
     assert "direct-usb" not in config["receivers"][0]
+    assert config["direct-usb"] == {
+        "protocol-version": 3,
+        "gain-observation-interval-samples": 2048,
+        "gain-observation-capacity": 256,
+    }
     assert {receiver["antenna-spacing-m"] for receiver in config["receivers"]} == {
         spacing
     }
@@ -214,14 +216,8 @@ def test_canonical_v7_configs_are_self_contained(
 @pytest.mark.parametrize("rover_id", [1, 2, 3, 4])
 def test_every_production_rover_pins_hardware_qualified_rc16(rover_id):
     plan = resolve_capture_plan(rover_id)
-    assert (
-        plan.firmware_release_tag
-        == "v0.38-plutoplus-spf-gain-series-v4-rc16"
-    )
-    assert (
-        plan.firmware_asset_name
-        == "plutoplus-spf-main-867e18542311-pluto.dfu"
-    )
+    assert plan.firmware_release_tag == "v0.38-plutoplus-spf-gain-series-v4-rc16"
+    assert plan.firmware_asset_name == "plutoplus-spf-main-867e18542311-pluto.dfu"
     assert plan.firmware_image_url == (
         "https://github.com/misko/plutosdr-fw/releases/download/"
         "v0.38-plutoplus-spf-gain-series-v4-rc16/"
@@ -233,18 +229,12 @@ def test_every_production_rover_pins_hardware_qualified_rc16(rover_id):
     assert plan.firmware_git_sha == "867e18542311c25f5c1980bbdcfffc823e56f0a2"
     assert plan.gadget_git_sha == "2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552"
     assert plan.firmware_boot_mode == "qspi"
-    assert (
-        plan.firmware_device_fw
-        == "v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1"
-    )
+    assert plan.firmware_device_fw == "v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1"
 
 
 def test_boot_uses_explicit_active_device_version_from_config():
     source = (ROVER_ROOT / "prepare_direct_usb_boot.sh").read_text()
-    assert (
-        'firmware_device_fw="${config_values[15]}"'
-        in source
-    )
+    assert 'firmware_device_fw="${config_values[15]}"' in source
     assert (
         'expected_device_fw="${SPF_PLUTO_EXPECTED_DEVICE_FW:-$firmware_device_fw}"'
         in source

--- a/tests/test_rover_capture_profile.py
+++ b/tests/test_rover_capture_profile.py
@@ -100,7 +100,7 @@ def test_boot_launcher_prints_canonical_v7_plan_without_hardware(tmp_path):
     assert plan["capture_status_file"] == "/home/pi/preflight/capture_status.json"
     assert (
         plan["firmware_release_tag"]
-        == "v0.38-plutoplus-spf-gain-series-v4-rc12"
+        == "v0.38-plutoplus-spf-gain-series-v4-rc16"
     )
 
 
@@ -212,30 +212,30 @@ def test_canonical_v7_configs_are_self_contained(
 
 
 @pytest.mark.parametrize("rover_id", [1, 2, 3, 4])
-def test_every_production_rover_pins_hardware_qualified_rc12(rover_id):
+def test_every_production_rover_pins_hardware_qualified_rc16(rover_id):
     plan = resolve_capture_plan(rover_id)
     assert (
         plan.firmware_release_tag
-        == "v0.38-plutoplus-spf-gain-series-v4-rc12"
+        == "v0.38-plutoplus-spf-gain-series-v4-rc16"
     )
     assert (
         plan.firmware_asset_name
-        == "plutoplus-spf-main-fa5f95f0af2a-pluto.dfu"
+        == "plutoplus-spf-main-867e18542311-pluto.dfu"
     )
     assert plan.firmware_image_url == (
         "https://github.com/misko/plutosdr-fw/releases/download/"
-        "v0.38-plutoplus-spf-gain-series-v4-rc12/"
-        "plutoplus-spf-main-fa5f95f0af2a-pluto.dfu"
+        "v0.38-plutoplus-spf-gain-series-v4-rc16/"
+        "plutoplus-spf-main-867e18542311-pluto.dfu"
     )
     assert plan.firmware_image_sha256 == (
-        "2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4"
+        "27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911"
     )
-    assert plan.firmware_git_sha == "fa5f95f0af2a0586c80b54eff7ae04512cb96f7f"
-    assert plan.gadget_git_sha == "e14eae63ac6b7fe51828e85de34a8d4e1c50d49e"
+    assert plan.firmware_git_sha == "867e18542311c25f5c1980bbdcfffc823e56f0a2"
+    assert plan.gadget_git_sha == "2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552"
     assert plan.firmware_boot_mode == "qspi"
     assert (
         plan.firmware_device_fw
-        == "v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9"
+        == "v0.38-plutoplus-spf-gain-series-v4-rc12-9-g867e1"
     )
 
 

--- a/tests/test_rover_capture_profile.py
+++ b/tests/test_rover_capture_profile.py
@@ -99,7 +99,8 @@ def test_boot_launcher_prints_canonical_v7_plan_without_hardware(tmp_path):
     assert plan["data_version"] == "7"
     assert plan["capture_status_file"] == "/home/pi/preflight/capture_status.json"
     assert (
-        plan["firmware_release_tag"] == "v0.38-plutoplus-spf-gain-rssi-fingerprint-v3"
+        plan["firmware_release_tag"]
+        == "v0.38-plutoplus-spf-gain-series-v4-rc12"
     )
 
 
@@ -211,30 +212,30 @@ def test_canonical_v7_configs_are_self_contained(
 
 
 @pytest.mark.parametrize("rover_id", [1, 2, 3, 4])
-def test_every_production_rover_pins_supervised_v3_firmware(rover_id):
+def test_every_production_rover_pins_hardware_qualified_rc12(rover_id):
     plan = resolve_capture_plan(rover_id)
     assert (
         plan.firmware_release_tag
-        == "v0.38-plutoplus-spf-gain-rssi-fingerprint-v3"
+        == "v0.38-plutoplus-spf-gain-series-v4-rc12"
     )
     assert (
         plan.firmware_asset_name
-        == "plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu"
+        == "plutoplus-spf-main-fa5f95f0af2a-pluto.dfu"
     )
     assert plan.firmware_image_url == (
         "https://github.com/misko/plutosdr-fw/releases/download/"
-        "v0.38-plutoplus-spf-gain-rssi-fingerprint-v3/"
-        "plutoplus-spf-direct-usb-gain-rssi-fingerprint-v3-pluto.dfu"
+        "v0.38-plutoplus-spf-gain-series-v4-rc12/"
+        "plutoplus-spf-main-fa5f95f0af2a-pluto.dfu"
     )
     assert plan.firmware_image_sha256 == (
-        "86f2115eb344efcbd3d59af02caf80d396291cb9e20dcb01651cacf7e0334191"
+        "2209e23ccc76b9748b0b4435ff706f8edbd7ad0ce1b950ff4065a399d7de52d4"
     )
-    assert plan.firmware_git_sha == "f53dd006c26677a256520b86b7c864100ccd62d2"
-    assert plan.gadget_git_sha == "2072e1d0823ef6db3bc141dd733a90d76e23fc33"
+    assert plan.firmware_git_sha == "fa5f95f0af2a0586c80b54eff7ae04512cb96f7f"
+    assert plan.gadget_git_sha == "e14eae63ac6b7fe51828e85de34a8d4e1c50d49e"
     assert plan.firmware_boot_mode == "qspi"
     assert (
         plan.firmware_device_fw
-        == "v0.38-plutoplus-spf-gain-rssi-fingerprint-v2-8-gf53d"
+        == "v0.38-plutoplus-spf-gain-series-v4-rc11-2-gfa5f9"
     )
 
 


### PR DESCRIPTION
## Outcome

Promotes the exact hardware-qualified RC16 firmware, enables protocol-v3 gain-series metadata in canonical V7 collection, and restores maximum finite-burst direct-IP throughput to the same practical 20-22 MiB/s range as direct USB.

## What changed

- decouples radio DMA capture from UDP drain with a bounded eight-buffer finite queue
- uses MTU-safe UDP GSO plus negotiated USB-class pacing
- isolates the RX worker and gain sampler so capture cannot starve metadata reads
- reassembles into bounded buffers and parses complete frames without a redundant 4 MiB copy
- sizes the host UDP receive queue for a 64 MiB burst plus skb accounting
- reports partial frames, fragment failures, and kernel receive-queue overflow
- makes explicit rollback always reset into QSPI
- pins rover production and active calibration configs to exact RC16
- selects protocol v3 once at the config top level: 2,048-sample observation request, 256 slots
- filters LAN discovery candidates by the kernel's real egress interface

## Exact candidate

- Release: https://github.com/misko/plutosdr-fw/releases/tag/v0.38-plutoplus-spf-gain-series-v4-rc16
- Firmware commit: `867e18542311c25f5c1980bbdcfffc823e56f0a2`
- USB gadget: `2e8e40ade5dcf3c7880a5ebb58419ad7c37ed552`
- Direct-IP gadget: `7cae12eb62cfb2fb656169bd1cfe7da2a0aff583`
- DFU SHA-256: `27aca40915fd75fbcabfadef88fee96ff422c6058f83fab8a57a09b8d1eae911`
- Public build: https://github.com/misko/plutosdr-fw/actions/runs/31360123948

## Two-radio volatile hardware gate

- three shared-hub RAM boot epochs
- six physical TX2 -> 30 dB attenuator/splitter -> RX1/RX2 gates
- protocol-v2 compatibility: 6 passed
- V3 USB: 100 fresh starts/radio plus simultaneous streams
- V7 Zarr: 100 records/radio, written and reopened
- malformed-IP recovery and common V3 frame: passed
- max IP burst: 320 frames / 1.25 GiB at 21.33 MiB/s
- zero sequence, fragment, or receive-queue losses
- final production rollback baseline: 6 passed; both radios muted

## Persistent-QSPI canary

Serial `1040007c4a94000211000b009186843ef2` was flashed with `pluto.frm` only (mtd3). The bootloader/mtd0 MD5 stayed unchanged through the updater reboot and a second explicit reboot.

- exact device-fw and gadget SHA after both persistent boots
- 100 fresh protocol-v3 USB starts
- internal cyclic TX and external TX2 loopback: 2 passed
- hardware-backed V7 Zarr: 100 records written/reopened
- malformed-IP, one-frame IP, and 20 x 16-frame max burst: passed
- persistent max burst: 1.25 GiB at 21.81 MiB/s, zero loss/overflow
- host sysctl restored; TX1/TX2 `-80 dB` on both radios
- second bench radio remains on the prior QSPI image

Full evidence: [gain_series_v4_rc16_20260810.md](https://github.com/misko/spf/blob/ae84861/tests/radio_hardware/reports/gain_series_v4_rc16_20260810.md)

## Verification

- hardware: complete two-radio RAM gate plus one-radio persistent canary
- focused local tests on final changes: 63 passed
- prior exact-head CI: [31367605275](https://github.com/misko/spf/actions/runs/31367605275), 1,497 passed / 32 skipped / 2 xfailed
- final exact-head CI: [31372939879](https://github.com/misko/spf/actions/runs/31372939879), 1,515 passed / 32 skipped / 2 xfailed

The user-owned `docs/learnings.md` working-tree change remains intentionally excluded.
