### PR TITLE
Add prebuilt libiio deployment artifacts

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -3,8 +3,24 @@ name: Build, Deploy and Test
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - ".github/workflows/docker-build-and-test.yml"
+      - ".github/workflows/libiio-packages.yml"
+      - "packaging/libiio/**"
+      - "install_spf_libiio*.sh"
+      - "docs/libiio_frame_metadata_install.md"
+      - "tests/test_libiio_dependency_contract.py"
+      - "README.md"
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - ".github/workflows/docker-build-and-test.yml"
+      - ".github/workflows/libiio-packages.yml"
+      - "packaging/libiio/**"
+      - "install_spf_libiio*.sh"
+      - "docs/libiio_frame_metadata_install.md"
+      - "tests/test_libiio_dependency_contract.py"
+      - "README.md"
 
 jobs:
   build:

--- a/.github/workflows/libiio-packages.yml
+++ b/.github/workflows/libiio-packages.yml
@@ -1,0 +1,109 @@
+name: SPF libiio packages
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/libiio-packages.yml"
+      - "packaging/libiio/**"
+      - "install_spf_libiio*.sh"
+      - "tests/test_libiio_dependency_contract.py"
+  push:
+    branches: [main]
+    tags: ["libiio-artifacts-v*"]
+    paths:
+      - ".github/workflows/libiio-packages.yml"
+      - "packaging/libiio/**"
+      - "install_spf_libiio*.sh"
+      - "tests/test_libiio_dependency_contract.py"
+  workflow_dispatch:
+    inputs:
+      series:
+        description: Patched libiio line
+        required: true
+        default: "0.25"
+        type: choice
+        options: ["0.25", "0.26"]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: amd64
+            runner: ubuntu-24.04
+          - architecture: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    container: debian:12
+    env:
+      LIBIIO_SERIES: ${{ inputs.series || '0.25' }}
+    steps:
+      - name: Install build and test prerequisites
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential ca-certificates cmake dpkg-dev git pkg-config \
+            flex bison python3 python3-dev python3-pip python3-setuptools \
+            python3-venv python3-wheel libaio-dev libusb-1.0-0-dev libxml2-dev
+      - uses: actions/checkout@v4
+      - name: Build native package and Python wheel
+        run: |
+          packaging/libiio/build_artifacts.sh \
+            --series "$LIBIIO_SERIES" \
+            --output-dir dist/libiio
+      - name: Inspect package contents
+        run: packaging/libiio/test_artifacts.sh --bundle dist/libiio
+      - name: Install and smoke-test exact artifacts
+        run: |
+          python3 -m venv /tmp/spf-libiio-test-venv
+          install_spf_libiio_artifacts.sh \
+            --bundle dist/libiio \
+            --python /tmp/spf-libiio-test-venv/bin/python
+          packaging/libiio/test_artifacts.sh \
+            --bundle dist/libiio \
+            --runtime \
+            --python /tmp/spf-libiio-test-venv/bin/python
+      - name: Run focused repository contract tests
+        run: |
+          /tmp/spf-libiio-test-venv/bin/pip install pytest
+          /tmp/spf-libiio-test-venv/bin/python -m pytest -q \
+            tests/test_libiio_dependency_contract.py
+      - name: Upload tested deployment bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: spf-libiio-debian12-${{ matrix.architecture }}
+          path: dist/libiio/*
+          if-no-files-found: error
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/libiio-artifacts-v')
+    needs: build-and-test
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: spf-libiio-debian12-*
+          path: release-downloads
+      - name: Generate release checksums
+        run: |
+          mkdir release-assets
+          cp release-downloads/spf-libiio-debian12-amd64/*.deb release-assets/
+          cp release-downloads/spf-libiio-debian12-arm64/*.deb release-assets/
+          cp release-downloads/spf-libiio-debian12-amd64/*.whl release-assets/
+          cd release-assets
+          sha256sum *.deb *.whl > SHA256SUMS
+      - name: Publish immutable release artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            release-assets/*.deb release-assets/*.whl release-assets/SHA256SUMS \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes

--- a/.github/workflows/libiio-packages.yml
+++ b/.github/workflows/libiio-packages.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install and smoke-test exact artifacts
         run: |
           python3 -m venv /tmp/spf-libiio-test-venv
-          install_spf_libiio_artifacts.sh \
+          ./install_spf_libiio_artifacts.sh \
             --bundle dist/libiio \
             --python /tmp/spf-libiio-test-venv/bin/python
           packaging/libiio/test_artifacts.sh \

--- a/.github/workflows/libiio-packages.yml
+++ b/.github/workflows/libiio-packages.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Run focused repository contract tests
         run: |
           /tmp/spf-libiio-test-venv/bin/pip install pytest
-          /tmp/spf-libiio-test-venv/bin/python -m pytest -q \
+          /tmp/spf-libiio-test-venv/bin/python -m pytest -q --noconftest \
             tests/test_libiio_dependency_contract.py
       - name: Upload tested deployment bundle
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -266,14 +266,19 @@ source spf_venv/bin/activate
 pip install -e .
 
 # Install the hardware-qualified modified C library and Python binding last
-./install_spf_libiio.sh --series 0.25 --python "$VIRTUAL_ENV/bin/python"
+./install_spf_libiio_artifacts.sh \
+  --bundle ~/Downloads/spf-libiio \
+  --python "$VIRTUAL_ENV/bin/python"
 
 # Run the tests to verify installation
 pytest tests
 ```
 
 The modified libiio is required for v5 frame metadata; PyPI `pylibiio` alone
-is not sufficient. See [the SPF libiio installation guide](docs/libiio_frame_metadata_install.md)
+is not sufficient. CI publishes native Debian 12 packages for Pi 4/Pi 5
+(`arm64`) and standard x86-64 (`amd64`), plus the shared Python wheel. The
+source-building `install_spf_libiio.sh` remains available as a fallback. See
+[the SPF libiio installation guide](docs/libiio_frame_metadata_install.md)
 for immutable source pins, 0.26 instructions, verification, and isolated
 side-by-side installs.
 
@@ -311,5 +316,4 @@ side-by-side installs.
    cd bladeRF/host/libraries/libbladeRF_bindings/python
    python setup.py install
    ```
-
 

--- a/docs/libiio_frame_metadata_install.md
+++ b/docs/libiio_frame_metadata_install.md
@@ -20,6 +20,100 @@ Both were qualified over USB and standard libiio IP/TCP against
 
 ## Ubuntu, Debian, or Raspberry Pi OS
 
+### Recommended: prebuilt Debian 12 artifacts
+
+Normal rover deployment should use the release bundle rather than compiling on
+the rover. One `arm64` package supports both Pi 4 and Pi 5 when they run a
+64-bit Debian 12 or Raspberry Pi OS 12 userland. Standard x86-64 hosts use the
+`amd64` package. The Python wheel is `py3-none-any` and is shared by both.
+
+Download these three files from one `libiio-artifacts-v*` SPF GitHub release:
+
+- `spf-libiio_0.25+spfmeta3-1_arm64.deb` on Pi 4/Pi 5, or the `_amd64.deb`
+  equivalent on x86-64
+- `pylibiio-0.25+spfmeta3-py3-none-any.whl`
+- `SHA256SUMS`
+
+Place them in one directory and install them after SPF's ordinary Python
+dependencies:
+
+```bash
+./install_spf_libiio_artifacts.sh \
+  --bundle ~/Downloads/spf-libiio \
+  --python ~/spf-virtualenv/bin/python
+```
+
+The installer checks every checksum, selects the package matching the local
+Debian architecture, lets `apt` replace the distribution libiio packages, puts
+the patched wheel in the selected virtual environment, and verifies
+`MetadataBuffer`. Do not combine a `.deb`, wheel, and checksum file from
+different releases.
+
+The native package is intentionally limited to Debian 12's ABI. Build and test
+a separate package line before supporting Debian 13, Ubuntu, 32-bit Raspberry
+Pi OS (`armhf`), or another libc baseline. Pi CPU generation alone does not
+require another build.
+
+### Building artifacts locally
+
+Artifact definitions and source locks live in `packaging/libiio/`. Build on a
+native Debian 12 `amd64` or `arm64` machine:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential ca-certificates cmake dpkg-dev git pkg-config flex bison \
+  python3 python3-dev python3-pip python3-setuptools python3-wheel \
+  libaio-dev libusb-1.0-0-dev libxml2-dev
+
+packaging/libiio/build_artifacts.sh \
+  --series 0.25 \
+  --output-dir dist/libiio
+packaging/libiio/test_artifacts.sh --bundle dist/libiio
+```
+
+`packaging/libiio/versions.sh` is the single source of truth for immutable
+libiio tags, commits, metadata revision, and Debian packaging revision. Change
+the metadata revision when the protocol/binding changes; increment only the
+package revision for packaging-only fixes. Review the source commit before
+changing either lock.
+
+The builder deliberately does not use libiio 0.25's legacy CPack dependency
+discovery. It stages the normal CMake installation and creates explicit Debian
+metadata, while building the pure Python binding as a separate wheel so it can
+be installed into an isolated SPF virtual environment.
+
+### CI, releases, and artifact tests
+
+`.github/workflows/libiio-packages.yml` builds natively in clean Debian 12
+containers on GitHub's `amd64` and `arm64` runners. Each architecture performs:
+
+1. immutable tag/commit verification;
+2. package checksum, architecture, file-content, and wheel API inspection;
+3. installation of the exact `.deb` and wheel into the clean container;
+4. dynamic-link, `iio_info`, backend scan, Python version, and
+   `MetadataBuffer` smoke tests; and
+5. the focused SPF dependency-contract tests.
+
+Pull requests and changes on `main` retain the packages as workflow artifacts.
+To publish an immutable GitHub release after both architecture jobs pass, tag
+the reviewed SPF commit using a name such as:
+
+```bash
+git tag -a libiio-artifacts-v0.25-spfmeta3.1 -m "SPF libiio 0.25 metadata artifacts"
+git push origin libiio-artifacts-v0.25-spfmeta3.1
+```
+
+CI then publishes the two `.deb` files, one wheel, and a release-level
+`SHA256SUMS`. Hardware tests are intentionally a separate promotion gate: after
+a new source revision, install the release bundle on at least one Pi 4/Pi 5 and
+one x86-64 host, then run the existing `--radio-hardware` USB and IP metadata,
+rate, retune, and soak tests. Packaging-only revisions need clean-container
+tests plus one USB/IP smoke capture; they do not require repeating the complete
+RF qualification unless native code changed.
+
+### Source-build fallback
+
 Install build prerequisites:
 
 ```bash

--- a/install_spf_libiio.sh
+++ b/install_spf_libiio.sh
@@ -4,6 +4,10 @@
 set -euo pipefail
 umask 0022
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=packaging/libiio/versions.sh
+source "${script_dir}/packaging/libiio/versions.sh"
+
 series=0.25
 python_bin="${VIRTUAL_ENV:+${VIRTUAL_ENV}/bin/python}"
 python_bin="${python_bin:-python3}"
@@ -41,24 +45,11 @@ while (($#)); do
     esac
 done
 
-case "$series" in
-0.25)
-    source_ref=spf-frame-metadata-source/v0.25-final-v3
-    source_commit=c26258bfa33098c2b215e19cf85d448e89499b1a
-    expected_version=0.25
-    expected_git=c26258b
-    ;;
-0.26)
-    source_ref=spf-frame-metadata-source/v0.26-final-v3
-    source_commit=d5695c3eaa9cec99cc6f7b2c91565555044b907a
-    expected_version=0.26
-    expected_git=d5695c3
-    ;;
-*)
-    printf 'ERROR: --series must be 0.25 or 0.26, got %s\n' "$series" >&2
-    exit 2
-    ;;
-esac
+spf_libiio_select_version "$series"
+source_ref="$SPF_LIBIIO_SOURCE_REF"
+source_commit="$SPF_LIBIIO_SOURCE_COMMIT"
+expected_version="$SPF_LIBIIO_EXPECTED_VERSION"
+expected_git="$SPF_LIBIIO_EXPECTED_GIT"
 
 [[ "$prefix" == /* ]] || {
     printf 'ERROR: --prefix must be absolute: %s\n' "$prefix" >&2

--- a/install_spf_libiio_artifacts.sh
+++ b/install_spf_libiio_artifacts.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Install a prebuilt SPF libiio bundle into the OS and an SPF Python venv.
+
+set -euo pipefail
+
+bundle=
+python_bin="${VIRTUAL_ENV:+${VIRTUAL_ENV}/bin/python}"
+python_bin="${python_bin:-python3}"
+
+usage() {
+    cat <<'EOF'
+Usage: ./install_spf_libiio_artifacts.sh --bundle DIR [--python PATH]
+
+DIR must contain the matching spf-libiio Debian package, the pylibiio wheel,
+and SHA256SUMS from one CI/release build. Defaults to the active venv's Python.
+EOF
+}
+
+while (($#)); do
+    case "$1" in
+    --bundle) bundle="${2:?missing value for --bundle}"; shift 2 ;;
+    --python) python_bin="${2:?missing value for --python}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage >&2; printf 'ERROR: unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+done
+
+[[ -n "$bundle" && -d "$bundle" ]] || { usage >&2; exit 2; }
+bundle="$(cd "$bundle" && pwd)"
+architecture="$(dpkg --print-architecture)"
+deb="$(find "$bundle" -maxdepth 1 -type f -name "spf-libiio_*_${architecture}.deb" -print -quit)"
+wheel="$(find "$bundle" -maxdepth 1 -type f -name 'pylibiio-*-py3-none-any.whl' -print -quit)"
+[[ -n "$deb" ]] || { printf 'ERROR: no %s package in %s\n' "$architecture" "$bundle" >&2; exit 1; }
+[[ -n "$wheel" ]] || { printf 'ERROR: no pylibiio wheel in %s\n' "$bundle" >&2; exit 1; }
+"$python_bin" -m pip --version >/dev/null
+(cd "$bundle" && sha256sum --check SHA256SUMS)
+
+apt_command=(apt-get install -y "$deb")
+if [[ "$(id -u)" == 0 ]]; then
+    "${apt_command[@]}"
+else
+    command -v sudo >/dev/null || { printf 'ERROR: installing the .deb requires root or sudo\n' >&2; exit 1; }
+    sudo "${apt_command[@]}"
+fi
+"$python_bin" -m pip install --quiet --force-reinstall --no-deps "$wheel"
+
+"$python_bin" - <<'PY'
+import iio
+
+assert iio.version[:2] in ((0, 25), (0, 26)), iio.version
+assert hasattr(iio, "MetadataBuffer"), "patched binding lacks MetadataBuffer"
+print(f"PASS Python binding: {iio.__file__} version={iio.version}")
+PY
+iio_info --version

--- a/packaging/libiio/build_artifacts.sh
+++ b/packaging/libiio/build_artifacts.sh
@@ -156,6 +156,15 @@ cmake -S "$source_dir/bindings/python" -B "$python_build_dir" \
     -DCMAKE_SHARED_LIBRARY_SUFFIX=.so
 sed -i "s/version=\"${SPF_LIBIIO_EXPECTED_VERSION}\"/version=\"${wheel_version}\"/" \
     "$python_build_dir/setup.py"
+# Upstream's custom install command refuses to assemble a wheel unless libiio
+# is already installed on the build host. The wheel is pure Python and the
+# matching staged .deb is intentionally not installed until the test step.
+sed -i 's/cross_compiling = ("FALSE" == "TRUE")/cross_compiling = True/' \
+    "$python_build_dir/setup.py"
+grep -q 'cross_compiling = True' "$python_build_dir/setup.py" || {
+    printf 'ERROR: could not disable upstream build-host libiio check\n' >&2
+    exit 1
+}
 (
     cd "$python_build_dir"
     python3 setup.py --quiet bdist_wheel --dist-dir "$output_dir"

--- a/packaging/libiio/build_artifacts.sh
+++ b/packaging/libiio/build_artifacts.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Build a Debian package and Python wheel from an immutable SPF libiio tag.
+
+set -euo pipefail
+umask 0022
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=versions.sh
+source "${script_dir}/versions.sh"
+
+series=0.25
+output_dir="${PWD}/dist/libiio"
+jobs="$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '1')"
+keep_worktree=false
+
+usage() {
+    cat <<'EOF'
+Usage: packaging/libiio/build_artifacts.sh [options]
+
+Options:
+  --series 0.25|0.26  Patched host line (default: 0.25)
+  --output-dir PATH    Artifact directory (default: dist/libiio)
+  --jobs N             Parallel build jobs
+  --keep-worktree      Preserve the temporary source/build directory
+  -h, --help           Show this help
+
+The build host must be Debian 12 on amd64 or arm64. The resulting native .deb
+matches the build architecture; the pylibiio wheel is platform-independent.
+EOF
+}
+
+while (($#)); do
+    case "$1" in
+    --series) series="${2:?missing value for --series}"; shift 2 ;;
+    --output-dir) output_dir="${2:?missing value for --output-dir}"; shift 2 ;;
+    --jobs) jobs="${2:?missing value for --jobs}"; shift 2 ;;
+    --keep-worktree) keep_worktree=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage >&2; printf 'ERROR: unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+done
+
+spf_libiio_select_version "$series"
+[[ "$jobs" =~ ^[1-9][0-9]*$ ]] || {
+    printf 'ERROR: --jobs must be a positive integer: %s\n' "$jobs" >&2
+    exit 2
+}
+
+for command_name in cmake dpkg dpkg-architecture dpkg-deb git python3 sha256sum; do
+    command -v "$command_name" >/dev/null || {
+        printf 'ERROR: required command is absent: %s\n' "$command_name" >&2
+        exit 1
+    }
+done
+python3 -c 'import setuptools, wheel' >/dev/null 2>&1 || {
+    printf 'ERROR: python3-setuptools and python3-wheel are required to build the pylibiio artifact\n' >&2
+    exit 1
+}
+
+architecture="$(dpkg --print-architecture)"
+case "$architecture" in
+amd64|arm64) ;;
+*) printf 'ERROR: supported package architectures are amd64 and arm64, got %s\n' "$architecture" >&2; exit 1 ;;
+esac
+
+multiarch="$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+package_version="${SPF_LIBIIO_EXPECTED_VERSION}+spfmeta${SPF_LIBIIO_METADATA_REVISION}-${SPF_LIBIIO_PACKAGE_REVISION}"
+wheel_version="${SPF_LIBIIO_EXPECTED_VERSION}+spfmeta${SPF_LIBIIO_METADATA_REVISION}"
+
+mkdir -p "$output_dir"
+output_dir="$(cd "$output_dir" && pwd)"
+worktree="$(mktemp -d "${TMPDIR:-/tmp}/spf-libiio-package-${series}.XXXXXX")"
+cleanup() {
+    if [[ "$keep_worktree" == true ]]; then
+        printf 'Preserved build worktree: %s\n' "$worktree"
+    else
+        rm -rf -- "$worktree"
+    fi
+}
+trap cleanup EXIT
+
+source_dir="${worktree}/libiio"
+build_dir="${worktree}/build"
+stage_dir="${worktree}/package"
+python_build_dir="${worktree}/python-build"
+
+printf 'Cloning misko/libiio tag %s...\n' "$SPF_LIBIIO_SOURCE_REF"
+git -c advice.detachedHead=false clone --quiet --depth 1 \
+    --branch "$SPF_LIBIIO_SOURCE_REF" https://github.com/misko/libiio.git "$source_dir"
+actual_commit="$(git -C "$source_dir" rev-parse HEAD)"
+[[ "$actual_commit" == "$SPF_LIBIIO_SOURCE_COMMIT" ]] || {
+    printf 'ERROR: source-lock mismatch: tag resolved to %s, expected %s\n' \
+        "$actual_commit" "$SPF_LIBIIO_SOURCE_COMMIT" >&2
+    exit 1
+}
+
+# libiio 0.25 groups the command-line tools under the legacy WITH_TESTS flag.
+# Python is deliberately packaged separately so it can be installed in a venv.
+cmake -S "$source_dir" -B "$build_dir" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_INSTALL_LIBDIR="lib/${multiarch}" \
+    -DINSTALL_UDEV_RULE=OFF \
+    -DPYTHON_BINDINGS=OFF \
+    -DHAVE_DNS_SD=OFF \
+    -DWITH_DOC=OFF \
+    -DWITH_EXAMPLES=OFF \
+    -DWITH_IIOD=OFF \
+    -DWITH_LOCAL_BACKEND=ON \
+    -DWITH_NETWORK_BACKEND=ON \
+    -DWITH_SERIAL_BACKEND=OFF \
+    -DWITH_TESTS=ON \
+    -DWITH_USB_BACKEND=ON
+cmake --build "$build_dir" --parallel "$jobs"
+DESTDIR="$stage_dir" cmake --install "$build_dir"
+
+mkdir -p "$stage_dir/DEBIAN"
+installed_size="$(du -sk "$stage_dir/usr" | awk '{print $1}')"
+cat >"$stage_dir/DEBIAN/control" <<EOF
+Package: spf-libiio
+Version: ${package_version}
+Section: libs
+Priority: optional
+Architecture: ${architecture}
+Maintainer: SPF project <https://github.com/misko/spf>
+Installed-Size: ${installed_size}
+Depends: libc6 (>= 2.36), libusb-1.0-0, libxml2
+Provides: libiio0 (= ${SPF_LIBIIO_EXPECTED_VERSION}), libiio-dev (= ${SPF_LIBIIO_EXPECTED_VERSION}), libiio-utils (= ${SPF_LIBIIO_EXPECTED_VERSION})
+Conflicts: libiio0, libiio-dev, libiio-utils
+Replaces: libiio0, libiio-dev, libiio-utils
+Description: SPF libiio with per-capture metadata support
+ Hardware-qualified libiio ${SPF_LIBIIO_EXPECTED_VERSION} with capture index,
+ timing, gain history, gain endpoints, and RSSI endpoint metadata.
+X-SPF-Source-Commit: ${SPF_LIBIIO_SOURCE_COMMIT}
+EOF
+cat >"$stage_dir/DEBIAN/postinst" <<'EOF'
+#!/bin/sh
+set -e
+ldconfig
+EOF
+cat >"$stage_dir/DEBIAN/postrm" <<'EOF'
+#!/bin/sh
+set -e
+ldconfig
+EOF
+chmod 0755 "$stage_dir/DEBIAN/postinst" "$stage_dir/DEBIAN/postrm"
+
+deb_name="spf-libiio_${package_version}_${architecture}.deb"
+dpkg-deb --root-owner-group --build "$stage_dir" "$output_dir/$deb_name"
+
+# Configure the upstream single-module Python package, then distinguish the
+# patched distribution from the unmodified PyPI release with a local version.
+cmake -S "$source_dir/bindings/python" -B "$python_build_dir" \
+    -DVERSION="$SPF_LIBIIO_EXPECTED_VERSION" \
+    -DCMAKE_INSTALL_FULL_LIBDIR="/usr/lib/${multiarch}" \
+    -DCMAKE_SHARED_LIBRARY_SUFFIX=.so
+sed -i "s/version=\"${SPF_LIBIIO_EXPECTED_VERSION}\"/version=\"${wheel_version}\"/" \
+    "$python_build_dir/setup.py"
+(
+    cd "$python_build_dir"
+    python3 setup.py --quiet bdist_wheel --dist-dir "$output_dir"
+)
+
+(
+    cd "$output_dir"
+    sha256sum "$deb_name" "pylibiio-${wheel_version}-py3-none-any.whl" >SHA256SUMS
+)
+
+printf '\nBuilt SPF libiio artifacts in %s:\n' "$output_dir"
+printf '  %s\n' "$deb_name" "pylibiio-${wheel_version}-py3-none-any.whl" SHA256SUMS

--- a/packaging/libiio/test_artifacts.sh
+++ b/packaging/libiio/test_artifacts.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Inspect built artifacts and, optionally, verify an installed runtime.
+
+set -euo pipefail
+
+bundle=
+python_bin=
+runtime=false
+
+usage() {
+    cat <<'EOF'
+Usage: packaging/libiio/test_artifacts.sh --bundle DIR [--runtime --python PATH]
+
+Without --runtime, validates checksums, package metadata/content, architecture,
+and the wheel API. With --runtime, also checks the installed library and tools.
+EOF
+}
+
+while (($#)); do
+    case "$1" in
+    --bundle) bundle="${2:?missing value for --bundle}"; shift 2 ;;
+    --python) python_bin="${2:?missing value for --python}"; shift 2 ;;
+    --runtime) runtime=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage >&2; printf 'ERROR: unknown argument: %s\n' "$1" >&2; exit 2 ;;
+    esac
+done
+
+[[ -n "$bundle" && -d "$bundle" ]] || { usage >&2; exit 2; }
+bundle="$(cd "$bundle" && pwd)"
+architecture="$(dpkg --print-architecture)"
+deb="$(find "$bundle" -maxdepth 1 -type f -name "spf-libiio_*_${architecture}.deb" -print -quit)"
+wheel="$(find "$bundle" -maxdepth 1 -type f -name 'pylibiio-*-py3-none-any.whl' -print -quit)"
+[[ -n "$deb" ]] || { printf 'ERROR: no %s .deb in %s\n' "$architecture" "$bundle" >&2; exit 1; }
+[[ -n "$wheel" ]] || { printf 'ERROR: no pylibiio wheel in %s\n' "$bundle" >&2; exit 1; }
+
+(cd "$bundle" && sha256sum --check SHA256SUMS)
+[[ "$(dpkg-deb --field "$deb" Package)" == spf-libiio ]]
+[[ "$(dpkg-deb --field "$deb" Architecture)" == "$architecture" ]]
+dpkg-deb --field "$deb" Version | grep -Eq '^0\.(25|26)\+spfmeta[0-9]+-[0-9]+$'
+package_contents="$(dpkg-deb --contents "$deb")"
+grep -Eq '/usr/lib/.*/libiio\.so\.0\.(25|26)$' <<<"$package_contents"
+grep -Eq '/usr/bin/iio_info$' <<<"$package_contents"
+python3 - "$wheel" <<'PY'
+import sys
+import zipfile
+
+with zipfile.ZipFile(sys.argv[1]) as archive:
+    source = archive.read("iio.py").decode()
+assert "class MetadataBuffer" in source
+PY
+
+if [[ "$runtime" == true ]]; then
+    [[ -n "$python_bin" ]] || { printf 'ERROR: --runtime requires --python\n' >&2; exit 2; }
+    "$python_bin" - <<'PY'
+import iio
+
+assert iio.version[:2] in ((0, 25), (0, 26)), iio.version
+assert hasattr(iio, "MetadataBuffer"), "patched binding lacks MetadataBuffer"
+print(f"PASS Python binding: {iio.__file__} version={iio.version}")
+PY
+    iio_info --version
+    iio_info -S
+    library_path="$(ldconfig -p | awk '/libiio\.so\.0 / {print $NF; exit}')"
+    [[ -n "$library_path" ]] || { printf 'ERROR: ldconfig cannot find libiio.so.0\n' >&2; exit 1; }
+    if ldd "$library_path" | grep -q 'not found'; then
+        printf 'ERROR: installed libiio has an unresolved shared-library dependency\n' >&2
+        exit 1
+    fi
+fi
+
+printf 'PASS SPF libiio artifact checks (%s)\n' "$architecture"

--- a/packaging/libiio/versions.sh
+++ b/packaging/libiio/versions.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Immutable, hardware-qualified SPF libiio source locks.
+# shellcheck disable=SC2034  # Values are consumed by scripts that source this file.
+
+SPF_LIBIIO_PACKAGE_REVISION=1
+
+spf_libiio_select_version() {
+    case "${1:-}" in
+    0.25)
+        SPF_LIBIIO_SOURCE_REF=spf-frame-metadata-source/v0.25-final-v3
+        SPF_LIBIIO_SOURCE_COMMIT=c26258bfa33098c2b215e19cf85d448e89499b1a
+        SPF_LIBIIO_EXPECTED_VERSION=0.25
+        SPF_LIBIIO_EXPECTED_GIT=c26258b
+        SPF_LIBIIO_METADATA_REVISION=3
+        ;;
+    0.26)
+        SPF_LIBIIO_SOURCE_REF=spf-frame-metadata-source/v0.26-final-v3
+        SPF_LIBIIO_SOURCE_COMMIT=d5695c3eaa9cec99cc6f7b2c91565555044b907a
+        SPF_LIBIIO_EXPECTED_VERSION=0.26
+        SPF_LIBIIO_EXPECTED_GIT=d5695c3
+        SPF_LIBIIO_METADATA_REVISION=3
+        ;;
+    *)
+        printf 'ERROR: libiio series must be 0.25 or 0.26, got %s\n' "${1:-}" >&2
+        return 2
+        ;;
+    esac
+}

--- a/tests/test_libiio_dependency_contract.py
+++ b/tests/test_libiio_dependency_contract.py
@@ -12,11 +12,39 @@ def test_python_dependencies_match_hardware_qualified_stack():
 
 
 def test_installer_pins_both_supported_libiio_source_commits():
+    versions = (ROOT / "packaging/libiio/versions.sh").read_text()
+    assert "spf-frame-metadata-source/v0.25-final-v3" in versions
+    assert "c26258bfa33098c2b215e19cf85d448e89499b1a" in versions
+    assert "spf-frame-metadata-source/v0.26-final-v3" in versions
+    assert "d5695c3eaa9cec99cc6f7b2c91565555044b907a" in versions
+
     installer = (ROOT / "install_spf_libiio.sh").read_text()
-    assert "spf-frame-metadata-source/v0.25-final-v3" in installer
-    assert "c26258bfa33098c2b215e19cf85d448e89499b1a" in installer
-    assert "spf-frame-metadata-source/v0.26-final-v3" in installer
-    assert "d5695c3eaa9cec99cc6f7b2c91565555044b907a" in installer
+    assert "packaging/libiio/versions.sh" in installer
+    assert 'hasattr(iio, "MetadataBuffer")' in installer
+
+
+def test_binary_artifact_workflow_covers_pi_and_x86_64():
+    workflow = (ROOT / ".github/workflows/libiio-packages.yml").read_text()
+    assert "ubuntu-24.04-arm" in workflow
+    assert "architecture: arm64" in workflow
+    assert "architecture: amd64" in workflow
+    assert "container: debian:12" in workflow
+    assert "packaging/libiio/test_artifacts.sh" in workflow
+    assert "python -m pytest" in workflow
+    assert "tests/test_libiio_dependency_contract.py" in workflow
+    assert "python3 -m pytest" not in workflow
+
+    legacy_workflow = (ROOT / ".github/workflows/docker-build-and-test.yml").read_text()
+    assert '"packaging/libiio/**"' in legacy_workflow
+    assert '".github/workflows/libiio-packages.yml"' in legacy_workflow
+
+
+def test_binary_installer_verifies_bundle_before_installing():
+    installer = (ROOT / "install_spf_libiio_artifacts.sh").read_text()
+    checksum_offset = installer.index("sha256sum --check SHA256SUMS")
+    apt_offset = installer.index("apt-get install")
+    pip_offset = installer.index('"$python_bin" -m pip install')
+    assert checksum_offset < apt_offset < pip_offset
     assert 'hasattr(iio, "MetadataBuffer")' in installer
 
 

--- a/tests/test_libiio_dependency_contract.py
+++ b/tests/test_libiio_dependency_contract.py
@@ -47,6 +47,10 @@ def test_binary_installer_verifies_bundle_before_installing():
     assert checksum_offset < apt_offset < pip_offset
     assert 'hasattr(iio, "MetadataBuffer")' in installer
 
+    builder = (ROOT / "packaging/libiio/build_artifacts.sh").read_text()
+    assert "cross_compiling = True" in builder
+    assert "matching staged .deb is intentionally not installed" in builder
+
 
 def test_legacy_sdr_requirements_do_not_downgrade_pyadi():
     requirements = (ROOT / "spf/sdrpluto/requirements.txt").read_text().splitlines()

--- a/tests/test_libiio_dependency_contract.py
+++ b/tests/test_libiio_dependency_contract.py
@@ -32,6 +32,7 @@ def test_binary_artifact_workflow_covers_pi_and_x86_64():
     assert "packaging/libiio/test_artifacts.sh" in workflow
     assert "./install_spf_libiio_artifacts.sh" in workflow
     assert "python -m pytest" in workflow
+    assert "--noconftest" in workflow
     assert "tests/test_libiio_dependency_contract.py" in workflow
     assert "python3 -m pytest" not in workflow
 

--- a/tests/test_libiio_dependency_contract.py
+++ b/tests/test_libiio_dependency_contract.py
@@ -30,6 +30,7 @@ def test_binary_artifact_workflow_covers_pi_and_x86_64():
     assert "architecture: amd64" in workflow
     assert "container: debian:12" in workflow
     assert "packaging/libiio/test_artifacts.sh" in workflow
+    assert "./install_spf_libiio_artifacts.sh" in workflow
     assert "python -m pytest" in workflow
     assert "tests/test_libiio_dependency_contract.py" in workflow
     assert "python3 -m pytest" not in workflow


### PR DESCRIPTION
## What changed

- build Debian 12 native packages for arm64 (Pi 4/Pi 5) and amd64
- build one platform-independent patched pylibiio wheel
- install and smoke-test the exact artifacts in clean Debian 12 CI containers
- publish immutable release assets when a `libiio-artifacts-v*` tag is pushed
- document local builds, deployment, version locks, CI, and hardware promotion

## Why

Rovers and x86-64 hosts should not clone toolchains and compile the modified
libiio during normal deployment. Versioned binary artifacts make the qualified
native library and Python binding faster to deploy and harder to mismatch.

## Validation

- built `spf-libiio_0.25+spfmeta3-1_arm64.deb` and
  `pylibiio-0.25+spfmeta3-py3-none-any.whl` locally
- installed those exact artifacts in a fresh Debian 12 arm64 container
- verified checksums, package contents, dynamic dependencies, all configured
  backends, `iio_info`, and `iio.MetadataBuffer`
- ran `tests/test_libiio_dependency_contract.py` (6 passed)
- parsed both changed GitHub Actions workflows and ran shell syntax checks

The existing full pytest workflow is excluded for packaging-only changes. The
new focused workflow performs native arm64 and amd64 builds and tests.
